### PR TITLE
ci: fix golangci-lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,50 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+      - run: make build
       - run: make test-vet
-      - uses: actions-contrib/golangci-lint@v1
-        with:
-          golangci_lint_version: "v1.26.0"
-          args: run ./...
+      - run: make lintdeps-install
+      - name: lint all
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --issues-exit-code=0
+      - name: lint deadcode
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable deadcode
+        continue-on-error: true
+      - name: lint misspell
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable misspell
+        continue-on-error: true
+      - name: lint goerr113
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable goerr113
+        continue-on-error: true
+      - name: lint gofmt
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable gofmt
+        continue-on-error: true
+      - name: lint gocritic
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable gocritic
+        continue-on-error: true
+      - name: lint goconst
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable goconst
+        continue-on-error: true
+      - name: lint gochecknoglobals
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable gochecknoglobals
+        continue-on-error: true
+      - name: lint ineffassign
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable ineffassign
+        continue-on-error: true
+      - name: lint unparam
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable unparam
+        continue-on-error: true
+      - name: lint staticcheck
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable staticcheck
+        continue-on-error: true
+      - name: lint golint
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable golint
+        continue-on-error: true
+      - name: lint gosec
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable gosec
+        continue-on-error: true
+      - name: lint scopelint
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable scopelint
+        continue-on-error: true
+      - name: lint prealloc
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --no-config --disable-all --enable prealloc
         continue-on-error: true


### PR DESCRIPTION
* `lint all` step that runs everything and always exits cleanly.
* individual steps for linters that need to be addressed.

fixes #537
