### PR TITLE
feat: 604 Open Groups Index

### DIFF
--- a/x/deployment/handler/endblock.go
+++ b/x/deployment/handler/endblock.go
@@ -6,28 +6,18 @@ import (
 	"github.com/ovrclk/akash/x/deployment/types"
 )
 
-// OnEndBlock create order and update order state for each deployment
+// OnEndBlock create order and update order state for each open Group.
 // Executed at the end of block
 func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
-
-	// create orders as necessary for Active Deployment
-	keeper.WithDeploymentsActive(ctx, func(d types.Deployment) bool {
-		for _, group := range keeper.GetGroups(ctx, d.ID()) {
-
-			// open groups only
-			if err := group.ValidateOrderable(); err != nil {
-				continue
-			}
-
-			// create order.
-			if _, err := mkeeper.CreateOrder(ctx, group.ID(), group.GroupSpec); err != nil {
-				ctx.Logger().With("group", group.ID(), "error", err).Error("creating order")
-				continue
-			}
-
-			// set state to ordered
-			keeper.OnOrderCreated(ctx, group)
+	// For each open group; create an order and update the Group's state.
+	keeper.WithOpenGroups(ctx, func(group types.Group) bool {
+		// create order.
+		if _, err := mkeeper.CreateOrder(ctx, group.ID(), group.GroupSpec); err != nil {
+			ctx.Logger().With("group", group.ID(), "error", err).Error("creating order")
 		}
+
+		// set state to ordered
+		keeper.OnOrderCreated(ctx, group)
 		return false
 	})
 }

--- a/x/deployment/handler/endblock_test.go
+++ b/x/deployment/handler/endblock_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ovrclk/akash/testutil"
@@ -69,5 +70,67 @@ func TestEndBlock(t *testing.T) {
 			suite.t.Error(("deployment state was closed, order should not have been created."))
 			return false
 		})
+	}
+}
+
+func TestEndBlockGroups(t *testing.T) {
+	suite := setupTestSuite(t)
+	df := func(s *testSuite, d types.Deployment, groups ...types.Group) {
+		grps := make([]types.GroupSpec, 0, len(groups))
+		for _, g := range groups {
+			grps = append(grps, g.GroupSpec)
+		}
+		m := types.MsgCreateDeployment{
+			ID:     d.ID(),
+			Groups: grps,
+		}
+		_, err := s.handler(s.ctx, m)
+		assert.NoError(s.t, err)
+	}
+	deployments := make([]types.Deployment, 0)
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("%d-create-deployment", i), func(t *testing.T) {
+			d0 := testutil.Deployment(suite.t)
+			d0.State = types.DeploymentActive
+			g0 := testutil.DeploymentGroup(suite.t, d0.DeploymentID, uint32(5))
+			g1 := testutil.DeploymentGroup(suite.t, d0.DeploymentID, uint32(100))
+			deployments = append(deployments, d0)
+			df(suite, d0, g0, g1)
+
+			t.Run("assert groups' state are open", func(t *testing.T) {
+				groups := suite.dkeeper.GetGroups(suite.ctx, d0.ID())
+				assert.Len(t, groups, 2)
+				for _, g := range groups {
+					assert.Equal(t, g.State, types.GroupOpen)
+				}
+			})
+		})
+	}
+	openGroups := 0
+	suite.dkeeper.WithOpenGroups(suite.ctx, func(g types.Group) bool {
+		openGroups++
+		return false
+	})
+	assert.Equal(suite.t, len(deployments)*2, openGroups)
+
+	// Execute EndBlock method
+	handler.OnEndBlock(suite.ctx, suite.dkeeper, suite.mkeeper)
+
+	// Assert no Open groups are left
+	leftOverGroups := 0
+	suite.dkeeper.WithOpenGroups(suite.ctx, func(g types.Group) bool {
+		leftOverGroups++
+		return false
+	})
+	assert.Equal(suite.t, 0, leftOverGroups)
+
+	// Use normal methods to assert Group statuses
+	for _, dep := range deployments {
+		groups := suite.dkeeper.GetGroups(suite.ctx, dep.ID())
+		assert.Len(suite.t, groups, 2)
+		assert.NotEqual(suite.t, types.GroupOpen, groups[0].State)
+		assert.NotEqual(suite.t, types.GroupOpen, groups[1].State)
+		assert.Error(suite.t, groups[0].ValidateOrderable())
+		assert.Error(suite.t, groups[1].ValidateOrderable())
 	}
 }

