### PR TITLE
feat: Close Group Message functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,3 +243,5 @@ test-sim-after-import:
 	@echo "Running application simulation-after-import..."
 	go test -mod=readonly -tags=$(BUILD_MAINNET) $(APP_DIR) -run=TestAppSimulationAfterImport -Enabled=true \
 		-NumBlocks=50 -BlockSize=100 -Commit=true -Seed=99 -Period=5 -v -timeout 10m
+
+test-sims: test-sim-fullapp test-sim-nondeterminism test-sim-import-export test-sim-after-import

--- a/app/params/weights.go
+++ b/app/params/weights.go
@@ -8,6 +8,7 @@ const (
 	DefaultWeightMsgCreateDeployment int = 100
 	DefaultWeightMsgUpdateDeployment int = 10
 	DefaultWeightMsgCloseDeployment  int = 100
+	DefaultWeightMsgCloseGroup       int = 100
 
 	DefaultWeightMsgCreateBid  int = 100
 	DefaultWeightMsgCloseBid   int = 100

--- a/events/publish_test.go
+++ b/events/publish_test.go
@@ -18,6 +18,7 @@ func Test_processEvent(t *testing.T) {
 		dtypes.EventDeploymentCreate{ID: testutil.DeploymentID(t)},
 		dtypes.EventDeploymentUpdate{ID: testutil.DeploymentID(t)},
 		dtypes.EventDeploymentClose{ID: testutil.DeploymentID(t)},
+		dtypes.EventGroupClose{ID: testutil.GroupID(t)},
 
 		// x/market events
 		mtypes.EventOrderCreated{ID: testutil.OrderID(t)},

--- a/x/deployment/types/codec.go
+++ b/x/deployment/types/codec.go
@@ -15,6 +15,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgCreateDeployment{}, ModuleName+"/"+msgTypeCreateDeployment, nil)
 	cdc.RegisterConcrete(MsgUpdateDeployment{}, ModuleName+"/"+msgTypeUpdateDeployment, nil)
 	cdc.RegisterConcrete(MsgCloseDeployment{}, ModuleName+"/"+msgTypeCloseDeployment, nil)
+	cdc.RegisterConcrete(MsgCloseGroup{}, ModuleName+"/"+msgTypeCloseGroup, nil)
 }
 
 // MustMarshalJSON panics if an error occurs. Besides that it behaves exactly like MarshalJSON

