### PR TITLE
test: Fuzz Bid winning random distribution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf // indirect
+	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f // indirect
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.7.3


### PR DESCRIPTION
Update the TestWinningDistribution test to be configured via Google's
Fuzz library. This uncovers some interesting behavior with how cruel
crypto/rand can be on distribution expectations.

Goal posts for expected distribution results were lowered from
(rounds/bidNum) * 0.5 to (rounds/bidNum) * 0.3.

Fuzzed Rounds and BidNum are limited to a maximum of 150.