### PR TITLE
refactor: replaces events type const

### DIFF
--- a/sdkutil/event.go
+++ b/sdkutil/event.go
@@ -7,6 +7,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const (
+	akashEventMessageV1 = "akash.v1"
+
+	// EventTypeMessage defines the Akash message string
+	EventTypeMessage = akashEventMessageV1
+)
+
 var (
 	// ErrNotFound is the error with message "Not found"
 	ErrNotFound = errors.New("Not found")

--- a/x/deployment/types/event.go
+++ b/x/deployment/types/event.go
@@ -23,7 +23,7 @@ type EventDeploymentCreate struct {
 
 // ToSDKEvent method creates new sdk event for EventDeploymentCreate struct
 func (ev EventDeploymentCreate) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionDeploymentCreate),
@@ -39,7 +39,7 @@ type EventDeploymentUpdate struct {
 
 // ToSDKEvent method creates new sdk event for EventDeploymentUpdate struct
 func (ev EventDeploymentUpdate) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionDeploymentUpdate),
@@ -54,7 +54,7 @@ type EventDeploymentClose struct {
 
 // ToSDKEvent method creates new sdk event for EventDeploymentClose struct
 func (ev EventDeploymentClose) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionDeploymentClose),
@@ -113,8 +113,9 @@ func ParseEVGroupID(attrs []sdk.Attribute) (GroupID, error) {
 }
 
 // ParseEvent parses event and returns details of event and error if occurred
+// TODO: Enable returning actual events.
 func ParseEvent(ev sdkutil.Event) (interface{}, error) {
-	if ev.Type != sdk.EventTypeMessage {
+	if ev.Type != sdkutil.EventTypeMessage {
 		return nil, sdkutil.ErrUnknownType
 	}
 	if ev.Module != ModuleName {

--- a/x/deployment/types/events_test.go
+++ b/x/deployment/types/events_test.go
@@ -1,0 +1,187 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+
+	"github.com/ovrclk/akash/sdkutil"
+)
+
+var (
+	keyAcc, _ = sdk.AccAddressFromBech32("akash1qtqpdszzakz7ugkey7ka2cmss95z26ygar2mgr")
+	//keyParams = sdk.NewKVStoreKey(params.StoreKey)
+
+	errWildcard = errors.New("wildcard string error can't be matched")
+)
+
+type testEventParsing struct {
+	msg    sdkutil.Event
+	expErr error
+}
+
+func (tep testEventParsing) testMessageType() func(t *testing.T) {
+	_, err := ParseEvent(tep.msg)
+	return func(t *testing.T) {
+		t.Logf("ERR: %v", err)
+		// expected error doesn't match returned    || error returned but not expected
+		if (tep.expErr != nil && errors.Is(err, tep.expErr)) || (err != nil && tep.expErr == nil) {
+			// if the error expected is errWildcard to catch untyped errors, don't fail the test, the error was expected.
+			if errors.Is(tep.expErr, errWildcard) {
+				t.Errorf("unexpected error: %v exp: %v", err, tep.expErr)
+				t.Logf("%T %v", errors.Cause(err), err)
+				t.Logf("%+v", tep)
+			}
+		}
+	}
+}
+
+var TEPS = []testEventParsing{
+	{
+		msg: sdkutil.Event{
+			Type: "nil",
+		},
+		expErr: sdkutil.ErrUnknownType,
+	},
+	{
+		msg: sdkutil.Event{
+			Type: sdkutil.EventTypeMessage,
+		},
+		expErr: sdkutil.ErrUnknownModule,
+	},
+
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+		},
+		expErr: sdkutil.ErrUnknownAction,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: "nil",
+		},
+		expErr: sdkutil.ErrUnknownModule,
+	},
+
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: "nil",
+		},
+		expErr: sdkutil.ErrUnknownAction,
+	},
+
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentCreate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "5",
+				},
+			},
+		},
+		expErr: nil,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentCreate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "abc",
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentCreate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentUpdate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "5",
+				},
+			},
+		},
+		expErr: nil,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentUpdate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: "neh",
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "5",
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionDeploymentUpdate,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+}
+
+func TestEventParsing(t *testing.T) {
+	for i, test := range TEPS {
+		t.Run(fmt.Sprintf("%d", i),
+			test.testMessageType())
+	}
+}

--- a/x/market/types/event.go
+++ b/x/market/types/event.go
@@ -35,7 +35,7 @@ type EventOrderCreated struct {
 
 // ToSDKEvent method creates new sdk event for EventOrderCreated struct
 func (e EventOrderCreated) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionOrderCreated),
@@ -50,7 +50,7 @@ type EventOrderClosed struct {
 
 // ToSDKEvent method creates new sdk event for EventOrderClosed struct
 func (e EventOrderClosed) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionOrderClosed),
@@ -66,7 +66,7 @@ type EventBidCreated struct {
 
 // ToSDKEvent method creates new sdk event for EventBidCreated struct
 func (e EventBidCreated) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append(
 			append([]sdk.Attribute{
 				sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
@@ -84,7 +84,7 @@ type EventBidClosed struct {
 
 // ToSDKEvent method creates new sdk event for EventBidClosed struct
 func (e EventBidClosed) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append(
 			append([]sdk.Attribute{
 				sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
@@ -102,7 +102,7 @@ type EventLeaseCreated struct {
 
 // ToSDKEvent method creates new sdk event for EventLeaseCreated struct
 func (e EventLeaseCreated) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append(
 			append([]sdk.Attribute{
 				sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
@@ -119,7 +119,7 @@ type EventLeaseClosed struct {
 
 // ToSDKEvent method creates new sdk event for EventLeaseClosed struct
 func (e EventLeaseClosed) ToSDKEvent() sdk.Event {
-	return sdk.NewEvent(sdk.EventTypeMessage,
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
 		append(
 			append([]sdk.Attribute{
 				sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
@@ -224,7 +224,7 @@ func parseEVPriceAttributes(attrs []sdk.Attribute) (sdk.Coin, error) {
 
 // ParseEvent parses event and returns details of event and error if occurred
 func ParseEvent(ev sdkutil.Event) (interface{}, error) {
-	if ev.Type != sdk.EventTypeMessage {
+	if ev.Type != sdkutil.EventTypeMessage {
 		return nil, sdkutil.ErrUnknownType
 	}
 	if ev.Module != ModuleName {


### PR DESCRIPTION
* Previously used the sdk.EventTypeMessage == "message" string to
identify all of our messages. This provided little value.
* Updated all ephemeral messages to be prefixed with
"sdkutil.EventTypeMessage" == "akash.v1".
* Added tests to assert successful event parsing, though they just check 
there are no parsing errors right now.

fixes #607
