### PR TITLE
refactor: DeploymentManager state machine

### DIFF
--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -66,7 +66,7 @@ func newDeploymentManager(s *service, lease mtypes.LeaseID, mgroup *manifest.Gro
 
 	go func() {
 		<-dm.lc.Done()
-		s.managerch <- dm
+		s.managerch <- dm // inform `service{}` that the deployment released and no longer served
 	}()
 
 	return dm
@@ -91,7 +91,7 @@ func (dm *deploymentManager) teardown() error {
 }
 
 func (dm *deploymentManager) run() {
-	defer dm.lc.ShutdownCompleted()
+	defer dm.lc.ShutdownCompleted() // triggers lc.Done()
 	runch := dm.startDeploy()
 
 loop:
@@ -169,7 +169,7 @@ loop:
 
 func (dm *deploymentManager) startMonitor() {
 	dm.wg.Add(1)
-	dm.monitor = newDeploymentMonitor(dm)
+	//dm.monitor = newDeploymentMonitor(dm)
 	go func(m *deploymentMonitor) {
 		defer dm.wg.Done()
 		<-m.done()

--- a/provider/cluster/monitor.go
+++ b/provider/cluster/monitor.go
@@ -24,6 +24,7 @@ const (
 	monitorHealthcheckPeriodJitter = time.Second * 5
 )
 
+// wtf does this do....
 type deploymentMonitor struct {
 	bus     pubsub.Bus
 	session session.Session
@@ -37,18 +38,21 @@ type deploymentMonitor struct {
 	lc       lifecycle.Lifecycle
 }
 
-func newDeploymentMonitor(dm *deploymentManager) *deploymentMonitor {
+func newDeploymentMonitor(ctx context.Context, bus pubsub.Bus,
+	session session.Session, client Client,
+	lease mtypes.LeaseID, mgroup *manifest.Group,
+	log log.Logger) *deploymentMonitor {
 	m := &deploymentMonitor{
-		bus:     dm.bus,
-		session: dm.session,
-		client:  dm.client,
-		lease:   dm.lease,
-		mgroup:  dm.mgroup,
-		log:     dm.log.With("cmp", "deployment-monitor"),
+		bus:     bus,
+		session: session,
+		client:  client,
+		lease:   lease,
+		mgroup:  mgroup,
+		log:     log.With("cmp", "deployment-monitor"),
 		lc:      lifecycle.New(),
 	}
 
-	go m.lc.WatchChannel(dm.lc.ShuttingDown())
+	go m.lc.WatchChannel(ctx.Done())
 	go m.run()
 
 	return m

--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -87,6 +87,8 @@ func NewService(ctx context.Context, session session.Session, bus pubsub.Bus, cl
 	return s, nil
 }
 
+var _ Service = (*service)(nil)
+
 type service struct {
 	session session.Session
 	client  Client
@@ -220,7 +222,7 @@ loop:
 					"lease", dm.lease, "group-name", dm.mgroup.Name)
 			}
 
-			// todo: unreserve resources
+			// TODO: unreserve resources
 
 			delete(s.managers, mquery.LeasePath(dm.lease))
 		}
@@ -232,6 +234,7 @@ loop:
 		if manager != nil {
 			manager := <-s.managerch
 			s.log.Debug("manager done", "lease", manager.lease)
+			// TODO: ??? shutdown each manager?
 		}
 	}
 

--- a/provider/cluster/state.go
+++ b/provider/cluster/state.go
@@ -1,0 +1,188 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ovrclk/akash/manifest"
+	"github.com/ovrclk/akash/provider/session"
+	"github.com/ovrclk/akash/pubsub"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+type stateFunc func(*deployState) stateFunc
+
+// deployState manages the a Lease's ManifestGroup being deployed
+// to a provider's client.
+type deployState struct {
+	ctx   context.Context
+	state stateFunc
+	mux   sync.Mutex
+
+	// Unused fields
+	bus     pubsub.Bus
+	session session.Session
+
+	client  Client
+	lease   mtypes.LeaseID
+	mgroup  *manifest.Group
+	monitor *deploymentMonitor
+
+	updatech   chan *manifest.Group
+	teardownch chan struct{}
+	errch      chan error
+
+	log log.Logger
+}
+
+func newDeployState(ctx context.Context, s *service, lease mtypes.LeaseID, mgroup *manifest.Group) *deployState {
+	log := s.log.With("cmp", "deployment-state", "lease", lease, "manifest-group", mgroup.Name)
+
+	ds := &deployState{
+		ctx:     ctx,
+		bus:     s.bus, // unused
+		client:  s.client,
+		session: s.session, // unused
+
+		state:  stateDeploying, // initial state, deploy the manifest
+		lease:  lease,
+		mgroup: mgroup,
+
+		updatech:   make(chan *manifest.Group),
+		teardownch: make(chan struct{}),
+		errch:      nil,
+
+		log: log.With("cmp", "deploystate"),
+	}
+	go runLoop(ds, stateDeploying, log)
+	return ds
+}
+
+func newTestDeployState(ctx context.Context, s *service, lease mtypes.LeaseID, mgroup *manifest.Group) (*deployState, stateFunc) {
+	log := s.log.With("cmp", "deployment-state", "lease", lease, "manifest-group", mgroup.Name)
+
+	ds := &deployState{
+		ctx:     ctx,
+		bus:     s.bus, // unused
+		client:  s.client,
+		session: s.session, // unused
+
+		state:  stateDeploying, // initial state, deploy the manifest
+		lease:  lease,
+		mgroup: mgroup,
+
+		updatech:   make(chan *manifest.Group),
+		teardownch: make(chan struct{}),
+		errch:      nil,
+
+		log: log.With("cmp", "deploystate"),
+	}
+	var sf stateFunc
+	initState := stateDeploying
+	go func(initState stateFunc) {
+		state := initState
+		for state != nil {
+			sf = state(ds)
+			log.With("state", s).Debug("state transitioned")
+			state = sf
+		}
+	}(initState) // runLoop(ds, stateDeploying, log)
+	return ds, sf
+}
+
+func (ds *deployState) run() {
+	// For clean separation declare and use state as a local variable. eg: `state := ds.startState`
+	for ds.state != nil {
+		ds.state = ds.state(ds)
+	}
+}
+
+func (ds *deployState) update(mgroup *manifest.Group) error {
+	ds.mux.Lock()
+	defer ds.mux.Unlock()
+
+	ds.errch = make(chan error, 1)
+	ds.updatech <- mgroup
+	return <-ds.errch
+}
+
+func (ds *deployState) teardown() error {
+	ds.mux.Lock()
+	defer ds.mux.Unlock()
+
+	ds.errch = make(chan error, 1)
+	ds.teardownch <- struct{}{}
+	return <-ds.errch
+
+}
+
+// runLoop provides state transition loop until there are no more states.
+// logs transitions between states, and initializes the provided state with
+// the deployState struct.
+func runLoop(ds *deployState, initState stateFunc, log log.Logger) {
+	state := initState
+	for state != nil {
+		s := state(ds)
+		log.With("state", s).Debug("state transitioned")
+		state = s
+	}
+}
+
+// deployStateStart initializes the deployment and waits till it is fully operational
+func stateDeploying(ds *deployState) stateFunc {
+	if ds.monitor != nil {
+		ds.monitor.shutdown() //
+		ds.monitor = nil
+	}
+	// TODO: Pass ds context to Deploy()
+	err := ds.client.Deploy(ds.ctx, ds.lease, ds.mgroup)
+	if err != nil {
+		ds.log.Error("deploying error", err)
+		if ds.errch != nil {
+			ds.errch <- err
+		}
+		return stateErrored
+	}
+
+	ds.monitor = newDeploymentMonitor(ds.ctx, ds.bus, ds.session, ds.client, ds.lease, ds.mgroup, ds.log)
+	return stateNominal
+}
+
+// stateNominal is entered when deployment is active, and there is nothing to do
+// but wait for signals to perform actions.
+func stateNominal(ds *deployState) stateFunc {
+	select {
+	case mg := <-ds.updatech:
+		ds.mgroup = mg
+		return stateDeploying
+	case <-ds.ctx.Done():
+		return stateTearingdown
+	case <-ds.teardownch:
+		return stateTearingdown
+	}
+}
+
+// stateErrored engages when an uncrecoverable point has been reached.
+func stateErrored(ds *deployState) stateFunc {
+	ds.errch = nil // reset the error channel
+	// TODO: Determine if there are other steps to take in an errored state.
+	return stateNominal
+}
+
+// stateTearingdown handles safe shutdown.
+func stateTearingdown(ds *deployState) stateFunc {
+	if ds.monitor != nil {
+		ds.monitor.shutdown()
+	}
+
+	err := ds.client.TeardownLease(ds.ctx, ds.lease)
+	if err != nil {
+		ds.log.Error("error tearing down deployment", err)
+		if ds.errch != nil {
+			ds.errch <- err
+		}
+	}
+
+	return nil // exit state machine
+}

--- a/provider/cluster/state_test.go
+++ b/provider/cluster/state_test.go
@@ -1,0 +1,83 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/ovrclk/akash/client"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+)
+
+/* Source: https://git.sr.ht/~samwhited/testlog/tree/b1b3e8e82fd6990e91ce9d0fbcbe69ac2d9b1f98/testlog.go
+// New returns a new logger that logs to the provided testing.T.
+func New(t testing.TB) *log.Logger {
+	t.Helper()
+	return log.New(testWriter{TB: t}, t.Name()+" ", log.LstdFlags|log.Lshortfile|log.LUTC)
+}
+*/
+
+type testWriter struct {
+	testing.TB
+}
+
+func (tw testWriter) Write(p []byte) (int, error) {
+	tw.Helper()
+	tw.Logf("%s", p)
+	return len(p), nil
+}
+
+var (
+	stateDeployTests = []struct {
+		lease mtypes.LeaseID
+	}{}
+)
+
+/*
+type Client interface {
+	Query() QueryClient
+	Tx() TxClient
+}
+*/
+type cosmosClient struct{}
+
+func (cc *cosmosClient) Query() client.QueryClient {
+	return nil
+}
+func (cc *cosmosClient) Tx() client.TxClient {
+	return nil
+}
+
+func TestStateDeploy(t *testing.T) {
+	/* TODO: Improve utilities around testing the CosmosSDK so tests
+	can be run against the State machine.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//tw := new(testWriter)
+	l := log.NewNopLogger()
+	lease := mtypes.LeaseID{}
+	mg := &manifest.Group{}
+
+	nc := &nullClient{
+		leases: make(map[string]*manifest.Group),
+	} //*blockchain client*
+	cc := &cosmosClient{}
+
+	bus := pubsub.NewBus()
+	sess := session.New(l, cc, &query.Provider{})
+	// TODO: provider := Provider{...owner host attributes}
+
+	s, err := NewService(ctx, sess, bus, nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//NewService(ctx context.Context, session session.Session, bus pubsub.Bus, client Client)
+	sStruct, ok := s.(*service)
+	if !ok {
+		t.Fatal("service failed type assertion")
+	}
+
+	// completely empty initialization
+	ds, state := newTestDeployState(ctx, sStruct, lease, mg)
+	t.Logf("%+v state: %+v", ds, state)
+	*/
+}


### PR DESCRIPTION
* Deployment state managed with function types via the Rob Pike method of state machines.
the deploymentManager is refactored into deployState.
* Unit Tests will eventually be able to check the state of the
machine after submitting messages.
* Context added after rebase.

### Testing

Usually this pattern helps creating deterministic tests, and evaluation of state achieved given envents XYZ, however the tight coupling of 'service's makes testing based on events very difficult to initialize.

* Prototyped deployment state testing.
* Currently the test setup panics due to complex initializers, so disabled.
