### PR TITLE
provider: use uuid instead of deployment id for hostnames

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 331591a3d80cf1be2293f7cfcc0867077c81f29ec2b6c40da5107cdcee68b69f
-updated: 2018-07-25T16:31:39.857735966-07:00
+hash: 0c87ff7affe3cdef5c94810a29ab86ac5f73360aa0e41dd98ca107fbfa20c19e
+updated: 2018-07-27T19:57:05.312652522-07:00
 imports:
 - name: github.com/blang/semver
   version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
@@ -133,6 +133,8 @@ imports:
   - difflib
 - name: github.com/rcrowley/go-metrics
   version: e2704e165165ec55d062f5919b4b29494e9fa790
+- name: github.com/satori/go.uuid
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/spf13/afero
@@ -148,7 +150,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 3ebe029320b2676d667ae88da602a5f854788a8a
 - name: github.com/spf13/viper
-  version: d493c32b69b8c6f2377bf30bc4d70267ffbc0793
+  version: 15738813a09db5c8e5b60a19d67d3f9bd38da3a4
 - name: github.com/stretchr/objx
   version: b8b73a35e9830ae509858c10dec5866b4d5c8bff
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,6 @@ import:
   - proto
   - jsonpb
 - package: github.com/spf13/cobra
-- package: github.com/satori/go.uuid
 - package: github.com/spf13/viper
   version: master
 - package: github.com/tendermint/go-crypto
@@ -67,3 +66,5 @@ import:
   version: ^3.3.0
 - package: github.com/blang/semver
   version: ^3.5.1
+- package: github.com/satori/go.uuid
+  version: ~1.2.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,7 @@ import:
   - proto
   - jsonpb
 - package: github.com/spf13/cobra
+- package: github.com/satori/go.uuid
 - package: github.com/spf13/viper
   version: master
 - package: github.com/tendermint/go-crypto

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -215,7 +215,7 @@ type ingressBuilder struct {
 }
 
 func newIngressBuilder(host string, lid types.LeaseID, group *types.ManifestGroup, service *types.ManifestService, expose *types.ManifestServiceExpose) *ingressBuilder {
-	uid := uuid.Must(uuid.NewV4())
+	uid := uuid.NewV4()
 	expose.Hosts = append(expose.Hosts, fmt.Sprintf("%v.%s.%v", service.Name, uid, host))
 	return &ingressBuilder{
 		deploymentBuilder: deploymentBuilder{builder: builder{lid, group}, service: service},

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -9,6 +9,7 @@ import (
 
 	akashv1 "github.com/ovrclk/akash/pkg/apis/akash.network/v1"
 	"github.com/ovrclk/akash/types"
+	"github.com/satori/go.uuid"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/api/extensions/v1beta1"
@@ -214,7 +215,8 @@ type ingressBuilder struct {
 }
 
 func newIngressBuilder(host string, lid types.LeaseID, group *types.ManifestGroup, service *types.ManifestService, expose *types.ManifestServiceExpose) *ingressBuilder {
-	expose.Hosts = append(expose.Hosts, fmt.Sprintf("%v.%v.%v", service.Name, lid.DeploymentID(), host))
+	uid := uuid.Must(uuid.NewV4())
+	expose.Hosts = append(expose.Hosts, fmt.Sprintf("%v.%s.%v", service.Name, uid, host))
 	return &ingressBuilder{
 		deploymentBuilder: deploymentBuilder{builder: builder{lid, group}, service: service},
 		expose:            expose,


### PR DESCRIPTION
The maximum allowed length for a domain name label is **63** bytes. The current implementation uses deployment ids which are **64** bytes long. 

For eg: `web.ece4d213af89da02c0f4b5e589dcb9dd9313d4fc228ba9ad316cc8fb79ac163a.147-75-71-243.aksh.io`

This patch uses UUIDs instead that are 36 bytes.

(fixes #324)