### PR TITLE
provider/cluster: add support for deployment ingress domains

### DIFF
--- a/_run/multi/Makefile
+++ b/_run/multi/Makefile
@@ -42,12 +42,14 @@ helm-install-provider-%:
 	helm install "$(PROVIDER_CHART)"                     \
 		-n "$(@:helm-install-provider-%=%)"                \
 		--set "ingress.domain=$(shell minikube ip).nip.io" \
+		--set "deployment.ingress.domain=$(shell minikube ip).nip.io" \
 		--set "provider.region=$(shell echo "$@" | sed -e 's/.*-\(.*-.*\)-[0-9][0-9]*/\1/')"
 
 helm-upgrade-provider-%:
 	helm upgrade "$(@:helm-upgrade-provider-%=%)" "$(PROVIDER_CHART)" \
 		--recreate-pods                                                 \
 		--set "ingress.domain=$(shell minikube ip).nip.io"              \
+		--set "deployment.ingress.domain=$(shell minikube ip).nip.io" \
 		--set "provider.region=$(shell echo "$@" | sed -e 's/.*-\(.*-.*\)-[0-9][0-9]*/\1/')"
 
 helm-delete-provider-%:

--- a/_run/multi/akash-provider/run.sh
+++ b/_run/multi/akash-provider/run.sh
@@ -33,7 +33,7 @@ if [ ! -s "$masterKey" ] || [ ! -s "$providerKey" ]; then
 
   echo "adding provider"
   eval $(./akash provider add /config/provider.yml -k master -m shell)
-  echo $akash_add_provider_0_data > "$providerKey"
+  echo $akash_add_provider_0_key > "$providerKey"
   echo "added provider: " $(cat "$providerKey")
 fi
 

--- a/_run/multi/akash-provider/templates/deployment.yaml
+++ b/_run/multi/akash-provider/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
               value: ClusterIP
             - name: AKASH_DEPLOYMENT_INGRESS_STATIC_HOSTS
               value: "false"
+            - name: AKASH_DEPLOYMENT_INGRESS_DOMAIN
+              value: "{{ .Values.deployment.ingress.domain }}"
           ports:
             - containerPort: {{ .Values.provider.port }}
               name: http

--- a/_run/multi/akash-provider/values.yaml
+++ b/_run/multi/akash-provider/values.yaml
@@ -1,11 +1,39 @@
+akash:
+  node: http://api.akashtest.net:80
+
+provider:
+  # Host URI to advertise
+  hostURI: http://example.com
+
+  # Create a key using: `akash key create`
+  privateKeyName: "KEY_NAME"
+
+  # Generate an address by registering the provider
+  # using: `akash provider add -k KEY_NAME`
+  address: "ADDRESS"
+
+  # name of the secret storing private key
+  privateKeySecretName: "PRIVATE_KEY_NAME"
+
+  # port to listen on
+  port: 3001
+
+deployment:
+  # ServiceType of the deployment. Some cloud providers 
+  # (like aws or gcp) require either LoadBalancer / NodeHost
+  serviceType: ClusterIP 
+  ingress:
+    # will generate a unique url for each deployment. 
+    # [uuid].domain
+    staticHosts: true
+    domain: example.com
+
 image:
   repository: ovrclk/akash
   tag: latest
   pullPolicy: Never
 
 ingress:
-  domain: 192.168.99.101.nip.io
-
-provider:
-  port: 3001
-  region: us-west
+  # Pubic routable Hostname of the the provider, 
+  # should match provider.hostURI
+  domain: example.com

--- a/_run/multi/run.sh
+++ b/_run/multi/run.sh
@@ -12,7 +12,7 @@ do_init(){
 	echo $akash_create_key_0_public_key > "$DATA_ROOT/master.key"
 	eval $(akash key create other -m shell)
 	echo $akash_create_key_0_public_key > "$DATA_ROOT/other.key"
-  _akashd init "$(cat "$DATA_ROOT/master.key")" -t helm -c "${HELM_NODE_COUNT:-4}"
+  _akashd init "$(cat "$DATA_ROOT/master.key")" -t helm -n "node-0,node-1,node-2"
 }
 
 case "$1" in

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 961600c01577bd31412d5d385a33442863ec9ceeeb8aab8a60626b67b877ea9e
-updated: 2019-05-15T20:09:33.246655-07:00
+hash: d5ed37e74bc3cbafcd22f4afd0989257ad50be8d2552aad92548b411cbe45d9d
+updated: 2019-10-16T16:48:58.342839-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
@@ -22,7 +22,7 @@ imports:
 - name: github.com/caarlos0/env
   version: 518fcfb943252f77846f92ce5794086d9cb4a1b5
 - name: github.com/cosmos/cosmos-sdk
