### PR TITLE
feat:604 Active Lease indexing

### DIFF
--- a/x/deployment/keeper/key.go
+++ b/x/deployment/keeper/key.go
@@ -45,7 +45,7 @@ func groupOpenKey(id types.GroupID) []byte {
 // group key prefix for accessing the Group's data.
 func groupOpenKeyConvert(openKey []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(groupPrefix)
-	_, err := buf.Write(openKey[1:])
+	_, err := buf.Write(openKey[len(groupPrefix):])
 	if err != nil {
 		return nil, err
 	}

--- a/x/market/handler/endblock.go
+++ b/x/market/handler/endblock.go
@@ -22,14 +22,9 @@ func OnEndBlock(ctx sdk.Context, keepers Keepers) error {
 }
 
 func transferFundsForActiveLeases(ctx sdk.Context, keepers Keepers) error {
-
 	// for all active leases, transfer funds
 	count := 0
-	keepers.Market.WithLeases(ctx, func(lease types.Lease) bool {
-
-		if lease.State != types.LeaseActive {
-			return false
-		}
+	keepers.Market.WithActiveLeases(ctx, func(lease types.Lease) bool {
 
 		amt := sdk.NewCoins(lease.Price)
 

--- a/x/market/keeper/keeper_test.go
+++ b/x/market/keeper/keeper_test.go
@@ -152,6 +152,18 @@ func Test_WithLeases(t *testing.T) {
 		return false
 	})
 	assert.Equal(t, 1, count)
+
+	t.Run("active-count", func(t *testing.T) {
+		activeCount := 0
+		keeper.WithActiveLeases(ctx, func(result types.Lease) bool {
+			if assert.Equal(t, id, result.ID()) {
+				activeCount++
+			}
+			return false
+		})
+
+		assert.Equal(t, 1, activeCount)
+	})
 }
 
 func Test_LeaseForOrder(t *testing.T) {

--- a/x/market/keeper/key.go
+++ b/x/market/keeper/key.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	orderPrefix = []byte{0x01, 0x00}
-	bidPrefix   = []byte{0x02, 0x00}
-	leasePrefix = []byte{0x03, 0x00}
+	orderPrefix       = []byte{0x01, 0x00}
+	bidPrefix         = []byte{0x02, 0x00}
+	leasePrefix       = []byte{0x03, 0x00}
+	leaseActivePrefix = []byte{0x03, 0x01}
 )
 
 func orderKey(id types.OrderID) []byte {
@@ -41,6 +42,25 @@ func leaseKey(id types.LeaseID) []byte {
 	binary.Write(buf, binary.BigEndian, id.OSeq)
 	buf.Write(id.Provider.Bytes())
 	return buf.Bytes()
+}
+
+func leaseKeyActive(id types.LeaseID) []byte {
+	buf := bytes.NewBuffer(leaseActivePrefix)
+	buf.Write(id.Owner.Bytes())
+	binary.Write(buf, binary.BigEndian, id.DSeq)
+	binary.Write(buf, binary.BigEndian, id.GSeq)
+	binary.Write(buf, binary.BigEndian, id.OSeq)
+	buf.Write(id.Provider.Bytes())
+	return buf.Bytes()
+}
+
+func convertLeaseActiveKey(activeKey []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(leasePrefix)
+	_, err := buf.Write(activeKey[len(leaseActivePrefix):])
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func ordersForGroupPrefix(id dtypes.GroupID) []byte {

--- a/x/market/keeper/key_test.go
+++ b/x/market/keeper/key_test.go
@@ -1,0 +1,21 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/ovrclk/akash/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveLeaseKeys(t *testing.T) {
+	lease := testutil.LeaseID(t)
+	key := leaseKey(lease)
+	activeKey := leaseKeyActive(lease)
+	assert.NotEqual(t, key, activeKey)
+
+	t.Run("assert converted active lease key matches data key", func(t *testing.T) {
+		convertedActiveKey, err := convertLeaseActiveKey(activeKey)
+		assert.NoError(t, err)
+		assert.Equal(t, convertedActiveKey, key)
+	})
+}


### PR DESCRIPTION
Equivalent to the [Open Group indexing](https://github.com/ovrclk/akash/pull/729) queries.

Creates a second index in the `market` module which does not store data,
only tracks active Leases. Once a lease is moved out of active state the
key is removed from the index.

Testing improvement is not significant, mostly depending on existing
tests. More will come down with the Open Bids index.

refs: #604