### PR TITLE
perf: remove provider transaction event subscription

### DIFF
--- a/events/query.go
+++ b/events/query.go
@@ -8,11 +8,6 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-func txQuery() pubsub.Query {
-	return tmquery.MustParse(
-		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx))
-}
-
 func blkQuery() pubsub.Query {
 	return tmquery.MustParse(
 		fmt.Sprintf("%s='%s'", tmtypes.EventTypeKey, tmtypes.EventNewBlockHeader))

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -47,6 +47,7 @@ func runCmd(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
+// doRunCmd initializes all of the Provider functionality, hangs, and awaits shutdown signals.
 func doRunCmd(ctx context.Context, cdc *codec.Codec, cmd *cobra.Command, _ []string) error {
 	cctx := ccontext.NewCLIContext().WithCodec(cdc)
 
@@ -81,6 +82,7 @@ func doRunCmd(ctx context.Context, cdc *codec.Codec, cmd *cobra.Command, _ []str
 		return err
 	}
 
+	// k8s client creation
 	cclient, err := createClusterClient(log, cmd, pinfo.HostURI)
 	if err != nil {
 		return err
@@ -117,6 +119,7 @@ func doRunCmd(ctx context.Context, cdc *codec.Codec, cmd *cobra.Command, _ []str
 
 func createClusterClient(log log.Logger, cmd *cobra.Command, host string) (cluster.Client, error) {
 	if val, _ := cmd.Flags().GetBool(flagClusterK8s); !val {
+		// Condition that there is no Kubernetes API to work with.
 		return cluster.NullClient(), nil
 	}
 	ns, err := cmd.Flags().GetString(flagK8sManifestNS)


### PR DESCRIPTION
* Deactivated events.Publish subscribes to the tendermint event bus
and re-published events to the rest of the provider/
modules.
* Small docstring additions.

fixes #606
