### PR TITLE
fix: panic: error with code 2 is already registered: "invalid provider: not absoulte host uri"

### DIFF
--- a/x/provider/types/errors.go
+++ b/x/provider/types/errors.go
@@ -7,12 +7,13 @@ import (
 var (
 	// ErrInvalidProviderURI register error code for invalid provider uri
 	ErrInvalidProviderURI = sdkerrors.Register(ModuleName, 1, "invalid provider: invalid host uri")
+
 	// ErrNotAbsProviderURI register error code for not absolute provider uri
 	ErrNotAbsProviderURI = sdkerrors.Register(ModuleName, 2, "invalid provider: not absoulte host uri")
 
 	// ErrProviderNotFound provider not found
-	ErrProviderNotFound = sdkerrors.Register(ModuleName, 2, "invalid provider: address not found")
+	ErrProviderNotFound = sdkerrors.Register(ModuleName, 3, "invalid provider: address not found")
 
 	// ErrInvalidAddress invalid provider address
-	ErrInvalidAddress = sdkerrors.Register(ModuleName, 2, "invalid address")
+	ErrInvalidAddress = sdkerrors.Register(ModuleName, 4, "invalid address")
 )


### PR DESCRIPTION
Fix for:

```
panic: error with code 2 is already registered: "invalid provider: not absoulte host uri"

goroutine 1 [running]:
github.com/cosmos/cosmos-sdk/types/errors.Register(0x4c4db8d, 0x8, 0x2, 0x4c6d951, 0x23, 0xc000f7d710)
	/Users/gosuri/code/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.38.0/types/errors/errors.go:101 +0x389
github.com/ovrclk/akash/x/provider/types.init()
	/Users/gosuri/code/go/src/github.com/ovrclk/akash/x/provider/types/errors.go:14 +0x112
```