### PR TITLE
photon flags tests

### DIFF
--- a/_demo/readme.md
+++ b/_demo/readme.md
@@ -2,7 +2,7 @@
 
 Start minikube
 ```sh
-$ minikube create --cpus 4 --memory 4096
+$ minikube start --cpus 4 --memory 4096
 ```
 
 Initialize helm

--- a/_demo/run.sh
+++ b/_demo/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CMD=$0
+DATA=$(dirname $0)/data/client
 
 nodeport(){
   echo $(kubectl get service node-0-photon-node -o jsonpath='{.spec.ports[?(@.name == "photond-rpc")].nodePort}')
@@ -11,14 +12,19 @@ do_node(){
 }
 
 do_send(){
-  export PHOTON_NODE=$(do_node)
-  ../photon send 100 $(cat data/other.key) -k master --node "$PHOTON_NODE" -d data/client
+  node=$(do_node)
+  ../photon send 100 $(cat data/other.key) -k master -n "$node" -d "$DATA"
 }
 
 do_query(){
   key=${1:-master}
-  export PHOTON_NODE=$(do_node)
-  ../photon query $(cat "data/$key.key") -d data/client
+  node=$(do_node)
+  ../photon query account $(cat "data/$key.key") -n "$node" -d "$DATA"
+}
+
+do_ping(){
+  node=$(do_node)
+  ../photon ping -n "$node" -d "$DATA"
 }
 
 do_usage(){
@@ -38,6 +44,10 @@ case "$cmd" in
   query)
     do_query "$@"
     ;;
+  ping)
+    do_ping "$@"
+    ;;
   *)
     do_usage
+    ;;
 esac

--- a/cmd/photon/base.go
+++ b/cmd/photon/base.go
@@ -1,54 +1,15 @@
 package main
 
 import (
-	"os"
-	"path"
-
-	"github.com/ovrclk/photon/cmd/photon/constants"
+	"github.com/ovrclk/photon/cmd/photon/context"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func initEnv(root string) error {
-	viper.SetEnvPrefix("PHOTON")
-	viper.AutomaticEnv()
-
-	viper.SetConfigFile(path.Join(root, "photon.toml"))
-
-	if err := viper.ReadInConfig(); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return nil
-}
-
-func saveConfig() error {
-	return viper.WriteConfig()
-}
-
 func baseCommand() *cobra.Command {
-	viper.SetEnvPrefix("PHOTON")
-
 	cmd := &cobra.Command{
 		Use:   "photon",
 		Short: "Photon client",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			root, _ := cmd.Flags().GetString(constants.FlagRootDir)
-			return initEnv(root)
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			return saveConfig()
-		},
 	}
-
-	cmd.PersistentFlags().StringP(constants.FlagRootDir, "d", defaultRootDir(), "data directory")
-
+	context.SetupBaseCommand(cmd)
 	return cmd
-}
-
-func defaultRootDir() string {
-	if val := os.Getenv("PHOTON_DATA"); val != "" {
-		return val
-	}
-	return os.ExpandEnv("$HOME/.photon")
 }

--- a/cmd/photon/base_test.go
+++ b/cmd/photon/base_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ovrclk/photon/cmd/photon/context"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootDir_Env(t *testing.T) {
+	basedir, err := ioutil.TempDir("", "photon-photon")
+	require.NoError(t, err)
+	defer os.RemoveAll(basedir)
+
+	os.Setenv("PHOTON_DATA", basedir)
+
+	assertCommand(t, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		assert.Equal(t, basedir, ctx.RootDir())
+		return nil
+	})
+}
+
+func TestRootDir_Flag(t *testing.T) {
+	basedir, err := ioutil.TempDir("", "photon-photon")
+	require.NoError(t, err)
+	defer os.RemoveAll(basedir)
+
+	os.Setenv("PHOTON_DATA", basedir)
+
+	assertCommand(t, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		assert.Equal(t, basedir, ctx.RootDir())
+		return nil
+	}, "-d", basedir)
+}
+
+func assertCommand(t *testing.T, fn context.Runner, args ...string) {
+	viper.Reset()
+
+	ran := false
+
+	base := baseCommand()
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: context.WithContext(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			ran = true
+			return fn(ctx, cmd, args)
+		}),
+	}
+
+	base.AddCommand(cmd)
+	base.SetArgs(append([]string{"test"}, args...))
+	require.NoError(t, base.Execute())
+	assert.True(t, ran)
+}