--- a/x/deployment/types/errors.go
+++ b/x/deployment/types/errors.go
@@ -17,6 +17,9 @@ const (
 	errInternal
 	errInvalidDeployment
 	errInvalidGroupID
+	errGroupNotFound
+	errGroupClosed
+	errGroupNotOpen
 )
 
 var (
@@ -32,7 +35,7 @@ var (
 	ErrDeploymentClosed = sdkerrors.Register(ModuleName, errDeploymentClosed, "Deployment closed")
 	// ErrOwnerAcctMissing is the error for owner account missing
 	ErrOwnerAcctMissing = sdkerrors.Register(ModuleName, errOwnerAcctMissing, "Owner account missing")
-	// ErrEmptyGroups is the error when groups are empty
+	// ErrInvalidGroups is the error when groups are empty
 	ErrInvalidGroups = sdkerrors.Register(ModuleName, errInvalidGroups, "Invalid groups")
 	// ErrInvalidDeploymentID is the error for invalid deployment id
 	ErrInvalidDeploymentID = sdkerrors.Register(ModuleName, errInvalidDeploymentID, "Invalid: deployment id")
@@ -44,4 +47,10 @@ var (
 	ErrInvalidDeployment = sdkerrors.Register(ModuleName, errInvalidDeployment, "Invalid deployment")
 	// ErrInvalidGroupID is the error when already deployment exists
 	ErrInvalidGroupID = sdkerrors.Register(ModuleName, errInvalidGroupID, "Deployment exists")
+	// ErrGroupNotFound is the keeper's error for not finding a group
+	ErrGroupNotFound = sdkerrors.Register(ModuleName, errGroupNotFound, "Group not found")
+	// ErrGroupClosed is the error when deployment is closed
+	ErrGroupClosed = sdkerrors.Register(ModuleName, errGroupClosed, "Group already closed")
+	// ErrGroupNotOpen indicates the Group state has progressed beyond initial Open.
+	ErrGroupNotOpen = sdkerrors.Register(ModuleName, errGroupNotOpen, "Group not open")
 )

--- a/x/deployment/types/events_test.go
+++ b/x/deployment/types/events_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,9 +12,7 @@ import (
 )
 
 var (
-	keyAcc, _ = sdk.AccAddressFromBech32("akash1qtqpdszzakz7ugkey7ka2cmss95z26ygar2mgr")
-	//keyParams = sdk.NewKVStoreKey(params.StoreKey)
-
+	keyAcc, _   = sdk.AccAddressFromBech32("akash1qtqpdszzakz7ugkey7ka2cmss95z26ygar2mgr")
 	errWildcard = errors.New("wildcard string error can't be matched")
 )
 
@@ -147,6 +145,64 @@ var TEPS = []testEventParsing{
 		msg: sdkutil.Event{
 			Type:   sdkutil.EventTypeMessage,
 			Module: ModuleName,
+			Action: evActionGroupClose,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "5",
+				},
+				{
+					Key:   evGSeqKey,
+					Value: "1",
+				},
+			},
+		},
+		expErr: nil,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionGroupClose,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evDSeqKey,
+					Value: "5",
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
+			Action: evActionGroupClose,
+			Attributes: []sdk.Attribute{
+				{
+					Key:   evOwnerKey,
+					Value: keyAcc.String(),
+				},
+				{
+					Key:   evGSeqKey,
+					Value: "1",
+				},
+			},
+		},
+		expErr: errWildcard,
+	},
+	{
+		msg: sdkutil.Event{
+			Type:   sdkutil.EventTypeMessage,
+			Module: ModuleName,
 			Action: evActionDeploymentUpdate,
 			Attributes: []sdk.Attribute{
 				{
@@ -179,7 +235,6 @@ var TEPS = []testEventParsing{
 
 func TestEventParsing(t *testing.T) {
 	for i, test := range TEPS {
-		t.Run(fmt.Sprintf("%d", i),
-			test.testMessageType())
+		t.Run(strconv.Itoa(i), test.testMessageType())
 	}
 }

--- a/x/deployment/types/msgs.go
+++ b/x/deployment/types/msgs.go
@@ -8,6 +8,7 @@ const (
 	msgTypeCreateDeployment = "create-deployment"
 	msgTypeUpdateDeployment = "update-deployment"
 	msgTypeCloseDeployment  = "close-deployment"
+	msgTypeCloseGroup       = "close-group"
 )
 
 // MsgCreateDeployment defines an SDK message for creating deployment
@@ -106,5 +107,34 @@ func (msg MsgCloseDeployment) GetSignBytes() []byte {
 
 // GetSigners defines whose signature is required
 func (msg MsgCloseDeployment) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.ID.Owner}
+}
+
+// MsgCloseGroup defines SDK message to close a single Group within a Deployment.
+type MsgCloseGroup struct {
+	ID GroupID
+}
+
+// Route implements the sdk.Msg interface for routing
+func (msg MsgCloseGroup) Route() string { return RouterKey }
+
+// Type implements the sdk.Msg interface exposing message type
+func (msg MsgCloseGroup) Type() string { return msgTypeCloseGroup }
+
+// ValidateBasic calls underlying GroupID.Validate() check and returns result
+func (msg MsgCloseGroup) ValidateBasic() error {
+	if err := msg.ID.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgCloseGroup) GetSignBytes() []byte {
+	return sdk.MustSortJSON(cdc.MustMarshalJSON(msg))
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgCloseGroup) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.ID.Owner}
 }

--- a/x/deployment/types/types.go
+++ b/x/deployment/types/types.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ovrclk/akash/types"
@@ -18,10 +16,6 @@ const (
 	DeploymentActive DeploymentState = iota + 1 // active
 	// DeploymentClosed is used when state of deployment is closed
 	DeploymentClosed // closed
-)
-
-var (
-	ErrGroupNotOpen = errors.New("group not open")
 )
 
 // DeploymentStateMap is used to decode deployment state flag value
@@ -57,15 +51,6 @@ const (
 	// GroupClosed is used when state of group is closed
 	GroupClosed // closed
 )
-
-// GroupStateMap is used to decode group state flag value
-var GroupStateMap = map[string]GroupState{
-	"open":               GroupOpen,
-	"ordered":            GroupOrdered,
-	"matched":            GroupMatched,
-	"insufficient-funds": GroupInsufficientFunds,
-	"closed":             GroupClosed,
-}
 
 // GroupSpec stores group specifications
 type GroupSpec struct {
@@ -126,17 +111,28 @@ type Group struct {
 }
 
 // ID method returns GroupID details of specific group
-func (d Group) ID() GroupID {
-	return d.GroupID
+func (g Group) ID() GroupID {
+	return g.GroupID
 }
 
-// ValidateOrderable method checks whether group opened or not
-func (d Group) ValidateOrderable() error {
-	switch d.State {
+// ValidateOrderable method checks whether group status is Open or not
+func (g Group) ValidateOrderable() error {
+	switch g.State {
 	case GroupOpen:
 		return nil
 	default:
 		return ErrGroupNotOpen
+	}
+}
+
+// ValidateClosable provides error response if group is already closed,
+// and thus should not be closed again, else nil.
+func (g Group) ValidateClosable() error {
+	switch g.State {
+	case GroupClosed:
+		return ErrGroupClosed
+	default:
+		return nil
 	}
 }
 

--- a/x/deployment/types/types_test.go
+++ b/x/deployment/types/types_test.go
@@ -1,0 +1,56 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/ovrclk/akash/x/deployment/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type gStateTest struct {
+	state                types.GroupState
+	expValidateOrderable error
+	expValidateClosable  error
+}
+
+func TestGroupState(t *testing.T) {
+	tests := []gStateTest{
+		{
+			state: types.GroupOpen,
+		},
+		{
+			state:                types.GroupOrdered,
+			expValidateOrderable: types.ErrGroupNotOpen,
+		},
+		{
+			state:                types.GroupMatched,
+			expValidateOrderable: types.ErrGroupNotOpen,
+		},
+		{
+			state:                types.GroupInsufficientFunds,
+			expValidateOrderable: types.ErrGroupNotOpen,
+		},
+		{
+			state:                types.GroupClosed,
+			expValidateClosable:  types.ErrGroupClosed,
+			expValidateOrderable: types.ErrGroupNotOpen,
+		},
+		{
+			state:                types.GroupState(99),
+			expValidateOrderable: types.ErrGroupNotOpen,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("------test-%d: %#v", i, test)
+		group := types.Group{
+			GroupID: testutil.GroupID(t),
+			State:   test.state,
+		}
+
+		assert.Equal(t, group.ValidateOrderable(), test.expValidateOrderable, group.State)
+
+		assert.Equal(t, group.ValidateClosable(), test.expValidateClosable, group.State)
+	}
+}


### PR DESCRIPTION
Enable closing a specific group within an existing Akash Deployment.
This will signal the provider to set the Group.State to Closed.

`akashctl tx deployment group close --owner=? --dseq=? --gseq=?` command
added to send the `MsgCloseGroup`.

Simulation tests passing: With a prequisite in SimulateMsgCloseGroup() to skip
sending the MsgGroupClose if the Group.State is already Closed. This is
not the same behavior as the Deployment's Simulation function, but
Simulate...Group throws the handleMsgCloseGroup() ErrGroupClosed when
the simulation runs.

fixes: #642
