### PR TITLE
docs: use global deployment for sample deployment

### DIFF
--- a/_docs/testnet/testnet-deployment.yml
+++ b/_docs/testnet/testnet-deployment.yml
@@ -17,14 +17,12 @@ profiles:
       memory: "512Mi"
       disk: "512Mi"
   placement:
-    san-jose:
-      attributes:
-        region: sjc
+    global:
       pricing:
         web: 200u
 
 deployment:
   webapp:
-    san-jose:
+    global:
       profile: web
       count: 1


### PR DESCRIPTION
There were too many apps in sjc and global presents a better picture