### PR TITLE
refactor: Client interface accepts Context params

### DIFF
--- a/provider/cluster/kube/deployment_test.go
+++ b/provider/cluster/kube/deployment_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -21,6 +22,7 @@ const (
 
 func TestDeploy(t *testing.T) {
 	t.Skip()
+	ctx := context.Background()
 
 	owner := ed25519.GenPrivKey().PubKey().Address()
 	provider := ed25519.GenPrivKey().PubKey().Address()
@@ -43,6 +45,6 @@ func TestDeploy(t *testing.T) {
 	client, err := NewClient(log, "host", "lease")
 	assert.NoError(t, err)
 
-	err = client.Deploy(leaseID, &mani.GetGroups()[0])
+	err = client.Deploy(ctx, leaseID, &mani.GetGroups()[0])
 	assert.NoError(t, err)
 }

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -194,11 +195,13 @@ func (dm *deploymentManager) startTeardown() <-chan error {
 }
 
 func (dm *deploymentManager) doDeploy() error {
-	return dm.client.Deploy(dm.lease, dm.mgroup)
+	ctx := context.Background() // TODO: refactor management
+	return dm.client.Deploy(ctx, dm.lease, dm.mgroup)
 }
 
 func (dm *deploymentManager) doTeardown() error {
-	return dm.client.TeardownLease(dm.lease)
+	ctx := context.Background() // TODO: refactor management
+	return dm.client.TeardownLease(ctx, dm.lease)
 }
 
 func (dm *deploymentManager) do(fn func() error) <-chan error {

--- a/provider/cluster/monitor.go
+++ b/provider/cluster/monitor.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -136,7 +137,8 @@ func (m *deploymentMonitor) runCheck() <-chan runner.Result {
 }
 
 func (m *deploymentMonitor) doCheck() (bool, error) {
-	status, err := m.client.LeaseStatus(m.lease)
+	ctx := context.Background() // TODO: manage context within the deploymentMonitor{}
+	status, err := m.client.LeaseStatus(ctx, m.lease)
 
 	if err != nil {
 		m.log.Error("lease status", "err", err)

--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -251,7 +251,7 @@ func (s *service) teardownLease(lid mtypes.LeaseID) {
 }
 
 func findDeployments(ctx context.Context, log log.Logger, client Client, session session.Session) ([]Deployment, error) {
-	deployments, err := client.Deployments()
+	deployments, err := client.Deployments(ctx)
 	if err != nil {
 		log.Error("fetching deployments", "err", err)
 		return nil, err


### PR DESCRIPTION
Kube provider client now accepts contexts

Removed struct-stored context.Context from k8s client{}. Now all functions
accept the caller's Context to manage shutdown behavior.

fixes #555

Signed-off-by: Joshua Roppo <joshroppo@gmail.com>
