### PR TITLE
cmd/akash: add key show

### DIFF
--- a/cmd/akash/key.go
+++ b/cmd/akash/key.go
@@ -20,9 +20,9 @@ func keyCommand() *cobra.Command {
 	}
 	cmd.AddCommand(keyCreateCommand())
 	cmd.AddCommand(keyListCommand())
+	cmd.AddCommand(keyShowCommand())
 	return cmd
 }
-
 func keyCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [name]",
@@ -79,5 +79,39 @@ func doKeyListCommand(session session.Session, cmd *cobra.Command, args []string
 		fmt.Fprintf(tw, "%v\t%v\n", info.Name, X(info.Address()))
 	}
 	tw.Flush()
+	return nil
+}
+
+func keyShowCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show [name]",
+		Short: "display a key",
+		RunE:  session.WithSession(session.RequireRootDir(doKeyShowCommand)),
+	}
+	session.AddFlagKeyType(cmd, cmd.Flags())
+	return cmd
+}
+
+func doKeyShowCommand(session session.Session, cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("name argument required")
+	}
+
+	kmgr, err := session.KeyManager()
+	if err != nil {
+		return err
+	}
+
+	info, err := kmgr.Get(args[0])
+	if err != nil {
+		return err
+	}
+
+	if len(info.Address()) == 0 {
+		fmt.Errorf("key not found %s", args[0])
+		return nil
+	}
+
+	fmt.Println(X(info.Address()))
 	return nil
 }

--- a/cmd/akash/key.go
+++ b/cmd/akash/key.go
@@ -86,6 +86,7 @@ func keyShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show [name]",
 		Short: "display a key",
+		Args:  cobra.ExactArgs(1),
 		RunE:  session.WithSession(session.RequireRootDir(doKeyShowCommand)),
 	}
 	session.AddFlagKeyType(cmd, cmd.Flags())
@@ -102,13 +103,15 @@ func doKeyShowCommand(session session.Session, cmd *cobra.Command, args []string
 		return err
 	}
 
-	info, err := kmgr.Get(args[0])
+	name := args[0]
+
+	info, err := kmgr.Get(name)
 	if err != nil {
 		return err
 	}
 
 	if len(info.Address()) == 0 {
-		return fmt.Errorf("key not found %s", args[0])
+		return fmt.Errorf("key not found %s", name)
 	}
 
 	fmt.Println(X(info.Address()))

--- a/cmd/akash/key.go
+++ b/cmd/akash/key.go
@@ -108,8 +108,7 @@ func doKeyShowCommand(session session.Session, cmd *cobra.Command, args []string
 	}
 
 	if len(info.Address()) == 0 {
-		fmt.Errorf("key not found %s", args[0])
-		return nil
+		return fmt.Errorf("key not found %s", args[0])
 	}
 
 	fmt.Println(X(info.Address()))


### PR DESCRIPTION
Fixes  #270 

Currently, the keys are retrieved using `akash key list` which is good for display but not optimized for scripting; for example to query the master account: 

```
$ akash query account $(akash key list  | grep master | awk '{print $2}')
```

This change add a simpler way to query for individual keys makes scripting experience better. The above command could be rewritten as follows:

```
$ akash query account $(akash key show master)
```
