### PR TITLE
Deployment EndBlock testing(prep for Indexing)

### DIFF
--- a/testutil/base.go
+++ b/testutil/base.go
@@ -11,6 +11,10 @@ import (
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 )
 
+// CoinDenom provides ability to create coins in test functions and
+// pass them into testutil functionality.
+const CoinDenom = "akash"
+
 // Name generates a random name with the given prefix
 func Name(_ testing.TB, prefix string) string {
 	return fmt.Sprintf("%s-%v", prefix, rand.Uint64())
@@ -40,12 +44,15 @@ func Attributes(t testing.TB) []sdk.Attribute {
 
 }
 
+// Resources produces an attribute list for populating a Group's
+// 'Resources' fields.
 func Resources(t testing.TB) []dtypes.Resource {
 	t.Helper()
 	count := rand.Intn(10) + 1
 
 	vals := make([]dtypes.Resource, 0, count)
 	for i := 0; i < count; i++ {
+		coin := sdk.NewCoin(CoinDenom, sdk.NewInt(rand.Int63n(9999)))
 		res := dtypes.Resource{
 			Unit: types.Unit{
 				CPU:     100,
@@ -53,7 +60,7 @@ func Resources(t testing.TB) []dtypes.Resource {
 				Storage: 10,
 			},
 			Count: 1,
-			Price: sdk.NewCoin("thepricedcoin", sdk.NewInt(int64(rand.Uint16()))),
+			Price: coin,
 		}
 		vals = append(vals, res)
 	}

--- a/testutil/deployment.go
+++ b/testutil/deployment.go
@@ -26,6 +26,7 @@ func DeploymentGroup(t testing.TB, did dtypes.DeploymentID, gseq uint32) dtypes.
 		GroupSpec: dtypes.GroupSpec{
 			Name:         Name(t, "dgroup"),
 			Requirements: Attributes(t),
+			Resources:    Resources(t),
 		},
 	}
 }

--- a/x/deployment/handler/endblock.go
+++ b/x/deployment/handler/endblock.go
@@ -10,14 +10,8 @@ import (
 // Executed at the end of block
 func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
 
-	// create orders as necessary
-	keeper.WithDeployments(ctx, func(d types.Deployment) bool {
-
-		// active deployments only
-		if d.State != types.DeploymentActive {
-			return false
-		}
-
+	// create orders as necessary for Active Deployment
+	keeper.WithDeploymentsActive(ctx, func(d types.Deployment) bool {
 		for _, group := range keeper.GetGroups(ctx, d.ID()) {
 
 			// open groups only
@@ -34,8 +28,6 @@ func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
 			// set state to ordered
 			keeper.OnOrderCreated(ctx, group)
 		}
-
 		return false
 	})
-
 }

--- a/x/deployment/handler/endblock_test.go
+++ b/x/deployment/handler/endblock_test.go
@@ -1,0 +1,73 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/ovrclk/akash/x/deployment/handler"
+	"github.com/ovrclk/akash/x/deployment/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndBlock(t *testing.T) {
+	suite := setupTestSuite(t)
+	d0 := testutil.Deployment(suite.t)
+	g0 := testutil.DeploymentGroup(suite.t, d0.DeploymentID, uint32(5))
+	g1 := testutil.DeploymentGroup(suite.t, d0.DeploymentID, uint32(100))
+	g1.State = types.GroupClosed
+
+	d1 := testutil.Deployment(suite.t)
+	d1.State = types.DeploymentClosed
+	g2 := testutil.DeploymentGroup(suite.t, d1.DeploymentID, uint32(8))
+
+	// create deployments in storage
+	df := func(s *testSuite, d types.Deployment, groups ...types.Group) {
+		grps := make([]types.GroupSpec, 0, len(groups))
+		for _, g := range groups {
+			grps = append(grps, g.GroupSpec)
+		}
+		m := types.MsgCreateDeployment{
+			ID:     d.ID(),
+			Groups: grps,
+		}
+		_, err := s.handler(s.ctx, m)
+		assert.NoError(s.t, err)
+
+		if d.State == types.DeploymentClosed {
+			m := types.MsgCloseDeployment{
+				ID: d.ID(),
+			}
+			_, err := s.handler(s.ctx, m)
+			assert.NoError(s.t, err)
+		}
+	}
+	df(suite, d0, g0, g1)
+	df(suite, d1, g2)
+
+	// Execute EndBlock method
+	handler.OnEndBlock(suite.ctx, suite.dkeeper, suite.mkeeper)
+
+	// Check results of EndBlock
+	gx := suite.dkeeper.GetGroups(suite.ctx, d0.ID())
+	assert.NotEmpty(t, gx, "no groups returned from keeper")
+	for _, g := range gx {
+		orderCreated := false
+		suite.mkeeper.WithOrdersForGroup(suite.ctx, g.ID(), func(o mtypes.Order) bool {
+			suite.t.Logf("Order for group: %#v found", o.GroupID())
+			orderCreated = true
+			return true
+		})
+		assert.True(t, orderCreated, "order was not created for a group")
+	}
+
+	// d1 is a closed group, assert no orders created
+	gy := suite.dkeeper.GetGroups(suite.ctx, d1.ID())
+	assert.Len(suite.t, gy, 1, "un-expected number of groups:", len(gy))
+	if len(gy) == 1 {
+		suite.mkeeper.WithOrdersForGroup(suite.ctx, gy[0].ID(), func(o mtypes.Order) bool {
+			suite.t.Error(("deployment state was closed, order should not have been created."))
+			return false
+		})
+	}
+}

--- a/x/deployment/keeper/keeper.go
+++ b/x/deployment/keeper/keeper.go
@@ -147,6 +147,22 @@ func (k Keeper) WithDeployments(ctx sdk.Context, fn func(types.Deployment) bool)
 	}
 }
 
