### PR TITLE
Update Makefile dependencies

### DIFF
--- a/.buildkite/script/test.sh
+++ b/.buildkite/script/test.sh
@@ -41,6 +41,7 @@ do_tests_lite(){
 
 do_coverage(){
   echo "--- :female-scientist: capturing test coverage"
+  make image-bins
   go test -coverprofile=coverage.txt -covermode=count -coverpkg="./..." ./...
 
   echo "--- :satellite_antenna: uploading test coverage"

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,13 @@ release:
 image-minikube:
 	eval $$(minikube docker-env) && make image
 
-test:
+test: image-bins
 	$(GO) test ./...
 
-test-nocache:
+test-nocache: image-bins
 	$(GO) test -count=1 ./...
 
-test-full:
+test-full: image-bins
 	$(GO) test -race ./...
 
 test-lint:


### PR DESCRIPTION
Unknown history of these test requirements, however currently tests are
failing due to missing the _build/akash[d] binaries.

This change adds the Make `image-bins` step to all of the targets which
run tests. Locally this has corrected the reproduced test failures we're
seeing on BuildKite.

