### PR TITLE
release: remove windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,12 +4,10 @@ builds:
     binary: akash
     main: ./cmd/akash
     goarch: [amd64, arm64]
-    goos: [linux,darwin,windows]
+    goos: [linux, darwin]
     ignore:
       - goos: darwin
         goarch: 386
-      - goos: windows
-        goarch: arm
     ldflags: -s -w -X github.com/ovrclk/akash/version.version={{.Version}} -X github.com/ovrclk/akash/version.commit={{.Commit}} -X github.com/ovrclk/akash/version.date={{.Date}}
 
   - id: akashd


### PR DESCRIPTION
windows builds fails due to:

multiple-value "golang.org/x/sys/windows".GetCurrentProcess() in single-value context

Signed-off-by: Greg Osuri <me@gregosuri.com>