### PR TITLE
enhancement: equivalent bids deterministic winner

### DIFF
--- a/testutil/ids.go
+++ b/testutil/ids.go
@@ -4,12 +4,12 @@ import (
 	"math/rand"
 	"testing"
 
-	ckeys "github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	mtypes "github.com/ovrclk/akash/x/market/types"
-	"github.com/stretchr/testify/require"
 )
 
 func Keyring(t testing.TB) keys.Keybase {
@@ -17,11 +17,12 @@ func Keyring(t testing.TB) keys.Keybase {
 	return obj
 }
 
+// AccAddress provides an Account's Address bytes from a ed25519 generated
+// private key.
 func AccAddress(t testing.TB) sdk.AccAddress {
 	t.Helper()
-	info, _, err := Keyring(t).CreateMnemonic("test", keys.English, ckeys.DefaultKeyPass, keys.Secp256k1)
-	require.NoError(t, err)
-	return info.GetAddress()
+	privKey := ed25519.GenPrivKey()
+	return sdk.AccAddress(privKey.PubKey().Address())
 }
 
 func DeploymentID(t testing.TB) dtypes.DeploymentID {

--- a/x/market/handler/endblock.go
+++ b/x/market/handler/endblock.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"hash/fnv"
 	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ovrclk/akash/x/market/types"
+	"github.com/pkg/errors"
 )
 
 // OnEndBlock transfer funds for active leases and update order states
@@ -55,6 +57,52 @@ func transferFundsForActiveLeases(ctx sdk.Context, keepers Keepers) error {
 	return nil
 }
 
+var errNoBids error = errors.New("no bids to pick winner from")
+
+func pickBidWinner(bids []types.Bid) (winner *types.Bid, err error) {
+	// open bids; match by lowest price; sort bids by price
+	sort.Slice(bids, func(i, j int) bool {
+		// The BidID DSeq is pulled from the original OrderID.
+		// So it can't be used to determine who bid first like a timestamp.
+		return bids[i].Price.IsLT(bids[j].Price)
+	})
+	switch len(bids) {
+	case 0:
+		// This is a fatal case
+		return nil, errNoBids
+	case 1:
+		return &bids[0], nil
+	}
+
+	if !bids[0].Price.IsEqual(bids[1].Price) {
+		// Lowest bid(0) is unique, return the winner
+		return &bids[0], nil
+	}
+
+	// There are equivalent bid prices; select winner with deterministic
+	// random ordering based on given bids.
+	// FNV hash provider addresses all of the bids
+	h := fnv.New32a()
+	bidIndex := 0
+	_, err = h.Write(bids[bidIndex+1].Provider.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	for ; bidIndex+1 < len(bids); bidIndex++ {
+		if !bids[bidIndex].Price.IsEqual(bids[bidIndex+1].Price) {
+			break
+		}
+		_, err := h.Write(bids[bidIndex+1].Provider.Bytes())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create a numeric hash from the Stringified Bid values
+	n := int(h.Sum32()) % (bidIndex + 1) // Calculate the remainder to select index of equal bids
+	return &bids[n], nil
+}
+
 func matchOrders(ctx sdk.Context, keepers Keepers) error {
 
 	// match unmatched orders.
@@ -78,22 +126,24 @@ func matchOrders(ctx sdk.Context, keepers Keepers) error {
 			return false
 		}
 
-		// open bids; match by lowest price
-		sort.Slice(bids, func(i, j int) bool {
-			// TODO handle same price
-			return bids[i].Price.IsLT(bids[j].Price)
-		})
-
-		winner := bids[0]
+		winner, err := pickBidWinner(bids)
+		if err != nil {
+			pErr := errors.Wrap(err, "picking bid winner returned unrecoverable error")
+			panic(pErr.Error())
+		}
 
 		// create lease
-		keepers.Market.CreateLease(ctx, winner)
+		keepers.Market.CreateLease(ctx, *winner)
 
 		// set winning bid state to matched
-		keepers.Market.OnBidMatched(ctx, winner)
+		keepers.Market.OnBidMatched(ctx, *winner)
 
 		// set losing bids to state lost
-		for _, bid := range bids[1:] {
+		// Set all but winning bid to State: Lost
+		for _, bid := range bids {
+			if winner.Equals(bid.BidID) {
+				continue // skip setting state to lost
+			}
 			keepers.Market.OnBidLost(ctx, bid)
 		}
 

--- a/x/market/handler/endblock_test.go
+++ b/x/market/handler/endblock_test.go
@@ -1,0 +1,190 @@
+package handler
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/ovrclk/akash/x/market/types"
+)
+
+type winnerTest struct {
+	desc      string
+	bids      []types.Bid
+	expWinner *types.Bid
+	expErr    error
+}
+
+func (w *winnerTest) testFunc(t *testing.T) {
+	winner, err := pickBidWinner(w.bids)
+	if !errors.Is(err, w.expErr) {
+		t.Errorf("returned err: %v does not match %v", err, w.expErr)
+	}
+	if w.expWinner != nil && !winner.Equals(w.expWinner.ID()) {
+		t.Errorf("unexpected winner: %#v\n%q : %v", winner, types.BidIDString(winner.BidID), winner.Price)
+		t.Logf("winner: %+v coin: %s", winner.ID(), winner.Price.String())
+	}
+}
+
+func TestBidWinner(t *testing.T) {
+	originOID := testutil.OrderID(t)
+
+	bid0 := createBid(t, originOID, 3)
+	bid1 := createBid(t, originOID, 5)
+	bid2 := createBid(t, originOID, 5)
+	bid3 := createBid(t, originOID, 4)
+	bid4 := createBid(t, originOID, 5)
+	bid5 := createBid(t, originOID, 5)
+	bid6 := createBid(t, originOID, 5)
+	bid7 := createBid(t, originOID, 8)
+	bid8 := createBid(t, originOID, 6)
+	bid9 := createBid(t, originOID, 5)
+
+	var winnerTests = []winnerTest{
+		{
+			desc:      "no bids",
+			bids:      []types.Bid{},
+			expWinner: nil,
+			expErr:    errNoBids,
+		},
+		{
+			desc:      "single bid",
+			bids:      []types.Bid{bid9},
+			expWinner: &bid9,
+		},
+		{
+			desc:      "two bids",
+			bids:      []types.Bid{bid7, bid4},
+			expWinner: &bid4,
+		},
+		{
+			desc:      "two matching bids",
+			bids:      []types.Bid{bid9, bid7, bid4},
+			expWinner: &bid4,
+		},
+		{
+			desc:      "all the same bid values",
+			bids:      []types.Bid{bid9, bid9, bid9, bid9, bid9},
+			expWinner: &bid9,
+		},
+		{
+			desc:      "two of the same",
+			bids:      []types.Bid{bid9, bid3},
+			expWinner: &bid3,
+		},
+		{
+			desc:      "multiple of the same, but one lowest value",
+			bids:      []types.Bid{bid1, bid0, bid9, bid2, bid3, bid4},
+			expWinner: &bid0,
+		},
+		{
+			desc:      "confirm last bid in list is picked",
+			bids:      []types.Bid{bid1, bid9, bid2, bid3, bid4, bid0},
+			expWinner: &bid0,
+		},
+		{
+			desc:      "two matching low bids",
+			bids:      []types.Bid{bid5, bid6, bid7, bid8},
+			expWinner: &bid6,
+		},
+	}
+
+	for _, test := range winnerTests {
+		t.Run(test.desc, test.testFunc)
+	}
+}
+
+type testDist struct {
+	desc      string
+	bidNum    int
+	rounds    int
+	expErr    error
+	expUneven bool
+}
+
+func (td *testDist) testFunc(t *testing.T) {
+	originOID := testutil.OrderID(t)
+
+	distributionSpread := make(map[int]int, td.bidNum)
+	for i := 0; i < td.rounds; i++ {
+		bIndex := make(map[string]int, td.bidNum)
+		bids := make([]types.Bid, 0, td.bidNum)
+		// generate N bids all with the same bidding amount
+		for j := 0; j < td.bidNum; j++ {
+			b := createBid(t, originOID, 5)
+			bIndex[b.Provider.String()] = j
+			bids = append(bids, b)
+		}
+
+		winner, err := pickBidWinner(bids)
+		if !errors.Is(err, td.expErr) {
+			t.Errorf("returned err: %v does not match %v", err, td.expErr)
+		}
+		// Check provider
+		slot := bIndex[winner.Provider.String()]
+		distributionSpread[slot]++
+	}
+
+	for i := 0; i < td.bidNum; i++ {
+		v := distributionSpread[i]
+		if v == 0 && !td.expUneven {
+			t.Errorf("index[%d] had no winners when even distribution was expected", i)
+			continue
+		}
+		// calculate a reasonable low expectation of wins given the number of test rounds and number of bidders
+		r := float64(td.rounds/td.bidNum) * 0.5
+		if float64(v) < r {
+			t.Errorf("less than %d winnings of [%d]", td.bidNum, i)
+		}
+		t.Logf("winner distribution: %d: %d", i, v)
+	}
+
+}
+
+func TestWinningDistribution(t *testing.T) {
+	tests := []testDist{
+		{
+			desc:   "one bidder",
+			bidNum: 1,
+			rounds: 50,
+			expErr: nil,
+		},
+		{
+			desc:   "five winners",
+			bidNum: 5,
+			rounds: 50,
+			expErr: nil,
+		},
+		{
+			desc:   "ten winners",
+			bidNum: 10,
+			rounds: 500,
+			expErr: nil,
+		},
+		{
+			desc:      "too many bidders",
+			bidNum:    100,
+			rounds:    50,
+			expUneven: true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), test.testFunc)
+	}
+}
+
+func createBid(t *testing.T, oid types.OrderID, bid int) types.Bid {
+	t.Helper()
+	akashDenom := "akash"
+	sdkInt := int64(bid)
+	b := types.Bid{
+		BidID: types.MakeBidID(oid, testutil.AccAddress(t)),
+		State: types.BidOpen,
+		Price: sdk.NewCoin(akashDenom, sdk.NewInt(sdkInt)),
+	}
+	return b
+}


### PR DESCRIPTION
Deterministically choose a winner from a set of bids for an order.

* Sort bids on order: collect lowest with matching bid values
* From lowest bids, aggregate all bids' strings and fnv hash
* `fnv value` %(remainder) len(matching bids) = winning bid.
* Unit tests to assert deterministic return values.

* TODO: https://github.com/ovrclk/akash/issues/637 to improve 
bid query performance.

fixes #619
