### PR TITLE
fix: reject provider messages with duplicated attributes

### DIFF
--- a/x/provider/handler/handler.go
+++ b/x/provider/handler/handler.go
@@ -37,6 +37,10 @@ func handleMsgCreate(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCreateP
 		return nil, errors.Wrapf(types.ErrProviderExists, "id: %s", msg.Owner)
 	}
 
+	if err := msg.Attributes.Validate(); err != nil {
+		return nil, err
+	}
+
 	if err := keeper.Create(ctx, types.Provider(msg)); err != nil {
 		return nil, sdkerrors.Wrapf(ErrInternal, "err: %v", err)
 	}
@@ -50,6 +54,10 @@ func handleMsgUpdate(ctx sdk.Context, keeper keeper.Keeper, mkeeper mkeeper.Keep
 	prov, found := keeper.Get(ctx, msg.Owner)
 	if !found {
 		return nil, errors.Wrapf(types.ErrProviderNotFound, "id: %s", msg.Owner)
+	}
+
+	if err := msg.Attributes.Validate(); err != nil {
+		return nil, err
 	}
 
 	var err error

--- a/x/provider/handler/handler_test.go
+++ b/x/provider/handler/handler_test.go
@@ -92,6 +92,47 @@ func TestProviderCreate(t *testing.T) {
 	require.True(t, errors.Is(err, types.ErrProviderExists))
 }
 
+func TestProviderCreateWithDuplicated(t *testing.T) {
+	suite := setupTestSuite(t)
+
+	msg := types.MsgCreateProvider{
+		Owner:      testutil.AccAddress(t),
+		HostURI:    testutil.Hostname(t),
+		Attributes: testutil.Attributes(t),
+	}
+
+	msg.Attributes = append(msg.Attributes, msg.Attributes[0])
+
+	res, err := suite.handler(suite.ctx, msg)
+	require.Nil(t, res)
+	require.EqualError(t, err, types.ErrDuplicateAttributes.Error())
+}
+
+func TestProviderUpdateWithDuplicated(t *testing.T) {
+	suite := setupTestSuite(t)
+
+	createMsg := types.MsgCreateProvider{
+		Owner:      testutil.AccAddress(t),
+		HostURI:    testutil.Hostname(t),
+		Attributes: testutil.Attributes(t),
+	}
+
+	updateMsg := types.MsgUpdateProvider{
+		Owner:      createMsg.Owner,
+		HostURI:    testutil.Hostname(t),
+		Attributes: createMsg.Attributes,
+	}
+
+	updateMsg.Attributes = append(updateMsg.Attributes, updateMsg.Attributes[0])
+
+	err := suite.keeper.Create(suite.ctx, types.Provider(createMsg))
+	require.NoError(t, err)
+
+	res, err := suite.handler(suite.ctx, updateMsg)
+	require.Nil(t, res)
+	require.EqualError(t, err, types.ErrDuplicateAttributes.Error())
+}
+
 func TestProviderUpdateExisting(t *testing.T) {
 	suite := setupTestSuite(t)
 

--- a/x/provider/types/errors.go
+++ b/x/provider/types/errors.go
@@ -12,6 +12,7 @@ const (
 	errInvalidAddress
 	errAttributes
 	errIncompatibleAttributes
+	errDuplicateAttributes
 )
 
 var (
@@ -35,4 +36,7 @@ var (
 
 	// ErrIncompatibleAttributes error code for attributes update
 	ErrIncompatibleAttributes = sdkerrors.Register(ModuleName, errIncompatibleAttributes, "attributes cannot be changed")
+
+	// ErrDuplicateAttributes duplicates are prohibited
+	ErrDuplicateAttributes = sdkerrors.Register(ModuleName, errDuplicateAttributes, "attributes cannot have duplicates")
 )

--- a/x/provider/types/types.go
+++ b/x/provider/types/types.go
@@ -4,9 +4,25 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+type Attributes []sdk.Attribute
+
 // Provider stores owner and host details
 type Provider struct {
-	Owner      sdk.AccAddress  `json:"owner"`
-	HostURI    string          `json:"host-uri"`
-	Attributes []sdk.Attribute `json:"attributes"`
+	Owner      sdk.AccAddress `json:"owner"`
+	HostURI    string         `json:"host-uri"`
+	Attributes Attributes     `json:"attributes"`
+}
+
+func (attr Attributes) Validate() error {
+	store := make(map[string]bool)
+
+	for i := range attr {
+		if _, ok := store[attr[i].Key]; ok {
+			return ErrDuplicateAttributes
+		}
+
+		store[attr[i].Key] = true
+	}
+
+	return nil
 }


### PR DESCRIPTION
fixes #728
