### PR TITLE
query client, more key parsing

### DIFF
--- a/app/account/app.go
+++ b/app/account/app.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	apptypes "github.com/ovrclk/akash/app/types"
+	"github.com/ovrclk/akash/keys"
 	"github.com/ovrclk/akash/state"
 	"github.com/ovrclk/akash/types"
-	"github.com/ovrclk/akash/types/base"
 	"github.com/ovrclk/akash/types/code"
 	tmtypes "github.com/tendermint/abci/types"
 	"github.com/tendermint/tmlibs/log"
@@ -40,7 +40,7 @@ func (a *app) Query(req tmtypes.RequestQuery) tmtypes.ResponseQuery {
 		}
 	}
 	id := strings.TrimPrefix(req.Path, state.AccountPath)
-	key, err := base.DecodeString(id)
+	key, err := keys.ParseAccountPath(id)
 	if err != nil {
 		return tmtypes.ResponseQuery{
 			Code: code.ERROR,
@@ -48,7 +48,7 @@ func (a *app) Query(req tmtypes.RequestQuery) tmtypes.ResponseQuery {
 		}
 	}
 
-	acct, err := a.State().Account().Get(key)
+	acct, err := a.State().Account().Get(key.ID())
 	if err != nil {
 		return tmtypes.ResponseQuery{
 			Code: code.ERROR,

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	apptypes "github.com/ovrclk/akash/app/types"
+	"github.com/ovrclk/akash/keys"
 	"github.com/ovrclk/akash/state"
 	"github.com/ovrclk/akash/types"
 	"github.com/ovrclk/akash/types/base"
@@ -47,14 +48,14 @@ func (a *app) Query(req tmtypes.RequestQuery) tmtypes.ResponseQuery {
 		return a.doRangeQuery()
 	}
 
-	key, err := base.DecodeString(id)
+	key, err := keys.ParseProviderPath(id)
 	if err != nil {
 		return tmtypes.ResponseQuery{
 			Code: code.ERROR,
 			Log:  err.Error(),
 		}
 	}
-	return a.doQuery(key)
+	return a.doQuery(key.ID())
 }
 
 func (a *app) AcceptTx(ctx apptypes.Context, tx interface{}) bool {

--- a/cmd/akash/context/context.go
+++ b/cmd/akash/context/context.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/ovrclk/akash/cmd/akash/constants"
 	"github.com/ovrclk/akash/cmd/common"
+	"github.com/ovrclk/akash/query"
 	"github.com/ovrclk/akash/txutil"
+
+	gctx "context"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -25,12 +28,14 @@ type Context interface {
 	Node() string
 	Client() *tmclient.HTTP
 	TxClient() (txutil.Client, error)
+	QueryClient() query.Client
 	KeyName() string
 	KeyType() (keys.CryptoAlgo, error)
 	Key() (keys.Info, error)
 	Nonce() (uint64, error)
 	Log() log.Logger
 	Signer() (txutil.Signer, keys.Info, error)
+	Ctx() gctx.Context
 	Wait() bool
 }
 
@@ -160,6 +165,10 @@ func (ctx *context) TxClient() (txutil.Client, error) {
 	return txutil.NewClient(ctx.Client(), signer, key, nonce), nil
 }
 
+func (ctx *context) QueryClient() query.Client {
+	return query.NewClient(ctx.Client())
+}
+
 func (ctx *context) KeyName() string {
 	val, _ := ctx.cmd.Flags().GetString(constants.FlagKey)
 	return val
@@ -224,6 +233,10 @@ func (ctx *context) Nonce() (uint64, error) {
 func (ctx *context) Wait() bool {
 	val, _ := ctx.cmd.Flags().GetBool(constants.FlagWait)
 	return val
+}
+
+func (ctx *context) Ctx() gctx.Context {
+	return gctx.Background()
 }
 
 func loadKeyManager(root string) (keys.Keybase, tmdb.DB, error) {

--- a/cmd/akash/deployment.go
+++ b/cmd/akash/deployment.go
@@ -6,14 +6,12 @@ import (
 	"os"
 
 	"github.com/ovrclk/akash/cmd/akash/context"
-	"github.com/ovrclk/akash/cmd/akash/query"
 	"github.com/ovrclk/akash/cmd/common"
 	"github.com/ovrclk/akash/keys"
 	"github.com/ovrclk/akash/manifest"
 	"github.com/ovrclk/akash/marketplace"
 	"github.com/ovrclk/akash/sdl"
 	"github.com/ovrclk/akash/types"
-	"github.com/ovrclk/akash/types/base"
 	. "github.com/ovrclk/akash/util"
 	"github.com/spf13/cobra"
 )
@@ -110,7 +108,7 @@ func createDeployment(ctx context.Context, cmd *cobra.Command, args []string) er
 					fmt.Printf("Group %v/%v Lease: %v\n", tx.Group, len(groups),
 						keys.LeaseID(tx.LeaseID).Path())
 					// get lease provider
-					prov, err := query.Provider(ctx, tx.Provider)
+					prov, err := ctx.QueryClient().Provider(ctx.Ctx(), tx.Provider)
 					if err != nil {
 						fmt.Printf("ERROR: %v", err)
 					}
@@ -156,13 +154,13 @@ func closeDeployment(ctx context.Context, cmd *cobra.Command, args []string) err
 		return err
 	}
 
-	deployment, err := base.DecodeString(args[0])
+	deployment, err := keys.ParseDeploymentPath(args[0])
 	if err != nil {
 		return err
 	}
 
 	_, err = txclient.BroadcastTxCommit(&types.TxCloseDeployment{
-		Deployment: deployment,
+		Deployment: deployment.ID(),
 		Reason:     types.TxCloseDeployment_TENANT_CLOSE,
 	})
 
@@ -207,17 +205,17 @@ func sendManifest(ctx context.Context, cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	leaseAddr, err := base.DecodeString(args[1])
+	leaseAddr, err := keys.ParseLeasePath(args[1])
 	if err != nil {
 		return err
 	}
 
-	lease, err := query.Lease(ctx, leaseAddr)
+	lease, err := ctx.QueryClient().Lease(ctx.Ctx(), leaseAddr.ID())
 	if err != nil {
 		return err
 	}
 
-	provider, err := query.Provider(ctx, lease.Provider)
+	provider, err := ctx.QueryClient().Provider(ctx.Ctx(), lease.Provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/akash/query/account.go
+++ b/cmd/akash/query/account.go
@@ -2,8 +2,7 @@ package query
 
 import (
 	"github.com/ovrclk/akash/cmd/akash/context"
-	"github.com/ovrclk/akash/state"
-	"github.com/ovrclk/akash/types"
+	"github.com/ovrclk/akash/keys"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +19,14 @@ func queryAccountCommand() *cobra.Command {
 }
 
 func doQueryAccountCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
-	structure := new(types.Account)
-	account := args[0]
-	path := state.AccountPath + account
-	return doQuery(ctx, path, structure)
+	for _, arg := range args {
+		key, err := keys.ParseAccountPath(arg)
+		if err != nil {
+			return err
+		}
+		if err := handleMessage(ctx.QueryClient().Account(ctx.Ctx(), key.ID())); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/akash/query/deployment.go
+++ b/cmd/akash/query/deployment.go
@@ -2,8 +2,7 @@ package query
 
 import (
 	"github.com/ovrclk/akash/cmd/akash/context"
-	"github.com/ovrclk/akash/state"
-	"github.com/ovrclk/akash/types"
+	"github.com/ovrclk/akash/keys"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +18,17 @@ func queryDeploymentCommand() *cobra.Command {
 }
 
 func doQueryDeploymentCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
-	path := state.DeploymentPath
-	if len(args) > 0 {
-		structure := new(types.Deployment)
-		path += args[0]
-		return doQuery(ctx, path, structure)
-	} else {
-		structure := new(types.Deployments)
-		return doQuery(ctx, path, structure)
+	if len(args) == 0 {
+		handleMessage(ctx.QueryClient().Deployments(ctx.Ctx()))
 	}
+	for _, arg := range args {
+		key, err := keys.ParseDeploymentPath(arg)
+		if err != nil {
+			return err
+		}
+		if err := handleMessage(ctx.QueryClient().Deployment(ctx.Ctx(), key.ID())); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/akash/query/order.go
+++ b/cmd/akash/query/order.go
@@ -2,8 +2,7 @@ package query
 
 import (
 	"github.com/ovrclk/akash/cmd/akash/context"
-	"github.com/ovrclk/akash/state"
-	"github.com/ovrclk/akash/types"
+	"github.com/ovrclk/akash/keys"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +18,17 @@ func queryOrderCommand() *cobra.Command {
 }
 
 func doQueryOrderCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
-	path := state.OrderPath
-	if len(args) > 0 {
-		structure := new(types.Order)
-		path += args[0]
-		return doQuery(ctx, path, structure)
-	} else {
-		structure := new(types.Orders)
-		return doQuery(ctx, path, structure)
+	if len(args) == 0 {
+		handleMessage(ctx.QueryClient().Orders(ctx.Ctx()))
 	}
+	for _, arg := range args {
+		key, err := keys.ParseOrderPath(arg)
+		if err != nil {
+			return err
+		}
+		if err := handleMessage(ctx.QueryClient().Order(ctx.Ctx(), key.ID())); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/akash/query/provider.go
+++ b/cmd/akash/query/provider.go
@@ -1,11 +1,8 @@
 package query
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"github.com/ovrclk/akash/cmd/akash/context"
-	"github.com/ovrclk/akash/state"
-	"github.com/ovrclk/akash/types"
-	"github.com/ovrclk/akash/util"
+	"github.com/ovrclk/akash/keys"
 	"github.com/spf13/cobra"
 )
 
@@ -21,26 +18,17 @@ func queryProviderCommand() *cobra.Command {
 }
 
 func doQueryProviderCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
-	path := state.ProviderPath
-	if len(args) > 0 {
-		structure := new(types.Provider)
-		path += args[0]
-		return doQuery(ctx, path, structure)
-	} else {
-		structure := new(types.Providers)
-		return doQuery(ctx, path, structure)
+	if len(args) == 0 {
+		handleMessage(ctx.QueryClient().Providers(ctx.Ctx()))
 	}
-}
-
-func Provider(ctx context.Context, paddr []byte) (*types.Provider, error) {
-	provider := &types.Provider{}
-	path := state.ProviderPath + util.X(paddr)
-	result, err := Query(ctx, path)
-	if err != nil {
-		return nil, err
+	for _, arg := range args {
+		key, err := keys.ParseProviderPath(arg)
+		if err != nil {
+			return err
+		}
+		if err := handleMessage(ctx.QueryClient().Provider(ctx.Ctx(), key.ID())); err != nil {
+			return err
+		}
 	}
-	if err := proto.Unmarshal(result.Response.Value, provider); err != nil {
-		return nil, err
-	}
-	return provider, nil
+	return nil
 }

--- a/cmd/akash/query/query.go
+++ b/cmd/akash/query/query.go
@@ -2,13 +2,11 @@ package query
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
+	"os"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/ovrclk/akash/cmd/akash/context"
 	"github.com/spf13/cobra"
-	core_types "github.com/tendermint/tendermint/rpc/core/types"
 )
 
 func QueryCommand() *cobra.Command {
@@ -32,34 +30,15 @@ func QueryCommand() *cobra.Command {
 	return cmd
 }
 
-func Query(ctx context.Context, path string) (*core_types.ResultABCIQuery, error) {
-	client := ctx.Client()
-	result, err := client.ABCIQuery(path, nil)
-	if err != nil {
-		return result, err
-	}
-	if result.Response.IsErr() {
-		return result, errors.New(result.Response.GetLog())
-	}
-	return result, nil
-}
-
-func doQuery(ctx context.Context, path string, obj proto.Message) error {
-	result, err := Query(ctx, path)
+func handleMessage(obj proto.Message, err error) error {
 	if err != nil {
 		return err
 	}
-
-	if err := proto.Unmarshal(result.Response.Value, obj); err != nil {
-		return err
-	}
-
 	data, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return err
 	}
-
-	fmt.Println(string(data))
-
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte("\n"))
 	return nil
 }

--- a/cmd/akash/send.go
+++ b/cmd/akash/send.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/ovrclk/akash/cmd/akash/context"
+	"github.com/ovrclk/akash/keys"
 	"github.com/ovrclk/akash/types"
-	"github.com/ovrclk/akash/types/base"
 	"github.com/spf13/cobra"
 )
 
@@ -38,21 +38,21 @@ func doSendCommand(ctx context.Context, cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	to, err := base.DecodeString(args[1])
+	to, err := keys.ParseAccountPath(args[1])
 	if err != nil {
 		return err
 	}
 
 	result, err := txclient.BroadcastTxCommit(&types.TxSend{
 		From:   txclient.Key().Address(),
-		To:     to,
+		To:     to.ID(),
 		Amount: amount,
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Sent %v tokens to %v in block %v\n", amount, to.EncodeString(), result.Height)
+	fmt.Printf("Sent %v tokens to %v in block %v\n", amount, to.Path(), result.Height)
 
 	return nil
 }

--- a/cmd/akashd/init.go
+++ b/cmd/akashd/init.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/ovrclk/akash/keys"
 	ptypes "github.com/ovrclk/akash/types"
-	"github.com/ovrclk/akash/types/base"
 	"github.com/ovrclk/akash/util/initgen"
 	"github.com/spf13/cobra"
 )
@@ -83,13 +83,13 @@ func doInitCommand(ctx Context, cmd *cobra.Command, args []string) error {
 }
 
 func generateAkashGenesis(cmd *cobra.Command, args []string) (*ptypes.Genesis, error) {
-	addr, err := base.DecodeString(args[0])
+	key, err := keys.ParseAccountPath(args[0])
 	if err != nil {
 		return nil, err
 	}
 	return &ptypes.Genesis{
 		Accounts: []ptypes.Account{
-			ptypes.Account{Address: addr, Balance: maxTokens},
+			ptypes.Account{Address: key.ID(), Balance: maxTokens},
 		},
 	}, nil
 }

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -17,22 +17,28 @@ type Key interface {
 	Bytes() []byte
 }
 
-type Deployment base.Bytes
+type Address base.Bytes
 
-func DeploymentID(id base.Bytes) Deployment {
-	return Deployment(id)
+type (
+	Deployment = Address
+	Provider   = Address
+	Account    = Address
+)
+
+func (k Address) Path() string {
+	return util.X(k)
 }
 
-func (k Deployment) ID() base.Bytes {
-	return base.Bytes(k)
-}
-
-func (k Deployment) Bytes() []byte {
+func (k Address) Bytes() []byte {
 	return k
 }
 
-func (k Deployment) Path() string {
-	return util.X(k)
+func (k Address) ID() base.Bytes {
+	return base.Bytes(k)
+}
+
+func DeploymentID(id base.Bytes) Deployment {
+	return Address(id)
 }
 
 type DeploymentGroup struct {

--- a/keys/parse.go
+++ b/keys/parse.go
@@ -11,9 +11,21 @@ import (
 
 // XXX: interim hack (iteration!)
 
-func ParseDeploymentPath(buf string) (Deployment, error) {
+func ParseAddressPath(buf string) (Address, error) {
 	obj, err := base.DecodeString(buf)
-	return Deployment(obj), err
+	return Address(obj), err
+}
+
+func ParseDeploymentPath(buf string) (Deployment, error) {
+	return ParseAddressPath(buf)
+}
+
+func ParseProviderPath(buf string) (Provider, error) {
+	return ParseAddressPath(buf)
+}
+
+func ParseAccountPath(buf string) (Account, error) {
+	return ParseAddressPath(buf)
 }
 
 func ParseGroupPath(buf string) (DeploymentGroup, error) {
@@ -79,7 +91,12 @@ func ParseFulfillmentPath(buf string) (Fulfillment, error) {
 	obj.Group = order.Group
 	obj.Order = order.Seq
 
-	obj.Provider, err = base.DecodeString(parts[3])
+	provider, err := ParseProviderPath(parts[3])
+	if err != nil {
+		return obj, fmt.Errorf("invalid fulfillment path '%v': %v", buf, err)
+	}
+
+	obj.Provider = provider.ID()
 
 	return obj, err
 }

--- a/query/client.go
+++ b/query/client.go
@@ -1,0 +1,151 @@
+package query
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/ovrclk/akash/types"
+	tmclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+type Client interface {
+	Account(ctx context.Context, id []byte) (*types.Account, error)
+
+	Providers(ctx context.Context) (*types.Providers, error)
+	Provider(ctx context.Context, id []byte) (*types.Provider, error)
+
+	Deployments(ctx context.Context) (*types.Deployments, error)
+	Deployment(ctx context.Context, id []byte) (*types.Deployment, error)
+	DeploymentLeases(ctx context.Context, id []byte) (*types.Leases, error)
+
+	DeploymentGroup(ctx context.Context, id types.DeploymentGroupID) (*types.DeploymentGroup, error)
+
+	Orders(ctx context.Context) (*types.Orders, error)
+	Order(ctx context.Context, id types.OrderID) (*types.Order, error)
+
+	Leases(ctx context.Context) (*types.Leases, error)
+	Lease(ctx context.Context, id types.LeaseID) (*types.Lease, error)
+
+	Get(ctx context.Context, path string, obj proto.Message) error
+}
+
+type client struct {
+	tmc *tmclient.HTTP
+}
+
+func NewClient(tmc *tmclient.HTTP) Client {
+	return &client{tmc: tmc}
+}
+
+func (c *client) Account(ctx context.Context, id []byte) (*types.Account, error) {
+	obj := &types.Account{}
+	path := AccountPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Providers(ctx context.Context) (*types.Providers, error) {
+	obj := &types.Providers{}
+	path := ProvidersPath()
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Provider(ctx context.Context, id []byte) (*types.Provider, error) {
+	obj := &types.Provider{}
+	path := ProviderPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Deployments(ctx context.Context) (*types.Deployments, error) {
+	obj := &types.Deployments{}
+	path := DeploymentsPath()
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Deployment(ctx context.Context, id []byte) (*types.Deployment, error) {
+	obj := &types.Deployment{}
+	path := DeploymentPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) DeploymentGroup(ctx context.Context, id types.DeploymentGroupID) (*types.DeploymentGroup, error) {
+	obj := &types.DeploymentGroup{}
+	path := DeploymentGroupPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) DeploymentLeases(ctx context.Context, id []byte) (*types.Leases, error) {
+	obj := &types.Leases{}
+	path := DeploymentLeasesPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Orders(ctx context.Context) (*types.Orders, error) {
+	obj := &types.Orders{}
+	path := OrdersPath()
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Order(ctx context.Context, id types.OrderID) (*types.Order, error) {
+	obj := &types.Order{}
+	path := OrderPath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Leases(ctx context.Context) (*types.Leases, error) {
+	obj := &types.Leases{}
+	path := LeasesPath()
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Lease(ctx context.Context, id types.LeaseID) (*types.Lease, error) {
+	obj := &types.Lease{}
+	path := LeasePath(id)
+	if err := c.Get(ctx, path, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *client) Get(ctx context.Context, path string, obj proto.Message) error {
+	result, err := c.tmc.ABCIQuery(path, nil)
+	if err != nil {
+		return err
+	}
+
+	if result.Response.IsErr() {
+		return errors.New(result.Response.GetLog())
+	}
+
+	return proto.Unmarshal(result.Response.Value, obj)
+}

--- a/query/path.go
+++ b/query/path.go
@@ -4,23 +4,39 @@ import (
 	"github.com/ovrclk/akash/keys"
 	"github.com/ovrclk/akash/state"
 	"github.com/ovrclk/akash/types"
-	. "github.com/ovrclk/akash/util"
+	"github.com/ovrclk/akash/util"
 )
 
 func AccountPath(address []byte) string {
-	return state.AccountPath + X(address)
+	return state.AccountPath + util.X(address)
+}
+
+func ProvidersPath() string {
+	return state.ProviderPath
 }
 
 func ProviderPath(address []byte) string {
-	return state.ProviderPath + X(address)
+	return state.ProviderPath + util.X(address)
+}
+
+func DeploymentsPath() string {
+	return state.DeploymentPath
 }
 
 func DeploymentPath(address []byte) string {
-	return state.DeploymentPath + X(address)
+	return state.DeploymentPath + util.X(address)
+}
+
+func DeploymentLeasesPath(address []byte) string {
+	return state.LeasePath + util.X(address)
 }
 
 func DeploymentGroupPath(id types.DeploymentGroupID) string {
 	return state.DeploymentGroupPath + keys.DeploymentGroupID(id).Path()
+}
+
+func OrdersPath() string {
+	return state.OrderPath
 }
 
 func OrderPath(id types.OrderID) string {
@@ -29,6 +45,10 @@ func OrderPath(id types.OrderID) string {
 
 func FulfillmentPath(id types.FulfillmentID) string {
 	return state.FulfillmentPath + keys.FulfillmentID(id).Path()
+}
+
+func LeasesPath() string {
+	return state.LeasePath
 }
 
 func LeasePath(id types.LeaseID) string {


### PR DESCRIPTION
 * query: re-usable object query moved from `cmd/akash/query`
 * keys: parse more types