### PR TITLE
transaction monitor

### DIFF
--- a/app/account/app.go
+++ b/app/account/app.go
@@ -16,6 +16,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+const (
+	Name = apptypes.TagAppAccount
+)
+
 type app struct {
 	state  state.State
 	logger log.Logger
@@ -23,6 +27,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {
@@ -201,5 +209,7 @@ func (a *app) doDeliverTx(ctx apptypes.Context, tx *types.TxSend) tmtypes.Respon
 		}
 	}
 
-	return tmtypes.ResponseDeliverTx{}
+	return tmtypes.ResponseDeliverTx{
+		Tags: apptypes.NewTags(a.Name(), apptypes.TxTypeSend),
+	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -45,7 +45,7 @@ func Create(state state.State, logger log.Logger) (Application, error) {
 	var apps []apptypes.Application
 
 	{
-		app, err := account.NewApp(state, logger.With("app", "account"))
+		app, err := account.NewApp(state, logger.With("app", account.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +53,7 @@ func Create(state state.State, logger log.Logger) (Application, error) {
 	}
 
 	{
-		app, err := store.NewApp(state, logger.With("app", "store"))
+		app, err := store.NewApp(state, logger.With("app", store.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func Create(state state.State, logger log.Logger) (Application, error) {
 	}
 
 	{
-		app, err := deployment.NewApp(state, logger.With("app", "deployment"))
+		app, err := deployment.NewApp(state, logger.With("app", deployment.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func Create(state state.State, logger log.Logger) (Application, error) {
 	}
 
 	{
-		app, err := deploymentorder.NewApp(state, logger.With("app", "deploymentorder"))
+		app, err := deploymentorder.NewApp(state, logger.With("app", deploymentorder.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func Create(state state.State, logger log.Logger) (Application, error) {
 	}
 
 	{
-		app, err := datacenter.NewApp(state, logger.With("app", "datacenter"))
+		app, err := datacenter.NewApp(state, logger.With("app", datacenter.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +93,7 @@ func (app *app) ActivateMarket(validator *tmtmtypes.PrivValidatorFS, bus *tmtmty
 		return errors.New("market already activated")
 	}
 
-	mapp, err := market.NewApp(app.state, app.log.With("app", "market"))
+	mapp, err := market.NewApp(app.state, app.log.With("app", market.Name))
 	if err != nil {
 		return err
 	}

--- a/app/datacenter/app.go
+++ b/app/datacenter/app.go
@@ -16,6 +16,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+const (
+	Name = apptypes.TagAppDatacenter
+)
+
 type app struct {
 	state  state.State
 	logger log.Logger
@@ -23,6 +27,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a *app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {
@@ -193,5 +201,7 @@ func (a *app) doDeliverTx(ctx apptypes.Context, tx *types.TxCreateDatacenter) tm
 		}
 	}
 
-	return tmtypes.ResponseDeliverTx{}
+	return tmtypes.ResponseDeliverTx{
+		Tags: apptypes.NewTags(a.Name(), apptypes.TxTypeDatacenterCreate),
+	}
 }

--- a/app/deployment/app.go
+++ b/app/deployment/app.go
@@ -16,6 +16,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+const (
+	Name = apptypes.TagAppDeployment
+)
+
 type app struct {
 	state  state.State
 	logger log.Logger
@@ -23,6 +27,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a *app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {
@@ -209,5 +217,7 @@ func (a *app) doDeliverTx(ctx apptypes.Context, tx *types.TxCreateDeployment) tm
 		}
 	}
 
-	return tmtypes.ResponseDeliverTx{}
+	return tmtypes.ResponseDeliverTx{
+		Tags: apptypes.NewTags(a.Name(), apptypes.TxTypeDeployment),
+	}
 }

--- a/app/deploymentorder/app.go
+++ b/app/deploymentorder/app.go
@@ -16,6 +16,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+const (
+	Name = apptypes.TagAppDeploymentOrder
+)
+
 type app struct {
 	state  state.State
 	logger log.Logger
@@ -23,6 +27,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a *app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {
@@ -197,7 +205,9 @@ func (a *app) doDeliverTx(ctx apptypes.Context, tx *types.TxCreateDeploymentOrde
 		}
 	}
 
-	return tmtypes.ResponseDeliverTx{}
+	return tmtypes.ResponseDeliverTx{
+		Tags: apptypes.NewTags(a.Name(), apptypes.TxTypeCreateDeploymentOrder),
+	}
 }
 
 func CreateDeploymentOrderTxs(state state.State) ([]types.TxCreateDeploymentOrder, error) {

--- a/app/market/app.go
+++ b/app/market/app.go
@@ -7,6 +7,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+const (
+	Name = "marketplace"
+)
+
 type app struct {
 	state  state.State
 	logger log.Logger
@@ -14,6 +18,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a *app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {

--- a/app/store/app.go
+++ b/app/store/app.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	QueryPath = "/store"
+	Name      = "store"
 )
 
 type app struct {
@@ -21,6 +22,10 @@ type app struct {
 
 func NewApp(state state.State, logger log.Logger) (apptypes.Application, error) {
 	return &app{state, logger}, nil
+}
+
+func (a *app) Name() string {
+	return Name
 }
 
 func (a *app) AcceptQuery(req tmtypes.RequestQuery) bool {

--- a/app/types/tags.go
+++ b/app/types/tags.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	tmtypes "github.com/tendermint/abci/types"
+)
+
+const (
+	TagNameApp    = "app"
+	TagNameTxType = "tx.type"
+
+	TagAppAccount = "account"
+	TxTypeSend    = "send"
+
+	TagAppDeployment = "deployment"
+	TxTypeDeployment = "deployment"
+
+	TagAppDeploymentOrder       = "deployment-order"
+	TxTypeCreateDeploymentOrder = "deployment-order-create"
+
+	TagAppDatacenter       = "datacenter"
+	TxTypeDatacenterCreate = "datacenter-create"
+)
+
+func NewTagApp(name string) *tmtypes.KVPair {
+	return tmtypes.KVPairString(TagNameApp, name)
+}
+
+func NewTagTxType(name string) *tmtypes.KVPair {
+	return tmtypes.KVPairString(TagNameTxType, name)
+}
+
+func NewTags(appName, txType string) []*tmtypes.KVPair {
+	return []*tmtypes.KVPair{
+		NewTagApp(appName),
+		NewTagTxType(txType),
+	}
+}

--- a/app/types/types.go
+++ b/app/types/types.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Application interface {
+	Name() string
 	AcceptQuery(req tmtypes.RequestQuery) bool
 	Query(req tmtypes.RequestQuery) tmtypes.ResponseQuery
 

--- a/cmd/common/log.go
+++ b/cmd/common/log.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"io"
+
+	"github.com/go-kit/kit/log/term"
+	"github.com/tendermint/tmlibs/log"
+)
+
+func NewLogger(w io.Writer) log.Logger {
+	return log.NewTMLoggerWithColorFn(log.NewSyncWriter(w), logColorFn)
+}
+
+func logColorFn(keyvals ...interface{}) term.FgBgColor {
+	return term.FgBgColor{}
+}

--- a/cmd/common/signal.go
+++ b/cmd/common/signal.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func WatchSignals(ctx context.Context, cancel context.CancelFunc) <-chan struct{} {
+	donech := make(chan struct{})
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, syscall.SIGINT, syscall.SIGHUP)
+	go func() {
+		defer close(donech)
+		defer signal.Stop(sigch)
+		select {
+		case <-ctx.Done():
+		case <-sigch:
+			cancel()
+		}
+	}()
+	return donech
+}

--- a/cmd/photon/datacenter.go
+++ b/cmd/photon/datacenter.go
@@ -24,18 +24,18 @@ func datacenterCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.AddCommand(createCommand())
+	cmd.AddCommand(createDatacenterCommand())
 
 	return cmd
 }
 
-func createCommand() *cobra.Command {
+func createDatacenterCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create [file] [flags]",
 		Short: "create a datacenter",
 		Args:  cobra.ExactArgs(1),
-		RunE:  context.WithContext(context.RequireNode(doCreateCommand)),
+		RunE:  context.WithContext(context.RequireNode(doCreateDatacenterCommand)),
 	}
 
 	context.AddFlagKeyType(cmd, cmd.Flags())
@@ -46,7 +46,7 @@ func createCommand() *cobra.Command {
 	return cmd
 }
 
-func doCreateCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
+func doCreateDatacenterCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
 	datacenter, err := parseDatacenter(args[0])
 	if err != nil {
 		return err

--- a/cmd/photon/main.go
+++ b/cmd/photon/main.go
@@ -10,5 +10,6 @@ func main() {
 	root.AddCommand(datacenterCommand())
 	root.AddCommand(query.QueryCommand())
 	root.AddCommand(pingCommand())
+	root.AddCommand(marketplaceCommand())
 	root.Execute()
 }

--- a/cmd/photon/marketplace.go
+++ b/cmd/photon/marketplace.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+
+	goctx "context"
+
+	"github.com/ovrclk/photon/cmd/common"
+	"github.com/ovrclk/photon/cmd/photon/context"
+	"github.com/ovrclk/photon/marketplace"
+	"github.com/ovrclk/photon/types"
+	"github.com/spf13/cobra"
+	tmclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+func marketplaceCommand() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "marketplace",
+		Short: "monitor marketplace",
+		Args:  cobra.NoArgs,
+		RunE:  context.WithContext(context.RequireNode(doMarketplaceMonitorCommand)),
+	}
+
+	context.AddFlagNode(cmd, cmd.PersistentFlags())
+
+	return cmd
+}
+
+func doMarketplaceMonitorCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
+	client := tmclient.NewHTTP(ctx.Node(), "/websocket")
+
+	gctx, cancel := goctx.WithCancel(goctx.Background())
+	donech := common.WatchSignals(gctx, cancel)
+
+	m := marketplace.NewMonitor(gctx, ctx.Log(), client)
+	h := marketplaceMonitorHandler()
+
+	if err := m.Start(); err != nil {
+		return err
+	}
+
+	m.AddHandler("photon-cli", h, marketplace.TxQuery())
+
+	<-m.Wait()
+	cancel()
+	<-donech
+
+	return nil
+}
+
+func marketplaceMonitorHandler() marketplace.Handler {
+	return marketplace.NewBuilder().
+		OnTxSend(func(tx *types.TxSend) {
+			fmt.Printf("TRANSFER %v tokens from %X to %X\n", tx.GetAmount(), tx.From, tx.To)
+		}).Create()
+}

--- a/cmd/photond/start.go
+++ b/cmd/photond/start.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path"
 
-	"github.com/go-kit/kit/log/term"
 	"github.com/ovrclk/photon/app"
 	"github.com/ovrclk/photon/node"
 	"github.com/ovrclk/photon/state"
@@ -58,8 +56,7 @@ func doStartCommand(ctx Context, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	logger := log.NewTMLoggerWithColorFn(log.NewSyncWriter(os.Stdout), logColorFn)
-	logger = log.NewFilter(logger, log.AllowError(),
+	logger := log.NewFilter(ctx.Log(), log.AllowError(),
 		log.AllowDebugWith("module", "photon"))
 
 	applog := logger.With("module", "photon")
@@ -98,8 +95,4 @@ func tmgenesisProvider(path string) tmnode.GenesisDocProvider {
 	return func() (*tmtypes.GenesisDoc, error) {
 		return node.TMGenesisFromFile(path)
 	}
-}
-
-func logColorFn(keyvals ...interface{}) term.FgBgColor {
-	return term.FgBgColor{}
 }

--- a/marketplace/handler.go
+++ b/marketplace/handler.go
@@ -1,0 +1,67 @@
+package marketplace
+
+import (
+	"github.com/ovrclk/photon/types"
+)
+
+type Handler interface {
+	OnTxSend(*types.TxSend)
+	OnTxCreateDeployment(*types.TxCreateDeployment)
+	OnTxCreateDatacenter(*types.TxCreateDatacenter)
+}
+
+type handler struct {
+	onTxSend             func(*types.TxSend)
+	onTxCreateDeployment func(*types.TxCreateDeployment)
+	onTxCreateDatacenter func(*types.TxCreateDatacenter)
+}
+
+func (h handler) OnTxSend(tx *types.TxSend) {
+	if h.onTxSend != nil {
+		h.onTxSend(tx)
+	}
+}
+
+func (h handler) OnTxCreateDeployment(tx *types.TxCreateDeployment) {
+	if h.onTxCreateDeployment != nil {
+		h.onTxCreateDeployment(tx)
+	}
+}
+
+func (h handler) OnTxCreateDatacenter(tx *types.TxCreateDatacenter) {
+	if h.onTxCreateDatacenter != nil {
+		h.onTxCreateDatacenter(tx)
+	}
+}
+
+type Builder interface {
+	OnTxSend(func(*types.TxSend)) Builder
+	OnTxCreateDeployment(func(*types.TxCreateDeployment)) Builder
+	OnTxCreateDatacenter(func(*types.TxCreateDatacenter)) Builder
+	Create() Handler
+}
+
+type builder handler
+
+func NewBuilder() Builder {
+	return &builder{}
+}
+
+func (b *builder) OnTxSend(fn func(*types.TxSend)) Builder {
+	b.onTxSend = fn
+	return b
+}
+
+func (b *builder) OnTxCreateDeployment(fn func(*types.TxCreateDeployment)) Builder {
+	b.onTxCreateDeployment = fn
+	return b
+}
+
+func (b *builder) OnTxCreateDatacenter(fn func(*types.TxCreateDatacenter)) Builder {
+	b.onTxCreateDatacenter = fn
+	return b
+}
+
+func (b *builder) Create() Handler {
+	return (handler)(*b)
+}

--- a/marketplace/monitor.go
+++ b/marketplace/monitor.go
@@ -1,0 +1,139 @@
+package marketplace
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ovrclk/photon/txutil"
+	"github.com/ovrclk/photon/types"
+	"github.com/tendermint/tendermint/rpc/client"
+	tmtmtypes "github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tmlibs/log"
+	"github.com/tendermint/tmlibs/pubsub"
+)
+
+type Monitor interface {
+	AddHandler(name string, h Handler, q pubsub.Query)
+	Start() error
+	Stop() error
+	Wait() <-chan struct{}
+}
+
+type monitor struct {
+	client EventProvider
+
+	ctx context.Context
+	log log.Logger
+
+	donech chan struct{}
+	stopch chan struct{}
+
+	wg sync.WaitGroup
+}
+
+// limited client.HTTP to make testing easier.
+type EventProvider interface {
+	client.EventsClient
+	Start() error
+	Stop() error
+	Wait()
+}
+
+func NewMonitor(ctx context.Context, log log.Logger, client EventProvider) Monitor {
+
+	m := &monitor{
+		client: client,
+		ctx:    ctx,
+		log:    log,
+		donech: make(chan struct{}),
+		stopch: make(chan struct{}),
+		wg:     sync.WaitGroup{},
+	}
+
+	go m.doWait()
+
+	m.wg.Add(1)
+	go m.watchContext()
+
+	return m
+}
+
+func (m *monitor) doWait() {
+	m.client.Wait()
+	close(m.stopch)
+	m.wg.Wait()
+	close(m.donech)
+}
+
+func (m *monitor) watchContext() {
+	defer m.wg.Done()
+
+	select {
+	case <-m.ctx.Done():
+		m.Stop()
+	case <-m.stopch:
+	}
+
+}
+
+func (m *monitor) Start() error {
+	return m.client.Start()
+}
+
+func (m *monitor) Stop() error {
+	return m.client.Stop()
+}
+
+func (m *monitor) Wait() <-chan struct{} {
+	return m.donech
+}
+
+func (m *monitor) AddHandler(name string, h Handler, q pubsub.Query) {
+	ch := m.newListener(h)
+	m.client.Subscribe(m.ctx, name, q, ch)
+}
+
+func (m *monitor) newListener(h Handler) chan<- interface{} {
+	ch := make(chan interface{})
+
+	m.wg.Add(1)
+	go m.runListener(ch, h)
+
+	return ch
+}
+
+func (m *monitor) runListener(ch <-chan interface{}, h Handler) {
+	defer m.wg.Done()
+
+loop:
+	for {
+		select {
+		case <-m.stopch:
+			return
+		case ev := <-ch:
+			ed, ok := ev.(tmtmtypes.TMEventData)
+			if !ok {
+				continue loop
+			}
+
+			evt, ok := ed.Unwrap().(tmtmtypes.EventDataTx)
+			if !ok {
+				continue loop
+			}
+
+			tx, err := txutil.ProcessTx(evt.Tx)
+			if err != nil {
+				continue loop
+			}
+
+			switch tx := tx.Payload.GetPayload().(type) {
+			case *types.TxPayload_TxSend:
+				h.OnTxSend(tx.TxSend)
+			case *types.TxPayload_TxCreateDeployment:
+				h.OnTxCreateDeployment(tx.TxCreateDeployment)
+			case *types.TxPayload_TxCreateDatacenter:
+				h.OnTxCreateDatacenter(tx.TxCreateDatacenter)
+			}
+		}
+	}
+}

--- a/marketplace/query.go
+++ b/marketplace/query.go
@@ -1,0 +1,34 @@
+package marketplace
+
+import (
+	"fmt"
+
+	apptypes "github.com/ovrclk/photon/app/types"
+	tmtmtypes "github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tmlibs/pubsub"
+	tmquery "github.com/tendermint/tmlibs/pubsub/query"
+)
+
+func TxQuery() pubsub.Query {
+	return buildTxQuery("")
+}
+
+func TxQueryApp(name string) pubsub.Query {
+	return buildTxQuery("%s='%s'", apptypes.TagNameApp, name)
+}
+
+func TxQueryTxType(name string) pubsub.Query {
+	return buildTxQuery("%s='%s'", apptypes.TagNameTxType, name)
+}
+
+func TxQueryCreateDeploymentOrder() pubsub.Query {
+	return TxQueryTxType(apptypes.TxTypeCreateDeploymentOrder)
+}
+
+func buildTxQuery(format string, args ...interface{}) pubsub.Query {
+	val := fmt.Sprintf("%s='%s'", tmtmtypes.EventTypeKey, tmtmtypes.EventTx)
+	if format != "" {
+		val += fmt.Sprintf(" AND "+format, args...)
+	}
+	return tmquery.MustParse(val)
+}


### PR DESCRIPTION
 * add tags to transactions
 * add tx monitor utilities
 * initial marketplace monitor command
 * add Log() to cmd contexts

adds `{app,tx}` tags to transactions.  all apps seem to have only one tx right now, so both might not be necessary.