-  version: dba33693c4b714db7c01eb3926edf780be12a8e5
+  version: 7b4104aced52aa5b59a96c28b5ebeea7877fc4f0
   subpackages:
   - codec
   - crypto
@@ -69,7 +69,7 @@ imports:
 - name: github.com/go-stack/stack
   version: 2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a
 - name: github.com/gogo/protobuf
-  version: ba06b47c162d49f2af050fb4c75bcbc86a159d5c
+  version: 636bf0302bc95575d69441b25a2603156ffdddf1
   subpackages:
   - gogoproto
   - jsonpb
@@ -96,6 +96,8 @@ imports:
   version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/google/uuid
+  version: 0cd6bf5da1e1c83f8b45653022c74f71af0538a4
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -153,12 +155,16 @@ imports:
   version: 22422dad46e14561a0854ad42497a75af9b61909
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
+- name: github.com/lithammer/shortuuid
+  version: 1be5ab5d90f6624ae0484197d1bb079a399712f0
+  subpackages:
+  - '...'
 - name: github.com/magiconair/properties
   version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/mattn/go-colorable
-  version: 3a70a971f94a22f2fa562ffcc7a0eb45f5daf045
+  version: 98ec13f34aabf44cc914c65a1cfb7b9bc815aef1
 - name: github.com/mattn/go-isatty
-  version: c2a7a6ca930a4cd0bc33a3f298eb71960732a3a7
+  version: 88ba11cfdc67c7588b30042edf244b2875f892b6
 - name: github.com/mattn/go-runewidth
   version: 703b5e6b11ae25aeb2af9ebb5d5fdf8fa2575211
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -223,15 +229,17 @@ imports:
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
-  version: 7a605a50e69cd1ea431c4a1e6eebe9b287ef6de4
+  version: 40e41dd2240a2ae3f6b0a908ad9ddc6cefd5e456
 - name: github.com/stretchr/objx
   version: ef50b0de28773081167c97fc27cf29a0bf8b8c71
 - name: github.com/stretchr/testify
-  version: ffdc059bfe9ce6a4e144ba849dbedead332c6053
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - mock
   - require
+- name: github.com/subosito/gotenv
+  version: de67a6614a4de71ad5e380b6946e56ab957d58c5
 - name: github.com/syndtr/goleveldb
   version: ae2bd5eed72d46b28834ec3f60db3a3ebedd8dbd
   subpackages:
@@ -393,29 +401,21 @@ imports:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 25c4f928eaa6d96443009bd842389fb4fa48664e
+  version: 168a6198bcb0ef175f7dacec0b8691fc141dc9b8
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
-  - binarylog/grpc_binarylog_v1
   - codes
   - connectivity
   - credentials
-  - credentials/internal
   - encoding
   - encoding/proto
   - grpclog
   - internal
   - internal/backoff
-  - internal/balancerload
-  - internal/binarylog
   - internal/channelz
-  - internal/envconfig
   - internal/grpcrand
-  - internal/grpcsync
-  - internal/syscall
-  - internal/transport
   - keepalive
   - metadata
   - naming
@@ -426,6 +426,7 @@ imports:
   - stats
   - status
   - tap
+  - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/ovrclk/akash
 import:
 - package: github.com/gogo/protobuf
-  version: ^1.1.1
+  version: 1.1.1
   subpackages:
   - gogoproto
   - proto
@@ -12,17 +12,17 @@ import:
 - package: github.com/prometheus/client_golang
   version: ae27198cdd90bf12cd134ad79d1366a6cf49f632
 - package: github.com/cosmos/cosmos-sdk
-  version: ~0.33.0
+  version: 0.33.0
   subpackages:
   - crypto
 - package: github.com/tendermint/go-amino
-  version: ~0.14.1
+  version: 0.14.1
 - package: github.com/tendermint/iavl
-  version: ~0.12.2
+  version: 0.12.2
 - package: github.com/tendermint/tendermint
-  version: ~0.31.5
+  version: 0.31.5
 - package: github.com/stretchr/testify
-  version: ^1.2.1
+  version: 1.2.1
   subpackages:
   - require
   - assert