--- a/cmd/photon/context/base.go
+++ b/cmd/photon/context/base.go
@@ -1,0 +1,43 @@
+package context
+
+import (
+	"os"
+	"path"
+
+	"github.com/ovrclk/photon/cmd/photon/constants"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func SetupBaseCommand(cmd *cobra.Command) {
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		root, _ := cmd.Flags().GetString(constants.FlagRootDir)
+		return initCommandConfig(root)
+	}
+	cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+		return saveCommandConfig()
+	}
+	cmd.PersistentFlags().StringP(constants.FlagRootDir, "d", defaultRootDir(), "data directory")
+}
+
+func initCommandConfig(root string) error {
+	viper.SetEnvPrefix("PHOTON")
+	viper.AutomaticEnv()
+	viper.SetConfigFile(path.Join(root, "photon.toml"))
+
+	if err := viper.ReadInConfig(); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func saveCommandConfig() error {
+	return viper.WriteConfig()
+}
+
+func defaultRootDir() string {
+	if val := os.Getenv("PHOTON_DATA"); val != "" {
+		return val
+	}
+	return os.ExpandEnv("$HOME/.photon")
+}

--- a/cmd/photon/context/flags.go
+++ b/cmd/photon/context/flags.go
@@ -1,0 +1,22 @@
+package context
+
+import (
+	"github.com/ovrclk/photon/cmd/photon/constants"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func AddFlagNode(cmd *cobra.Command, flags *pflag.FlagSet) {
+	flags.StringP(constants.FlagNode, "n", constants.DefaultNode, "node host")
+	viper.BindPFlag(constants.FlagNode, flags.Lookup(constants.FlagNode))
+}
+
+func AddFlagKey(cmd *cobra.Command, flags *pflag.FlagSet) {
+	flags.StringP(constants.FlagKey, "k", "", "key name (required)")
+	cmd.MarkFlagRequired(constants.FlagKey)
+}
+
+func AddFlagNonce(cmd *cobra.Command, flags *pflag.FlagSet) {
+	flags.Uint64(constants.FlagNonce, 0, "nonce (optional)")
+}

--- a/cmd/photon/context/flags_test.go
+++ b/cmd/photon/context/flags_test.go
@@ -1,0 +1,89 @@
+package context_test
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/ovrclk/photon/cmd/photon/constants"
+	"github.com/ovrclk/photon/cmd/photon/context"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type flagFn func(cmd *cobra.Command, flags *pflag.FlagSet)
+
+func TestNode_Env(t *testing.T) {
+	const val = "foo.bar:123"
+
+	os.Setenv("PHOTON_NODE", val)
+
+	assertCommand(t, context.AddFlagNode, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		assert.Equal(t, val, ctx.Node())
+		return nil
+	})
+}
+
+func TestNode_Flag(t *testing.T) {
+	const val = "foo.bar:123"
+
+	assertCommand(t, context.AddFlagNode, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		assert.Equal(t, val, ctx.Node())
+		return nil
+	}, "-n", val)
+}
+
+func TestKey_Flag(t *testing.T) {
+	const val = "foo"
+
+	assertCommand(t, context.AddFlagKey, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		assert.Equal(t, val, ctx.KeyName())
+		return nil
+	}, "-k", val)
+}
+
+func TestFlag_Nonce(t *testing.T) {
+	const val uint64 = 10
+
+	assertCommand(t, context.AddFlagNonce, func(ctx context.Context, cmd *cobra.Command, args []string) error {
+		nonce, err := ctx.Nonce()
+		require.NoError(t, err)
+		require.Equal(t, val, nonce)
+		return nil
+	}, "--"+constants.FlagNonce, strconv.Itoa(int(val)))
+}
+
+func assertCommand(t *testing.T, flagfn flagFn, fn context.Runner, args ...string) {
+	basedir, err := ioutil.TempDir("", "photon-photon-context")
+	require.NoError(t, err)
+	defer os.RemoveAll(basedir)
+
+	viper.Reset()
+
+	ran := false
+
+	os.Setenv("PHOTON_DATA", basedir)
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: context.WithContext(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			ran = true
+			require.Equal(t, basedir, ctx.RootDir())
+			return fn(ctx, cmd, args)
+		}),
+	}
+
+	context.SetupBaseCommand(cmd)
+
+	if flagfn != nil {
+		flagfn(cmd, cmd.Flags())
+	}
+
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+}

--- a/cmd/photon/deployment.go
+++ b/cmd/photon/deployment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ovrclk/photon/types"
 	"github.com/ovrclk/photon/types/base"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	tmclient "github.com/tendermint/tendermint/rpc/client"
 )
 
@@ -27,13 +26,9 @@ func deploymentCommand() *cobra.Command {
 			context.RequireKey(context.RequireNode(doDeployCommand))),
 	}
 
