### PR TITLE
fix: updated code using unsafe package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
         continue-on-error: true
       - name: lint gosec
         run: $(go env GOPATH)/bin/golangci-lint run ./... --disable-all --enable gosec
-        continue-on-error: true
+        continue-on-error: false 
       - name: lint scopelint
         run: $(go env GOPATH)/bin/golangci-lint run ./... --disable-all --enable scopelint
         continue-on-error: false

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -1,7 +1,7 @@
 package kube
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -288,18 +288,18 @@ func exposeExternalPort(expose *manifest.ServiceExpose) int32 {
 	return int32(expose.ExternalPort)
 }
 
+// lidNS generates a unique sha256 sum for identifying a provider's object name.
 func lidNS(lid mtypes.LeaseID) string {
-	// TODO
-	var path string
-	// path := lid.String()
-	sha := sha1.Sum([]byte(path))
+	path := mtypes.BidIDString(lid.BidID())
+	sha := sha256.Sum256([]byte(path))
 	return hex.EncodeToString(sha[:])
 }
 
-// manifest
+// manifestBuilder composes the k8s akashv1.Manifest type from LeaseID and
+// manifest.Group data.
 type manifestBuilder struct {
 	builder
-	mns string
+	mns string // Q: is this supposed to be the k8s Namespace? It's the Object name now.
 }
 
 func newManifestBuilder(log log.Logger, ns string, lid mtypes.LeaseID, group *manifest.Group) *manifestBuilder {

--- a/provider/cluster/kube/builder_test.go
+++ b/provider/cluster/kube/builder_test.go
@@ -1,0 +1,93 @@
+package kube
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ovrclk/akash/manifest"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+/* Source: https://git.sr.ht/~samwhited/testlog/tree/b1b3e8e82fd6990e91ce9d0fbcbe69ac2d9b1f98/testlog.go
+// New returns a new logger that logs to the provided testing.T.
+func New(t testing.TB) *log.Logger {
+	t.Helper()
+	return log.New(testWriter{TB: t}, t.Name()+" ", log.LstdFlags|log.Lshortfile|log.LUTC)
+}
+*/
+
+type testWriter struct {
+	testing.TB
+}
+
+func (tw testWriter) Write(p []byte) (int, error) {
+	tw.Helper()
+	tw.Logf("%s", p)
+	return len(p), nil
+}
+
+func testLeaseID() mtypes.LeaseID {
+	owner := ed25519.GenPrivKey().PubKey().Address()
+	provider := ed25519.GenPrivKey().PubKey().Address()
+
+	leaseID := mtypes.LeaseID{
+		Owner:    sdk.AccAddress(owner),
+		DSeq:     randDSeq,
+		GSeq:     randGSeq,
+		OSeq:     randOSeq,
+		Provider: sdk.AccAddress(provider),
+	}
+	return leaseID
+}
+
+func TestLidNsSanity(t *testing.T) {
+	owner := ed25519.GenPrivKey().PubKey().Address()
+	provider := ed25519.GenPrivKey().PubKey().Address()
+	tw := testWriter{TB: t}
+	log := log.NewTMLogger(tw)
+
+	leaseID := mtypes.LeaseID{
+		Owner:    sdk.AccAddress(owner),
+		DSeq:     randDSeq,
+		GSeq:     randGSeq,
+		OSeq:     randOSeq,
+		Provider: sdk.AccAddress(provider),
+	}
+	g := &manifest.Group{}
+
+	shaNS := lidNS(leaseID)
+	t.Logf("sha256: %q", shaNS)
+	if shaNS == "" {
+		t.Errorf("sha* should not be empty")
+	}
+
+	mb := newManifestBuilder(log, shaNS, leaseID, g)
+
+	m, err := mb.create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Name != shaNS {
+		t.Errorf("k8s namespace: %q does not match %q", m.Namespace, shaNS)
+	}
+}
+
+func TestShaLengths(t *testing.T) {
+	lid := testLeaseID()
+	path := mtypes.BidIDString(lid.BidID())
+
+	sha256s := sha256.Sum256([]byte(path))
+	hex256 := hex.EncodeToString(sha256s[:])
+	t.Logf("sha256 sum: %d hex: %d", len(sha256s), len(hex256))
+
+	/* Disabled to escape `gosec` lint error on usage of sha1
+	sha1s := sha1.Sum([]byte(path))
+	hex1 := hex.EncodeToString(sha1s[:])
+	t.Logf("sha1 sum: %d hex: %d", len(sha1s), len(hex1))
+	*/
+}

--- a/x/market/types/id.go
+++ b/x/market/types/id.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
@@ -49,7 +51,8 @@ func (id OrderID) Validate() error {
 	return nil
 }
 
-// BidID stores owner, provider and all other seq numbers
+// BidID stores owner, provider and all other seq numbers.
+// A successful bid becomes a Lease(ID).
 type BidID struct {
 	Owner    sdk.AccAddress `json:"owner"`
 	DSeq     uint64         `json:"dseq"`
@@ -111,6 +114,11 @@ func (id BidID) Validate() error {
 	return nil
 }
 
+// BidIDString provides consistent conversion to string values for BidID/LeaseIDs.
+func BidIDString(id BidID) string {
+	return fmt.Sprintf("%s-%d-%d-%d-%s", id.Owner.String(), id.DSeq, id.GSeq, id.OSeq, id.Provider.String())
+}
+
 // LeaseID stores bid details of lease
 type LeaseID BidID
 
@@ -130,6 +138,7 @@ func (id LeaseID) Equals(other LeaseID) bool {
 	return id.BidID().Equals(other.BidID())
 }
 
+// Validate calls the BidID's validator and returns any error.
 func (id LeaseID) Validate() error {
 	if err := id.BidID().Validate(); err != nil {
 		return sdkerrors.Wrap(err, "LeaseID: Invalid BidID")


### PR DESCRIPTION
The usage of sha1 was removed and updated to sha256. The use of `sha*`
is minor compared to the changes which fix the functionality of creating
unique k8s object names based on the LeaseID.

Added test to assert that the name is properly passed into the k8s
type.

fixes #550
