### PR TITLE
feat: 604 Deployments State Index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f // indirect
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.7.3
@@ -40,6 +41,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
+	golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e
 	google.golang.org/appengine v1.6.6-0.20191016204603-16bce7d3dc4e // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/x/deployment/handler/endblock.go
+++ b/x/deployment/handler/endblock.go
@@ -4,14 +4,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ovrclk/akash/x/deployment/keeper"
 	"github.com/ovrclk/akash/x/deployment/types"
+	"sigs.k8s.io/kind/pkg/errors"
 )
 
 // OnEndBlock create order and update order state for each deployment
 // Executed at the end of block
 func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
-
 	// create orders as necessary for Active Deployment
-	keeper.WithDeploymentsActive(ctx, func(d types.Deployment) bool {
+	err := keeper.WithDeploymentsInState(ctx, types.DeploymentActive, func(d types.Deployment) bool {
 		for _, group := range keeper.GetGroups(ctx, d.ID()) {
 
 			// open groups only
@@ -30,4 +30,7 @@ func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
 		}
 		return false
 	})
+	if err != nil {
+		panic(errors.Wrap(err, "deployment endblock execution error"))
+	}
 }

--- a/x/deployment/handler/endblock_test.go
+++ b/x/deployment/handler/endblock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEndBlock(t *testing.T) {
+func TestEndBlockNominal(t *testing.T) {
 	suite := setupTestSuite(t)
 	d0 := testutil.Deployment(suite.t)
 	g0 := testutil.DeploymentGroup(suite.t, d0.DeploymentID, uint32(5))

--- a/x/deployment/keeper/keeper.go
+++ b/x/deployment/keeper/keeper.go
@@ -31,7 +31,7 @@ func (k Keeper) Codec() *codec.Codec {
 func (k Keeper) GetDeployment(ctx sdk.Context, id types.DeploymentID) (types.Deployment, bool) {
 	store := ctx.KVStore(k.skey)
 
-	key := deploymentKey(id)
+	key := deploymentIDKey(id)
 
 	if !store.Has(key) {
 		return types.Deployment{}, false
@@ -88,7 +88,10 @@ func (k Keeper) GetGroups(ctx sdk.Context, id types.DeploymentID) []types.Group 
 func (k Keeper) Create(ctx sdk.Context, deployment types.Deployment, groups []types.Group) error {
 	store := ctx.KVStore(k.skey)
 
-	key := deploymentKey(deployment.ID())
+	key, err := deploymentKey(deployment)
+	if err != nil {
+		return err
+	}
 
 	if store.Has(key) {
 		return types.ErrDeploymentExists
@@ -114,7 +117,10 @@ func (k Keeper) Create(ctx sdk.Context, deployment types.Deployment, groups []ty
 // UpdateDeployment updates deployment details
 func (k Keeper) UpdateDeployment(ctx sdk.Context, deployment types.Deployment) error {
 	store := ctx.KVStore(k.skey)
-	key := deploymentKey(deployment.ID())
+	key, err := deploymentKey(deployment)
+	if err != nil {
+		return err
+	}
 
 	if !store.Has(key) {
 		return types.ErrDeploymentNotFound

--- a/x/deployment/keeper/key.go
+++ b/x/deployment/keeper/key.go
@@ -19,6 +19,12 @@ func deploymentKey(id types.DeploymentID) []byte {
 	return buf.Bytes()
 }
 
+func deploymentStateKey(d types.Deployment) []byte {
+	buf := bytes.NewBuffer(deploymentPrefix)
+	binary.Write(buf, binary.BigEndian, d.State)
+	return buf.Bytes()
+}
+
 func groupKey(id types.GroupID) []byte {
 	buf := bytes.NewBuffer(groupPrefix)
 	buf.Write(id.Owner.Bytes())

--- a/x/deployment/keeper/key_test.go
+++ b/x/deployment/keeper/key_test.go
@@ -1,0 +1,45 @@
+package keeper
+
+import (
+	"strconv"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/ovrclk/akash/x/deployment/types"
+)
+
+const iterations = 100
+
+func TestDeploymentKeyValues(t *testing.T) {
+	for i := 0; i < iterations; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dep := testutil.Deployment(t)
+
+			// Assert Key length
+			key, err := deploymentStateIDKey(dep)
+			assert.NoError(t, err, "error creating deployment key")
+			assert.Equal(t, len(key), 30)
+
+			// Assert two keys to search are generated
+			keys, err := deploymentStatelessIDKeys(dep.ID())
+			assert.NoError(t, err, "error creating deployment keys")
+			assert.Len(t, keys, 2)
+		})
+	}
+}
+
+func TestDeploymentStateKeyValueExtents(t *testing.T) {
+	for i := 0; i < iterations; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			f := fuzz.New()
+			var dep types.DeploymentState
+			f.Fuzz(&dep)
+			key, err := deploymentStateKey(dep)
+			assert.NoError(t, err, "error creating deployment key")
+			assert.Equal(t, len(key), 2)
+		})
+	}
+}


### PR DESCRIPTION
Updated Deployment indexing key to enable filtering Deployments by their
State. This is hopefully to improve the performance of the deployment module's
OnEndBlock(). Provided by adding a State prefix value to the key, which is
passed to KVStorePrefixIterator(..., kvPrefix).

| Key      | Format                              |
|------|---                                      |
| Previous |               `0x01[OwnerID][DSeq]`  |
| New State Key   |  `0x01[State][OwnerID][DSeq]` |

Adding the state value behind the `deployment` prefix `0x01` value does
create the need for additional checks to be run when
GetDeployment(types.DeploymentID) is called, since it does not provide
the state, so the three potential state keys are generated and iterated
over in store.Get(key) calls, and then short circuit returns the
Deployment value.

Google's Fuzz library is imported to feed random values into tests of the
Key creating methods for durability testing.

Existing tests of the deployment module's code are fairly good, and
after finalizing the new key prefix format, they all pass.

fixes: #604 