### PR TITLE
attempt flapping test fix

### DIFF
--- a/cmd/akashd/start_test.go
+++ b/cmd/akashd/start_test.go
@@ -60,7 +60,7 @@ func Test_Start(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(2 * time.Second):
 		// cancel the process
 		testCtx.Cancel()
 	case err := <-errch:


### PR DESCRIPTION
refs #124 

The flapping test may be caused because close is called while the database is initializing.