@@ -42,10 +42,10 @@ import:
   subpackages:
   - OpenAPIv2
 - package: github.com/golang/protobuf
-  version: ~1.1.0
+  version: 1.1.0
 - package: github.com/grpc-ecosystem/grpc-gateway
 - package: google.golang.org/grpc
-  version: ^1.13.0
+  version: 1.13.0
 - package: github.com/juju/errors
 - package: k8s.io/client-go
   version: kubernetes-1.12.2
@@ -64,11 +64,11 @@ import:
 - package: k8s.io/gengo
 - package: github.com/hashicorp/golang-lru
 - package: github.com/caarlos0/env
-  version: ^3.3.0
+  version: 3.3.0
 - package: github.com/blang/semver
-  version: ^3.5.1
+  version: 3.5.1
 - package: github.com/satori/go.uuid
-  version: ~1.2.0
+  version: 1.2.0
 - package: golang.org/x/sys
   version: 1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded
   subpackages:
@@ -77,7 +77,7 @@ import:
   version: 3764759f34a542a3aef74d6b02e35be7ab893bba
   repo: https://github.com/tendermint/crypto
 - package: github.com/gosuri/uitable
-  version: ~0.0.2
+  version: 0.0.2
 - package: github.com/gosuri/uilive
   version: 0.0.2
 - package: github.com/fatih/color
@@ -90,3 +90,7 @@ import:
   version: ^0.0.7
 - package: github.com/ovrclk/dsky
   version: ~0.0.1
+- package: github.com/lithammer/shortuuid
+  version: 3.0.3
+  subpackages:
+  - '...'

--- a/provider/cluster/kube/config.go
+++ b/provider/cluster/kube/config.go
@@ -6,14 +6,15 @@ import (
 )
 
 type config_ struct {
-
 	// gcp:    NodePort
 	// others: ClusterIP
 	DeploymentServiceType corev1.ServiceType `env:"AKASH_DEPLOYMENT_SERVICE_TYPE" envDefault:"NodePort"`
 
 	// gcp:    False
 	// others: true
-	DeploymentIngressStaticHosts bool `env:"AKASH_DEPLOYMENT_INGRESS_STATIC_HOSTS" envDefault:"false"`
+	DeploymentIngressStaticHosts bool `env:"AKASH_DEPLOYMENT_INGRESS_STATIC_HOSTS" envDefault:"true"`
+	// Ingress domain to map deployments to
+	DeploymentIngressDomain string `env:"AKASH_DEPLOYMENT_INGRESS_DOMAIN"`
 
 	DeploymentIngressExposeLBHosts bool `env:"AKASH_DEPLOYMENT_INGRESS_EXPOSE_LB_HOSTS" envDefault:"true"`
 }


### PR DESCRIPTION
Every service in the lease will be mapped to short uuid for example `yb4exzwaxnbvvr4cmavewa.kant.akashtest.net` when `AKASH_DEPLOYMENT_INGRESS_STATIC_HOST=true` and `AKASH_DEPLOYMENT_INGRESS_DOMAIN=kant.akashtest.net`

**Example Output:**
```
Deployment
==========

Deployment ID:        	9cc85023234af786a227f1a365f7b1d56a161d5614c971fd24abf6c740f2b56d
Deployment Groups(s): 	Group:        	global
                      	Requirements:
                      	Resources:    	Count:  	2
                      	              	Price:  	100
                      	              	CPU:    	250
                      	              	Memory: 	134217728
                      	              	Disk:   	1073741824
Fulfillment(s):       	Group:    	1
                      	Price:    	15
                      	Provider: 	90efa2ec8cb6aba9db9ee9bb9b119e41670f42903b9d5be61461509431a2aa45

Lease(s)
========

Lease ID:    	9cc85023234af786a227f1a365f7b1d56a161d5614c971fd24abf6c740f2b56d/1/2/90efa2ec8cb6aba9db9ee9bb9b119e41670f42903b9d5be61461509431a2aa45
Services(s): 	NAME 	HOST(S) / IP(S)                          	AVAILABLE	TOTAL
             	web  	hello.147.75.91.165.nip.io               	2        	2
             	<nil>	yb4exzwaxnbvvr4cmavewa.kant.akashtest.net	<nil>    	<nil>
             	<nil>	147.75.91.165                            	<nil>    	<nil>


```
Signed-off-by: Greg Osuri <me@gregosuri.com>