### PR TITLE
lint: unparam cleanup of unused varaibles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
       - name: lint unparam
         run: $(go env GOPATH)/bin/golangci-lint run ./... --disable-all --enable unparam
-        continue-on-error: true
+        continue-on-error: false
       - name: lint staticcheck
         run: $(go env GOPATH)/bin/golangci-lint run ./... --disable-all --enable staticcheck
         continue-on-error: true

--- a/provider/bidengine/service.go
+++ b/provider/bidengine/service.go
@@ -176,7 +176,7 @@ type existingOrder struct {
 	bid   *mquery.Bid
 }
 
-func queryExistingOrders(ctx context.Context, session session.Session) ([]existingOrder, error) {
+func queryExistingOrders(_ context.Context, session session.Session) ([]existingOrder, error) {
 	orders, err := session.Client().Query().Orders(mtypes.OrderFilters{})
 	if err != nil {
 		session.Log().Error("error querying open orders:", "err", err)

--- a/provider/cluster/inventory.go
+++ b/provider/cluster/inventory.go
@@ -118,7 +118,7 @@ func (is *inventoryService) reserve(order mtypes.OrderID, resources atypes.Resou
 	}
 }
 
-func (is *inventoryService) unreserve(order mtypes.OrderID, resources atypes.ResourceGroup) (Reservation, error) {
+func (is *inventoryService) unreserve(order mtypes.OrderID, resources atypes.ResourceGroup) (Reservation, error) { // nolint:golint,unparam
 	ch := make(chan inventoryResponse, 1)
 	req := inventoryRequest{
 		order:     order,

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -53,7 +53,7 @@ func (b *nsBuilder) name() string {
 	return b.ns()
 }
 
-func (b *nsBuilder) create() (*corev1.Namespace, error) {
+func (b *nsBuilder) create() (*corev1.Namespace, error) { // nolint:golint,unparam
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   b.ns(),
@@ -62,7 +62,7 @@ func (b *nsBuilder) create() (*corev1.Namespace, error) {
 	}, nil
 }
 
-func (b *nsBuilder) update(obj *corev1.Namespace) (*corev1.Namespace, error) {
+func (b *nsBuilder) update(obj *corev1.Namespace) (*corev1.Namespace, error) { // nolint:golint,unparam
 	obj.Name = b.ns()
 	obj.Labels = b.labels()
 	return obj, nil
@@ -91,7 +91,7 @@ func (b *deploymentBuilder) labels() map[string]string {
 	return obj
 }
 
-func (b *deploymentBuilder) create() (*appsv1.Deployment, error) {
+func (b *deploymentBuilder) create() (*appsv1.Deployment, error) { // nolint:golint,unparam
 	replicas := int32(b.service.Count)
 	kdeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -117,7 +117,7 @@ func (b *deploymentBuilder) create() (*appsv1.Deployment, error) {
 	return kdeployment, nil
 }
 
-func (b *deploymentBuilder) update(obj *appsv1.Deployment) (*appsv1.Deployment, error) {
+func (b *deploymentBuilder) update(obj *appsv1.Deployment) (*appsv1.Deployment, error) { // nolint:golint,unparam
 	replicas := int32(b.service.Count)
 	obj.Labels = b.labels()
 	obj.Spec.Selector.MatchLabels = b.labels()
@@ -181,7 +181,7 @@ func newServiceBuilder(log log.Logger, lid mtypes.LeaseID, group *manifest.Group
 	}
 }
 
-func (b *serviceBuilder) create() (*corev1.Service, error) {
+func (b *serviceBuilder) create() (*corev1.Service, error) { // nolint:golint,unparam
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   b.name(),
@@ -197,7 +197,7 @@ func (b *serviceBuilder) create() (*corev1.Service, error) {
 	}, nil
 }
 
-func (b *serviceBuilder) update(obj *corev1.Service) (*corev1.Service, error) {
+func (b *serviceBuilder) update(obj *corev1.Service) (*corev1.Service, error) { // nolint:golint,unparam
 	obj.Labels = b.labels()
 	obj.Spec.Selector = b.labels()
 	obj.Spec.Ports = b.ports()
@@ -226,7 +226,7 @@ func newIngressBuilder(log log.Logger, host string, lid mtypes.LeaseID, group *m
 	if config.DeploymentIngressStaticHosts {
 		uid := strings.ToLower(shortuuid.New())
 		h := fmt.Sprintf("%s.%s", uid, config.DeploymentIngressDomain)
-		log.Debug("IngressBuilder: map", "host", h)
+		log.Debug("IngressBuilder: map ", h, " host ", host)
 		expose.Hosts = append(expose.Hosts, h)
 	}
 	return &ingressBuilder{
@@ -242,7 +242,7 @@ func newIngressBuilder(log log.Logger, host string, lid mtypes.LeaseID, group *m
 	}
 }
 
-func (b *ingressBuilder) create() (*extv1.Ingress, error) {
+func (b *ingressBuilder) create() (*extv1.Ingress, error) { // nolint:golint,unparam
 	return &extv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   b.name(),
@@ -254,7 +254,7 @@ func (b *ingressBuilder) create() (*extv1.Ingress, error) {
 	}, nil
 }
 
-func (b *ingressBuilder) update(obj *extv1.Ingress) (*extv1.Ingress, error) {
+func (b *ingressBuilder) update(obj *extv1.Ingress) (*extv1.Ingress, error) { // nolint:golint,unparam
 	obj.Labels = b.labels()
 	obj.Spec.Rules = b.rules()
 	return obj, nil

--- a/provider/manifest/handler.go
+++ b/provider/manifest/handler.go
@@ -264,7 +264,7 @@ func (h *handler) ensureManger(did dtypes.DeploymentID) (manager *manager, err e
 	return manager, nil
 }
 
-func fetchExistingLeases(ctx context.Context, session session.Session) ([]event.LeaseWon, error) {
+func fetchExistingLeases(_ context.Context, session session.Session) ([]event.LeaseWon, error) {
 	leases, err := session.Client().Query().ActiveLeasesForProvider(session.Provider().Address())
 	if err != nil {
 		return nil, err

--- a/provider/manifest/manager.go
+++ b/provider/manifest/manager.go
@@ -224,7 +224,7 @@ func (m *manager) fetchData(ctx context.Context) <-chan runner.Result {
 	})
 }
 
-func (m *manager) doFetchData(ctx context.Context) (*dquery.Deployment, error) {
+func (m *manager) doFetchData(_ context.Context) (*dquery.Deployment, error) {
 	deployment, err := m.session.Client().Query().Deployment(m.daddr)
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func (m *manager) doFetchData(ctx context.Context) (*dquery.Deployment, error) {
 	return &deployment, nil
 }
 
-func (m *manager) maybeScheduleStop() bool {
+func (m *manager) maybeScheduleStop() bool { // nolint:golint,unparam
 	if len(m.leases) > 0 || len(m.manifests) > 0 {
 		if m.stoptimer != nil {
 			m.log.Info("stopping stop timer")

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -37,7 +38,7 @@ func GetTxCmd(key string, cdc *codec.Codec) *cobra.Command {
 func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [sdl-file]",
-		Short: "Create deployment",
+		Short: fmt.Sprintf("Create %s", key),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)
@@ -77,7 +78,7 @@ func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 func cmdClose(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "close",
-		Short: "Close deployment",
+		Short: fmt.Sprintf("Close %s", key),
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)
@@ -102,7 +103,7 @@ func cmdClose(key string, cdc *codec.Codec) *cobra.Command {
 func cmdUpdate(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [sdl-file]",
-		Short: "update deployment",
+		Short: fmt.Sprintf("update %s", key),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)

--- a/x/deployment/handler/handler.go
+++ b/x/deployment/handler/handler.go
@@ -24,7 +24,7 @@ func NewHandler(keeper keeper.Keeper, mkeeper MarketKeeper) sdk.Handler {
 	}
 }
 
-func handleMsgCreate(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper, msg types.MsgCreateDeployment) (*sdk.Result, error) {
+func handleMsgCreate(ctx sdk.Context, keeper keeper.Keeper, _ MarketKeeper, msg types.MsgCreateDeployment) (*sdk.Result, error) {
 
 	deployment := types.Deployment{
 		DeploymentID: types.DeploymentID{
@@ -61,7 +61,7 @@ func handleMsgCreate(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper
 	}, nil
 }
 
-func handleMsgUpdate(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper, msg types.MsgUpdateDeployment) (*sdk.Result, error) {
+func handleMsgUpdate(ctx sdk.Context, keeper keeper.Keeper, _ MarketKeeper, msg types.MsgUpdateDeployment) (*sdk.Result, error) {
 	deployment, found := keeper.GetDeployment(ctx, msg.ID)
 	if !found {
 		return nil, types.ErrDeploymentNotFound

--- a/x/deployment/query/querier.go
+++ b/x/deployment/query/querier.go
@@ -24,7 +24,7 @@ func NewQuerier(keeper keeper.Keeper) sdk.Querier {
 	}
 }
 
-func queryDeployments(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryDeployments(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 	// isValidState denotes whether given state flag is valid or not
 	filters, isValidState, err := parseDepFiltersPath(path)
 	if err != nil {
@@ -72,7 +72,7 @@ func queryDeployments(ctx sdk.Context, path []string, req abci.RequestQuery, kee
 	return sdkutil.RenderQueryResponse(keeper.Codec(), values)
 }
 
-func queryDeployment(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryDeployment(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	id, err := parseDeploymentPath(path)
 	if err != nil {
@@ -92,7 +92,7 @@ func queryDeployment(ctx sdk.Context, path []string, req abci.RequestQuery, keep
 	return sdkutil.RenderQueryResponse(keeper.Codec(), value)
 }
 
-func queryGroup(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryGroup(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	id, err := ParseGroupPath(path)
 	if err != nil {

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -34,7 +35,7 @@ func GetTxCmd(key string, cdc *codec.Codec) *cobra.Command {
 func cmdCreateBid(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bid-create",
-		Short: "Create a bid",
+		Short: fmt.Sprintf("Create a %s bid", key),
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)
@@ -75,7 +76,7 @@ func cmdCreateBid(key string, cdc *codec.Codec) *cobra.Command {
 func cmdCloseBid(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bid-close",
-		Short: "Close a bid",
+		Short: fmt.Sprintf("Close a %s bid", key),
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)
@@ -101,7 +102,7 @@ func cmdCloseBid(key string, cdc *codec.Codec) *cobra.Command {
 func cmdCloseOrder(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "order-close",
-		Short: "Close an order",
+		Short: fmt.Sprintf("Close a %s order", key),
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)

--- a/x/market/query/querier.go
+++ b/x/market/query/querier.go
@@ -30,7 +30,7 @@ func NewQuerier(keeper keeper.Keeper) sdk.Querier {
 	}
 }
 
-func queryOrders(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryOrders(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 	// isValidState denotes whether given state flag is valid or not
 	filters, isValidState, err := parseOrderFiltersPath(path)
 	if err != nil {
@@ -62,7 +62,7 @@ func queryOrders(ctx sdk.Context, path []string, req abci.RequestQuery, keeper k
 	return sdkutil.RenderQueryResponse(keeper.Codec(), values)
 }
 
-func queryOrder(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryOrder(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	id, err := parseOrderPath(path)
 	if err != nil {
@@ -79,7 +79,7 @@ func queryOrder(ctx sdk.Context, path []string, req abci.RequestQuery, keeper ke
 	return sdkutil.RenderQueryResponse(keeper.Codec(), value)
 }
 
-func queryBids(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryBids(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 	// isValidState denotes whether given state flag is valid or not
 	filters, isValidState, err := parseBidFiltersPath(path)
 	if err != nil {
@@ -110,7 +110,7 @@ func queryBids(ctx sdk.Context, path []string, req abci.RequestQuery, keeper kee
 	return sdkutil.RenderQueryResponse(keeper.Codec(), values)
 }
 
-func queryBid(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryBid(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	id, err := parseBidPath(path)
 	if err != nil {
@@ -127,7 +127,7 @@ func queryBid(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keep
 	return sdkutil.RenderQueryResponse(keeper.Codec(), value)
 }
 
-func queryLeases(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryLeases(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 	// isValidState denotes whether given state flag is valid or not
 	filters, isValidState, err := parseLeaseFiltersPath(path)
 	if err != nil {
@@ -158,7 +158,7 @@ func queryLeases(ctx sdk.Context, path []string, req abci.RequestQuery, keeper k
 	return sdkutil.RenderQueryResponse(keeper.Codec(), values)
 }
 
-func queryLease(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryLease(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	id, err := parseLeasePath(path)
 	if err != nil {

--- a/x/provider/client/cli/tx.go
+++ b/x/provider/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -34,7 +35,7 @@ func GetTxCmd(key string, cdc *codec.Codec) *cobra.Command {
 func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [config-file]",
-		Short: "Create provider",
+		Short: fmt.Sprintf("Create %s", key),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)
@@ -65,7 +66,7 @@ func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 func cmdUpdate(key string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [config-file]",
-		Short: "Update provider",
+		Short: fmt.Sprintf("Update %s", key),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.NewCLIContext().WithCodec(cdc)

--- a/x/provider/query/querier.go
+++ b/x/provider/query/querier.go
@@ -22,7 +22,7 @@ func NewQuerier(keeper keeper.Keeper) sdk.Querier {
 	}
 }
 
-func queryProviders(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryProviders(ctx sdk.Context, _ []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 	var values Providers
 	keeper.WithProviders(ctx, func(obj types.Provider) bool {
 		values = append(values, Provider(obj))
@@ -31,7 +31,7 @@ func queryProviders(ctx sdk.Context, path []string, req abci.RequestQuery, keepe
 	return sdkutil.RenderQueryResponse(keeper.Codec(), values)
 }
 
-func queryProvider(ctx sdk.Context, path []string, req abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
+func queryProvider(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper keeper.Keeper) ([]byte, error) {
 
 	if len(path) != 1 {
 		return nil, sdkerrors.ErrInvalidRequest


### PR DESCRIPTION
'_'ing function parameters which are not used, updating some CLI
commands to use their 'key' parameters to enhance Cobra descriptions, no
changes to interfaces or function calls.

Used `// nolint` to silence all lint violations which were caused by
functions returning values which were zero-value or errors that were
always nil. Fixing would require chaning methods which might need to be
changed back later.

fixes #547