+// WithDeploymentsActive filters to only those with State: Active
+func (k Keeper) WithDeploymentsActive(ctx sdk.Context, fn func(types.Deployment) bool) {
+	store := ctx.KVStore(k.skey)
+	iter := sdk.KVStorePrefixIterator(store, deploymentPrefix)
+	for ; iter.Valid(); iter.Next() {
+		var val types.Deployment
+		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &val)
+		if val.State != types.DeploymentActive {
+			continue
+		}
+		if stop := fn(val); stop {
+			break
+		}
+	}
+}
+
 // OnOrderCreated updates group state to group ordered
 func (k Keeper) OnOrderCreated(ctx sdk.Context, group types.Group) {
 	// TODO: assert state transition

--- a/x/deployment/keeper/keeper_test.go
+++ b/x/deployment/keeper/keeper_test.go
@@ -45,6 +45,16 @@ func Test_Create(t *testing.T) {
 		})
 		assert.Equal(t, 1, count)
 	})
+	t.Run("one active deployment exists", func(t *testing.T) {
+		count := 0
+		keeper.WithDeploymentsActive(ctx, func(d types.Deployment) bool {
+			if assert.Equal(t, deployment.ID(), d.ID()) {
+				count++
+			}
+			return false
+		})
+		assert.Equal(t, 1, count)
+	})
 
 	// write more data.
 	{

--- a/x/market/handler/handler_test.go
+++ b/x/market/handler/handler_test.go
@@ -90,7 +90,7 @@ func TestCreateBidValid(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: provider,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(1)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(1)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -160,7 +160,7 @@ func TestCreateBidClosedOrder(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: suite.createProvider(gspec.Requirements).Owner,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(math.MaxInt64)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(math.MaxInt64)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -173,7 +173,7 @@ func TestCreateBidOverprice(t *testing.T) {
 
 	resources := []dtypes.Resource{
 		{
-			Price: sdk.NewCoin("thepricedcoin", sdk.NewInt(1)),
+			Price: sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(1)),
 		},
 	}
 	order, gspec := suite.createOrder(resources)
@@ -181,7 +181,7 @@ func TestCreateBidOverprice(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: suite.createProvider(gspec.Requirements).Owner,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(math.MaxInt64)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(math.MaxInt64)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -197,7 +197,7 @@ func TestCreateBidInvalidProvider(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: nil,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(1)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(1)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -213,7 +213,7 @@ func TestCreateBidInvalidAttributes(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: suite.createProvider(testutil.Attributes(t)).Owner,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(1)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(1)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -229,7 +229,7 @@ func TestCreateBidAlreadyExists(t *testing.T) {
 	msg := types.MsgCreateBid{
 		Order:    order.ID(),
 		Provider: suite.createProvider(gspec.Requirements).Owner,
-		Price:    sdk.NewCoin("thepricedcoin", sdk.NewInt(1)),
+		Price:    sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(1)),
 	}
 
 	res, err := suite.handler(suite.ctx, msg)
@@ -392,7 +392,7 @@ func TestCloseBidUnknownOrder(t *testing.T) {
 	group := testutil.DeploymentGroup(t, testutil.DeploymentID(t), 0)
 	orderID := types.MakeOrderID(group.ID(), 1)
 	provider := testutil.AccAddress(t)
-	price := sdk.NewCoin("thepricedcoin", sdk.NewInt(int64(rand.Uint16())))
+	price := sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(int64(rand.Uint16())))
 
 	bid, err := suite.mkeeper.CreateBid(suite.ctx, orderID, provider, price)
 	require.NoError(t, err)
@@ -424,7 +424,7 @@ func (st *testSuite) createBid() (types.Bid, types.Order) {
 	st.t.Helper()
 	order, _ := st.createOrder(testutil.Resources(st.t))
 	provider := testutil.AccAddress(st.t)
-	price := sdk.NewCoin("thepricedcoin", sdk.NewInt(int64(rand.Uint16())))
+	price := sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(int64(rand.Uint16())))
 	bid, err := st.mkeeper.CreateBid(st.ctx, order.ID(), provider, price)
 	require.NoError(st.t, err)
 	require.Equal(st.t, order.ID(), bid.ID().OrderID())


### PR DESCRIPTION
* WithDeploymentsActive() added to do basic filtering of all
deployments which are in active state.
    * Used in Deployment's EndBlock function.
    * Tests on EndBlock attempting to assert expected behavior.
    * TODO: Assert EndBlock error cases.
* testutil.CoinDenom added to enable passing created coins into testutil
methods which accept sdk.Coin's with consistent denoms.
    * Updated all tests which fit this case.

related: #604