### PR TITLE
fix: declare market bid errors as sdkerror

### DIFF
--- a/x/market/types/errors.go
+++ b/x/market/types/errors.go
@@ -23,6 +23,8 @@ const (
 	errCodeLeaseNotFound
 	errCodeBidExists
 	errCodeInvalidPrice
+	errCodeOrderMatched
+	errCodeOrderClosed
 )
 
 var (
@@ -62,4 +64,8 @@ var (
 	ErrBidExists = sdkerrors.Register(ModuleName, errCodeBidExists, "invalid bid: bid exists from provider")
 	// ErrBidInvalidPrice bid invalid price
 	ErrBidInvalidPrice = sdkerrors.Register(ModuleName, errCodeInvalidPrice, "bid price is invalid")
+	// ErrOrderMatched order matched
+	ErrOrderMatched = sdkerrors.New(ModuleName, errCodeOrderMatched, "order matched")
+	// ErrOrderClosed order closed
+	ErrOrderClosed = sdkerrors.New(ModuleName, errCodeOrderClosed, "order closed")
 )

--- a/x/market/types/types.go
+++ b/x/market/types/types.go
@@ -21,12 +21,6 @@ const (
 	OrderClosed // closed
 )
 
-var (
-	ErrOrderMatched = errors.New("order matched")
-	ErrOrderClosed  = errors.New("order closed")
-	ErrOrderOpen    = errors.New("order open")
-)
-
 // OrderStateMap is used to decode order state flag value
 var OrderStateMap = map[string]OrderState{
 	"open":    OrderOpen,


### PR DESCRIPTION
fixes #702

result
```
{
  "height": "301",
  "txhash": "5690F8A18FA254243D94B466ABAABF7437D80FA8EE43E71008596BF2CE9E527C",
  "codespace": "market",
  "code": 20,
  "raw_log": "order closed: failed to execute message; message index: 0",
  "gas_wanted": "200000",
  "gas_used": "36491"
}

```