--- a/x/deployment/keeper/keeper.go
+++ b/x/deployment/keeper/keeper.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ovrclk/akash/x/deployment/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Keeper of the deployment store
@@ -84,6 +83,27 @@ func (k Keeper) GetGroups(ctx sdk.Context, id types.DeploymentID) []types.Group 
 	return vals
 }
 
+// getOpenGroups returns all *open* groups of a deployment with given DeploymentID.
+func (k Keeper) getOpenGroups(ctx sdk.Context, id types.DeploymentID) []types.Group {
+	store := ctx.KVStore(k.skey)
+	key := groupsOpenKey(id)
+
+	var vals []types.Group
+	iter := sdk.KVStorePrefixIterator(store, key)
+	for ; iter.Valid(); iter.Next() {
+		gkey, _ := groupOpenKeyConvert(iter.Key())
+
+		buf := store.Get(gkey)
+		var val types.Group
+		k.cdc.MustUnmarshalBinaryBare(buf, &val)
+		if err := val.ValidateOrderable(); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	iter.Close()
+	return vals
+}
+
 // Create creates a new deployment with given deployment and group specifications
 func (k Keeper) Create(ctx sdk.Context, deployment types.Deployment, groups []types.Group) error {
 	store := ctx.KVStore(k.skey)
@@ -102,6 +122,7 @@ func (k Keeper) Create(ctx sdk.Context, deployment types.Deployment, groups []ty
 		}
 		gkey := groupKey(group.ID())
 		store.Set(gkey, k.cdc.MustMarshalBinaryBare(group))
+		k.updateOpenGroupsIndex(ctx, group)
 	}
 
 	ctx.EventManager().EmitEvent(
@@ -143,6 +164,7 @@ func (k Keeper) OnCloseGroup(ctx sdk.Context, group types.Group) error {
 	)
 
 	store.Set(key, k.cdc.MustMarshalBinaryBare(group))
+	k.updateOpenGroupsIndex(ctx, group)
 	return nil
 }
 
@@ -169,6 +191,24 @@ func (k Keeper) WithDeploymentsActive(ctx sdk.Context, fn func(types.Deployment)
 		if val.State != types.DeploymentActive {
 			continue
 		}
+		if stop := fn(val); stop {
+			break
+		}
+	}
+}
+
+// WithOpenGroups filters to only those with State: Open
+func (k Keeper) WithOpenGroups(ctx sdk.Context, fn func(types.Group) bool) {
+	store := ctx.KVStore(k.skey)
+	iter := sdk.KVStorePrefixIterator(store, groupOpenPrefix)
+	for ; iter.Valid(); iter.Next() {
+		gKey, err := groupOpenKeyConvert(iter.Key())
+		if err != nil {
+			continue
+		}
+		buf := store.Get(gKey)
+		var val types.Group
+		k.cdc.MustUnmarshalBinaryBare(buf, &val)
 		if stop := fn(val); stop {
 			break
 		}
@@ -218,5 +258,21 @@ func (k Keeper) OnDeploymentClosed(ctx sdk.Context, group types.Group) {
 func (k Keeper) updateGroup(ctx sdk.Context, group types.Group) {
 	store := ctx.KVStore(k.skey)
 	key := groupKey(group.ID())
+
 	store.Set(key, k.cdc.MustMarshalBinaryBare(group))
+	k.updateOpenGroupsIndex(ctx, group)
+}
+
+// updateOpenGroupsIndex wraps all calls to the index which tracks open Groups.
+func (k Keeper) updateOpenGroupsIndex(ctx sdk.Context, group types.Group) {
+	// Update the Open Groups prefixed index
+	store := ctx.KVStore(k.skey)
+	openKey := groupOpenKey(group.ID())
+
+	switch group.State {
+	case types.GroupOpen:
+		store.Set(openKey, []byte{})
+	default:
+		store.Delete(openKey)
+	}
 }

--- a/x/deployment/keeper/key.go
+++ b/x/deployment/keeper/key.go
@@ -9,7 +9,10 @@ import (
 
 var (
 	deploymentPrefix = []byte{0x01}
-	groupPrefix      = []byte{0x02}
+
+	groupPrefix = []byte{0x02}
+	// groupOpenPrefix is used only to track the set of Groups in Open state which need to have orders assigned.
+	groupOpenPrefix = []byte{0x03}
 )
 
 func deploymentKey(id types.DeploymentID) []byte {
@@ -19,6 +22,7 @@ func deploymentKey(id types.DeploymentID) []byte {
 	return buf.Bytes()
 }
 
+// groupKey provides prefixed key for a Group's marshalled data.
 func groupKey(id types.GroupID) []byte {
 	buf := bytes.NewBuffer(groupPrefix)
 	buf.Write(id.Owner.Bytes())
@@ -27,8 +31,40 @@ func groupKey(id types.GroupID) []byte {
 	return buf.Bytes()
 }
 
+// groupOpenKey provides prefixed key for groups which are in open state.
+// No data is stored under the key.
+func groupOpenKey(id types.GroupID) []byte {
+	buf := bytes.NewBuffer(groupOpenPrefix)
+	buf.Write(id.Owner.Bytes())
+	binary.Write(buf, binary.BigEndian, id.DSeq)
+	binary.Write(buf, binary.BigEndian, id.GSeq)
+	return buf.Bytes()
+}
+
+// groupOpenKeyConvert converts an open key to the original
+// group key prefix for accessing the Group's data.
+func groupOpenKeyConvert(openKey []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(groupPrefix)
+	_, err := buf.Write(openKey[1:])
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// groupsKey provides default store Key for Group data.
 func groupsKey(id types.DeploymentID) []byte {
 	buf := bytes.NewBuffer(groupPrefix)
+	buf.Write(id.Owner.Bytes())
+	binary.Write(buf, binary.BigEndian, id.DSeq)
+	return buf.Bytes()
+}
+
+// groupsOpenKey provides store key for Groups in state open.
+// Key is culled from the store once the Group is no longer in state Open.
+// Uses the groupOpenPrefix byte.
+func groupsOpenKey(id types.DeploymentID) []byte {
+	buf := bytes.NewBuffer(groupOpenPrefix)
 	buf.Write(id.Owner.Bytes())
 	binary.Write(buf, binary.BigEndian, id.DSeq)
 	return buf.Bytes()

--- a/x/deployment/keeper/key_test.go
+++ b/x/deployment/keeper/key_test.go
@@ -1,0 +1,29 @@
+package keeper
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupKeyConversion(t *testing.T) {
+	d := testutil.Deployment(t)
+	g := testutil.DeploymentGroup(t, d.ID(), uint32(0))
+
+	dataKey := groupKey(g.ID())
+	openKey := groupOpenKey(g.ID())
+
+	assert.NotEqual(t, dataKey, openKey)
+
+	convertedKey, err := groupOpenKeyConvert(openKey)
+	require.NoError(t, err)
+	assert.Equal(t, dataKey, convertedKey)
+
+	t.Run("open-group set for org key", func(t *testing.T) {
+		groupSetKey := groupsOpenKey(g.ID().DeploymentID())
+		assert.True(t, strings.Contains(string(openKey), string(groupSetKey)))
+	})
+}


### PR DESCRIPTION
To improve the performance of the `deployment` module's EndBlock method.
This PR creates a second prefix key in `x/deployment/keeper` to
facilitate tracking the newly created Group's in the 0x03 prefix.

This change short circuits the need for tracking Active Deployments
which @boz identified on the [prior
PR](https://github.com/ovrclk/akash/pull/723#pullrequestreview-441824680).

Tests indicate things are working correctly. However that's one area I'd
like which could probably use more development/abuse.

refs: #604