-	cmd.Flags().StringP(constants.FlagNode, "n", constants.DefaultNode, "node host")
-	viper.BindPFlag(constants.FlagNode, cmd.Flags().Lookup(constants.FlagNode))
-
-	cmd.Flags().StringP(constants.FlagKey, "k", "", "key name (required)")
-	cmd.MarkFlagRequired(constants.FlagKey)
-
-	cmd.Flags().Uint64(constants.FlagNonce, 0, "nonce (optional)")
+	context.AddFlagNode(cmd, cmd.Flags())
+	context.AddFlagKey(cmd, cmd.Flags())
+	context.AddFlagNonce(cmd, cmd.Flags())
 
 	return cmd
 }

--- a/cmd/photon/key_test.go
+++ b/cmd/photon/key_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ovrclk/photon/cmd/photon/context"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyCreateCommand(t *testing.T) {
+	basedir, err := ioutil.TempDir("", "photon-photon-key-create")
+	require.NoError(t, err)
+	defer os.RemoveAll(basedir)
+	os.Setenv("PHOTON_DATA", basedir)
+
+	const keyName = "foo"
+
+	{
+		viper.Reset()
+		base := baseCommand()
+		base.AddCommand(keyCommand())
+		base.SetArgs([]string{"key", "create", keyName})
+		require.NoError(t, base.Execute())
+	}
+
+	{
+		viper.Reset()
+		base := baseCommand()
+		cmd := &cobra.Command{
+			Use: "test",
+			RunE: context.WithContext(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+				key, err := ctx.Key()
+				require.NoError(t, err)
+				require.Equal(t, keyName, key.Name)
+				return nil
+			}),
+		}
+		context.AddFlagKey(cmd, cmd.Flags())
+
+		base.AddCommand(cmd)
+		base.SetArgs([]string{"test", "-k", keyName})
+		require.NoError(t, base.Execute())
+	}
+}

--- a/cmd/photon/main.go
+++ b/cmd/photon/main.go
@@ -8,5 +8,6 @@ func main() {
 	root.AddCommand(sendCommand())
 	root.AddCommand(deploymentCommand())
 	root.AddCommand(query.QueryCommand())
+	root.AddCommand(pingCommand())
 	root.Execute()
 }

--- a/cmd/photon/ping.go
+++ b/cmd/photon/ping.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ovrclk/photon/cmd/photon/context"
+	"github.com/spf13/cobra"
+	tmclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+func pingCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "ping remote node",
+		Args:  cobra.NoArgs,
+		RunE:  context.WithContext(context.RequireNode(doPingCommand)),
+	}
+	context.AddFlagNode(cmd, cmd.Flags())
+	return cmd
+}
+
+func doPingCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
+	client := tmclient.NewHTTP(ctx.Node(), "/websocket")
+
+	result, err := client.Status()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%v:%v\n", result.LatestBlockHeight, result.LatestBlockHash)
+
+	return nil
+}

--- a/cmd/photon/query/query.go
+++ b/cmd/photon/query/query.go
@@ -4,11 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/ovrclk/photon/cmd/photon/constants"
 	"github.com/ovrclk/photon/cmd/photon/context"
 	"github.com/ovrclk/photon/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	tmclient "github.com/tendermint/tendermint/rpc/client"
 )
 
@@ -20,8 +18,7 @@ func QueryCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().StringP(constants.FlagNode, "n", constants.DefaultNode, "node host")
-	viper.BindPFlag(constants.FlagNode, cmd.Flags().Lookup(constants.FlagNode))
+	context.AddFlagNode(cmd, cmd.PersistentFlags())
 
 	cmd.AddCommand(queryAccountCommand(), queryDeploymentCommand())
 

--- a/cmd/photon/send.go
+++ b/cmd/photon/send.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ovrclk/photon/types"
 	"github.com/ovrclk/photon/types/base"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	tmclient "github.com/tendermint/tendermint/rpc/client"
 )
 
@@ -24,13 +23,9 @@ func sendCommand() *cobra.Command {
 			context.RequireKey(context.RequireNode(doSendCommand))),
 	}
 
-	cmd.Flags().StringP(constants.FlagNode, "n", constants.DefaultNode, "node host")
-	viper.BindPFlag(constants.FlagNode, cmd.Flags().Lookup(constants.FlagNode))
-
-	cmd.Flags().StringP(constants.FlagKey, "k", "", "key name (required)")
-	cmd.MarkFlagRequired(constants.FlagKey)
-
-	cmd.Flags().Uint64(constants.FlagNonce, 0, "nonce (optional)")
+	context.AddFlagNode(cmd, cmd.Flags())
+	context.AddFlagKey(cmd, cmd.Flags())
+	context.AddFlagNonce(cmd, cmd.Flags())
 
 	return cmd
 }


### PR DESCRIPTION
 * move flag registration to context
 * move base config handling to context
 * tests: context flags, base dir, key create
 * fix `photon query` `-n` flag.

fixes #41