### PR TITLE
fix: Goreleaser referenced old Dockerfile.akash

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
 dockers:
   - binaries: 
     - akashctl
-    dockerfile: _build/Dockerfile.akash
+    dockerfile: _build/Dockerfile.akashctl
     goos: linux
     goarch: amd64
     image_templates:  


### PR DESCRIPTION
This change updates to filename to `Dockerfile.akashctl`
declaration which matches our new naming convention. Hopefully fixing
the broken Goreleaser pipeline step.