### PR TITLE
market app stub: determine block creator

### DIFF
--- a/app/market/app.go
+++ b/app/market/app.go
@@ -1,0 +1,37 @@
+package market
+
+import (
+	apptypes "github.com/ovrclk/photon/app/types"
+	"github.com/ovrclk/photon/state"
+	tmtypes "github.com/tendermint/abci/types"
+	"github.com/tendermint/tmlibs/log"
+)
+
+type app struct {
+	state  state.State
+	logger log.Logger
+}
+
+func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
+	return &app{state, logger}, nil
+}
+
+func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {
+	return false
+}
+
+func (a *app) Query(req tmtypes.RequestQuery) tmtypes.ResponseQuery {
+	return tmtypes.ResponseQuery{}
+}
+
+func (a *app) AcceptTx(ctx apptypes.Context, tx interface{}) bool {
+	return false
+}
+
+func (a *app) CheckTx(ctx apptypes.Context, tx interface{}) tmtypes.ResponseCheckTx {
+	return tmtypes.ResponseCheckTx{}
+}
+
+func (a *app) DeliverTx(ctx apptypes.Context, tx interface{}) tmtypes.ResponseDeliverTx {
+	return tmtypes.ResponseDeliverTx{}
+}

--- a/app/market/facilitator.go
+++ b/app/market/facilitator.go
@@ -1,0 +1,135 @@
+package market
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/ovrclk/photon/state"
+	tmtypes "github.com/tendermint/abci/types"
+	ctypes "github.com/tendermint/tendermint/consensus/types"
+	tmtmtypes "github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tmlibs/log"
+)
+
+const (
+	subscriber = "photon-market"
+)
+
+type Facilitator interface {
+	OnBeginBlock(req tmtypes.RequestBeginBlock) error
+	OnCommit(state state.State) error
+}
+
+type facilitator struct {
+	log       log.Logger
+	validator tmtmtypes.PrivValidator
+
+	block *tmtypes.RequestBeginBlock
+	rs    *ctypes.RoundState
+
+	mtx *sync.Mutex
+}
+
+func (f *facilitator) OnBeginBlock(req tmtypes.RequestBeginBlock) error {
+	f.block = &req
+	return nil
+}
+
+func (f *facilitator) OnCommit(state state.State) error {
+	if !f.checkCommit(state) {
+		f.log.Info("NOT MY TURN TO DO MARKET STUFF.")
+		return nil
+	}
+	f.log.Info("I SHOULD MAKE THE MARKET STUFF HAPPEN.")
+
+	// market stuff happens here
+
+	return nil
+}
+
+func (f *facilitator) checkCommit(state state.State) bool {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	if f.block == nil || f.rs == nil {
+		return false
+	}
+
+	if uint64(f.rs.Height) != state.Version() {
+		return false
+	}
+
+	if bytes.Compare(f.validator.GetAddress(), f.rs.Validators.GetProposer().PubKey.Address()) != 0 {
+		return false
+	}
+
+	if bytes.Compare(f.block.Hash, f.rs.ProposalBlock.Header.Hash()) != 0 {
+		return false
+	}
+
+	return true
+}
+
+func (f *facilitator) onProposalComplete(rs *ctypes.RoundState) {
+	f.log.Info("proposal complete",
+		"height", rs.Height,
+		"proposer", hex.EncodeToString(rs.Validators.GetProposer().PubKey.Address()),
+		"block-hash", rs.ProposalBlock.Header.Hash())
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.rs = rs
+}
+
+func (f *facilitator) onEvent(evt interface{}) {
+
+	tmed, ok := evt.(tmtmtypes.TMEventData)
+	if !ok {
+		f.log.Error("bad event type", "type", fmt.Sprintf("%T", evt))
+		return
+	}
+
+	edrs, ok := tmed.Unwrap().(tmtmtypes.EventDataRoundState)
+	if !ok {
+		f.log.Error("bad event data type", "type", fmt.Sprintf("%T", tmed))
+		return
+	}
+
+	if edrs.RoundState == nil {
+		f.log.Error("nil round state")
+		return
+	}
+
+	rs, ok := edrs.RoundState.(*ctypes.RoundState)
+	if !ok {
+		f.log.Error("bad round state type", "type", fmt.Sprintf("%T", edrs.RoundState))
+		return
+	}
+
+	f.onProposalComplete(rs)
+}
+
+func NewFacilitator(log log.Logger, validator tmtmtypes.PrivValidator, bus *tmtmtypes.EventBus) (Facilitator, error) {
+
+	f := &facilitator{
+		log:       log,
+		validator: validator,
+		mtx:       new(sync.Mutex),
+	}
+
+	ch := make(chan interface{})
+
+	if err := bus.Subscribe(context.Background(), "photon-market", tmtmtypes.EventQueryCompleteProposal, ch); err != nil {
+		return nil, err
+	}
+
+	go func(ch chan interface{}) {
+		for evt := range ch {
+			f.onEvent(evt)
+		}
+	}(ch)
+
+	return f, nil
+}

--- a/cmd/photond/start.go
+++ b/cmd/photond/start.go
@@ -79,6 +79,10 @@ func doStartCommand(ctx Context, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := app.ActivateMarket(pvalidator, n.EventBus()); err != nil {
+		return err
+	}
+
 	if err := n.Start(); err != nil {
 		return fmt.Errorf("Failed to start node: %v", err)
 	}


### PR DESCRIPTION
provide hook to determine block creator on commit()

 * send market transactions (`deployment-order`, `create-lease`) from block creator
 * for now, skip tx validations for who sent the market tx.