### PR TITLE
feat:727 Friendly stringer of Block ID types

### DIFF
--- a/sdkutil/event.go
+++ b/sdkutil/event.go
@@ -1,10 +1,10 @@
 package sdkutil
 
 import (
-	"errors"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -23,6 +23,10 @@ var (
 	ErrUnknownModule = errors.New("Unknown module")
 	// ErrUnknownAction is the error with message "Unknown action"
 	ErrUnknownAction = errors.New("Unknown action")
+	// ErrParsingBlockID indicates one of the uint parsers failed to convert a value.
+	ErrParsingBlockID = errors.New("error parsing block id values")
+	// ErrInvalidParseBlockIDInput indicates the splitting of block path failed.
+	ErrInvalidParseBlockIDInput = errors.New("error parsing block id input string")
 )
 
 type BaseModuleEvent struct {

--- a/sdkutil/object_id.go
+++ b/sdkutil/object_id.go
@@ -1,0 +1,182 @@
+package sdkutil
+
+import (
+	"path"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	blockIDOwnerPosition   = 0
+	blockIDDSeqPosition    = 1
+	blockIDGSeqPosition    = 2
+	blockIDOSeqPosition    = 3
+	blockIDProviderPostion = 4
+)
+
+// BlockID provides type to properly format print blockchain ID types.
+type BlockID struct {
+	Owner    *sdk.AccAddress
+	DSeq     *uint64
+	GSeq     *uint32
+	OSeq     *uint32
+	Provider *sdk.AccAddress
+}
+
+// NewBlockID initializes the BlockID struct, passing nil values is acceptable
+// for fields which are not used.
+func NewBlockID(owner *sdk.AccAddress, dseq *uint64, gseq *uint32, oseq *uint32, provider *sdk.AccAddress) BlockID {
+	return BlockID{
+		Owner:    owner,
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider,
+	}
+}
+
+// String method provides the full formating of all the BlockID fields which are not nil.
+// Format: [Owner AccAddress]/[DSeq]/[GSeq]/[OSeq]/[Provider AccAddress]
+// eg: akash1vgv30hr8lel8r7270wywmak5c82es3njws3u4z/795423625/1/1/akash1pxqksfr60zc6uadht6300uavwl3s58ct0apt9w
+func (b BlockID) String() string {
+	parts := make([]string, 0)
+	if b.Owner != nil {
+		parts = append(parts, b.Owner.String())
+	}
+	if b.DSeq != nil {
+		parts = append(parts, strconv.FormatUint(*b.DSeq, 10))
+	}
+	if b.GSeq != nil {
+		parts = append(parts, strconv.FormatUint(uint64(*b.GSeq), 10))
+	}
+	if b.OSeq != nil {
+		parts = append(parts, strconv.FormatUint(uint64(*b.OSeq), 10))
+	}
+	if b.Provider != nil {
+		parts = append(parts, b.Provider.String())
+	}
+	return path.Join(parts...)
+}
+
+// ReflectBlockID accepts an ID struct and unpacks the block identifying fields.
+// Useful for passing *ID types and getting consistent output based on the consistent
+// field names.
+func ReflectBlockID(id interface{}) *BlockID {
+	b := BlockID{}
+
+	val := reflect.ValueOf(id)
+	typeOfID := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		switch typeOfID.Field(i).Name {
+		case "Owner":
+			if field.Type() == reflect.TypeOf(sdk.AccAddress{}) {
+				x, ok := field.Interface().(sdk.AccAddress)
+				if ok && len(x) == sdk.AddrLen {
+					b.Owner = &x
+				}
+			}
+		case "DSeq":
+			if field.Type() == reflect.TypeOf(uint64(0)) {
+				x, ok := field.Interface().(uint64)
+				if ok {
+					b.DSeq = &x
+				}
+			}
+		case "GSeq":
+			if field.Type() == reflect.TypeOf(uint32(0)) {
+				x, ok := field.Interface().(uint32)
+				if ok {
+					b.GSeq = &x
+				}
+			}
+		case "OSeq":
+			if field.Type() == reflect.TypeOf(uint32(0)) {
+				x, ok := field.Interface().(uint32)
+				if ok {
+					b.OSeq = &x
+				}
+			}
+		case "Provider":
+			if field.Type() == reflect.TypeOf(sdk.AccAddress{}) {
+				x, ok := field.Interface().(sdk.AccAddress)
+				if ok && len(x) == sdk.AddrLen {
+					b.Provider = &x
+				}
+			}
+		default:
+			// Skip this field
+		}
+	}
+	return &b
+}
+
+// FmtBlockID provides a human readable representation of the block chain ID fields.
+func FmtBlockID(owner *sdk.AccAddress, dseq *uint64, gseq *uint32, oseq *uint32, provider *sdk.AccAddress) string {
+	return BlockID{
+		Owner:    owner,
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider,
+	}.String()
+}
+
+// ParseBlockID returns the values from a human readable ID string.
+func ParseBlockID(id string) (*BlockID, error) {
+	b := &BlockID{}
+
+	parts := strings.Split(id, string(filepath.Separator))
+	if len(parts) < 2 {
+		return nil, ErrInvalidParseBlockIDInput
+	}
+
+	// Owner Address field always expected
+	aa, err := sdk.AccAddressFromBech32(parts[blockIDOwnerPosition])
+	if err != nil {
+		return nil, errors.Wrap(ErrParsingBlockID, err.Error())
+	} else if len(aa) > 0 {
+		b.Owner = &aa
+	}
+
+	if len(parts) > blockIDDSeqPosition { // DSeq
+		dseq, err := strconv.ParseUint(parts[blockIDDSeqPosition], 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(ErrParsingBlockID, err.Error())
+		}
+		b.DSeq = &dseq
+	}
+
+	if len(parts) > blockIDGSeqPosition { // GSeq
+		gseq, err := strconv.ParseUint(parts[2], 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(ErrParsingBlockID, err.Error())
+		}
+		x := uint32(gseq)
+		b.GSeq = &x
+	}
+
+	if len(parts) > blockIDOSeqPosition { // OSeq
+		oseq, err := strconv.ParseUint(parts[3], 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(ErrParsingBlockID, err.Error())
+		}
+		x := uint32(oseq)
+		b.OSeq = &x
+	}
+
+	if len(parts) > blockIDProviderPostion { // Provider
+		pa, err := sdk.AccAddressFromBech32(parts[4])
+		if err != nil {
+			return nil, errors.Wrap(ErrParsingBlockID, err.Error())
+		}
+		b.Provider = &pa
+	}
+	return b, nil
+}

--- a/sdkutil/object_id_test.go
+++ b/sdkutil/object_id_test.go
@@ -1,0 +1,247 @@
+package sdkutil_test
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ovrclk/akash/sdkutil"
+	"github.com/ovrclk/akash/testutil"
+)
+
+const akashHexLen = 20
+const akashBech32Len = 44
+
+func TestBlockIDStringer(t *testing.T) {
+	hexRaw := "3ff68b134903fecb027c97bd05a1e3d54f05fcfc"
+	buf, err := hex.DecodeString(hexRaw)
+	acc := sdk.AccAddress(buf)
+	assert.NoError(t, err)
+	d, g, o := uint64(10), uint32(0), uint32(0)
+	x := sdkutil.FmtBlockID(&acc, &d, &g, &o, nil)
+	assert.Equal(t, x, "akash18lmgky6fq0lvkqnuj77stg0r648stl8ucf0m2z/10/0/0")
+
+	//neh := "211E4C7BB9D12D57E10BE88EB8EE8351031BF14B"
+	hexRaw = "a46e1186d64c2e523573bdad70a5832095abdc21"
+	buf, err = hex.DecodeString(hexRaw)
+	acc = sdk.AccAddress(buf)
+	assert.NoError(t, err)
+	x = sdkutil.FmtBlockID(&acc, &d, &g, &o, nil)
+	assert.Equal(t, x, "akash153hprpkkfsh9ydtnhkkhpfvryz26hhpp67e97k/10/0/0")
+
+	addr := testutil.AccAddress(t)
+	dseq := uint64(10)
+	gseq := uint32(5)
+	oseq := uint32(3)
+	provider := testutil.AccAddress(t)
+	fmtStr := sdkutil.FmtBlockID(&addr, &dseq, &gseq, &oseq, &provider)
+
+	b, err := sdkutil.ParseBlockID(fmtStr)
+	t.Run("parse formatted string", func(t *testing.T) {
+		assert.NoError(t, err)
+		assert.Equal(t, addr, *b.Owner)
+		assert.Equal(t, dseq, *b.DSeq)
+		assert.Equal(t, gseq, *b.GSeq)
+		assert.Equal(t, oseq, *b.OSeq)
+		assert.Equal(t, provider, *b.Provider)
+	})
+
+	newBlock := sdkutil.NewBlockID(
+		b.Owner,
+		b.DSeq,
+		b.GSeq,
+		b.OSeq,
+		b.Provider)
+	t.Run("compare block IDs", func(t *testing.T) {
+		assert.NoError(t, err)
+		assert.Equal(t, *newBlock.Owner, *b.Owner)
+		assert.Equal(t, *newBlock.DSeq, *b.DSeq)
+		assert.Equal(t, *newBlock.GSeq, *b.GSeq)
+		assert.Equal(t, *newBlock.OSeq, *b.OSeq)
+		assert.Equal(t, *newBlock.Provider, *b.Provider)
+
+	})
+}
+
+func TestErrorCases(t *testing.T) {
+	type errCase struct {
+		desc        string
+		errParseStr string
+		expErrIs    error
+	}
+	//full := "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/1478600512/2170091657/2036973947/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er"
+	tests := []errCase{
+		{
+			desc:        "error parsing empty values",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/",
+		},
+		{
+			desc:        "error parsing bad owner",
+			errParseStr: "hihi",
+			expErrIs:    sdkutil.ErrInvalidParseBlockIDInput,
+		},
+		{
+			desc:        "error parsing bad owner field",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp8xxx/1478600512/2170091657/2036973947/akash18u664a4m558u79vecdne93fwd80nhfgd9svxxx",
+		},
+		{
+			desc:        "error parsing owner string size",
+			errParseStr: "akash19jeunqhqy04wj5e3/1478600512/2170091657/2036973947/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er",
+		},
+		{
+			desc:        "error parsing dseq",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/14786005x/2157/20369/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er",
+		},
+		{
+			desc:        "error parsing empty dseq value",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d//2157/20369/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er",
+		},
+		{
+			desc:        "error parsing gseq",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/147860/2157x/2/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er",
+		},
+		{
+			desc:        "error parsing oseq",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/1478600512/2170091657/xxx/akash18u664a4m558u79vecdne93fwd80nhfgd9sv4er",
+		},
+		{
+			desc:        "error parsing provider",
+			errParseStr: "akash19jeunqhqy04wj5ee2t3kq2l6uee53fqkmp878d/1478600512/2170091657/2036973947/akash18u664a4m558u79vecdne93fwd80nhfgd9svxxx",
+		},
+	}
+
+	for _, test := range tests {
+		t.Log(test.desc)
+		b, err := sdkutil.ParseBlockID(test.errParseStr)
+		assert.Nil(t, b)
+		assert.Error(t, err)
+		if test.expErrIs != nil {
+			if !errors.Is(err, test.expErrIs) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}
+	}
+}
+
+func TestBidID(t *testing.T) {
+	bid := testutil.BidID(t)
+	block := sdkutil.ReflectBlockID(bid)
+
+	str := block.String()
+	block, err := sdkutil.ParseBlockID(str)
+	assert.NoError(t, err)
+
+	assert.Equal(t, bid.Owner, *block.Owner)
+	assert.Equal(t, bid.DSeq, *block.DSeq)
+	assert.Equal(t, bid.GSeq, *block.GSeq)
+	assert.Equal(t, bid.OSeq, *block.OSeq)
+	assert.Equal(t, bid.Provider, *block.Provider)
+}
+
+func TestGroupIDString(t *testing.T) {
+	gid := testutil.GroupID(t)
+	str := gid.String()
+
+	split := strings.Split(str, "/")
+	if len(split) != 3 {
+		t.Error("expected returned path have three elements")
+	}
+}
+
+func TestBlockReflectionID(t *testing.T) {
+	t.Run("deployment-id", func(t *testing.T) {
+		id := testutil.DeploymentID(t)
+		block := sdkutil.ReflectBlockID(id)
+
+		assert.Equal(t, id.Owner, *block.Owner)
+		assert.Equal(t, id.DSeq, *block.DSeq)
+
+		pb, err := sdkutil.ParseBlockID(block.String())
+		assert.NoError(t, err)
+		assert.Equal(t, id.Owner, *pb.Owner)
+		assert.Equal(t, id.DSeq, *pb.DSeq)
+	})
+
+	t.Run("group-id", func(t *testing.T) {
+		id := testutil.GroupID(t)
+		block := sdkutil.ReflectBlockID(id)
+
+		assert.Equal(t, id.Owner, *block.Owner)
+		assert.Equal(t, id.DSeq, *block.DSeq)
+		assert.Equal(t, id.GSeq, *block.GSeq)
+
+		pb, err := sdkutil.ParseBlockID(block.String())
+		assert.NoError(t, err)
+		assert.Equal(t, id.Owner, *pb.Owner)
+		assert.Equal(t, id.DSeq, *pb.DSeq)
+		assert.Equal(t, id.GSeq, *pb.GSeq)
+	})
+
+	t.Run("order-id", func(t *testing.T) {
+		id := testutil.OrderID(t)
+		block := sdkutil.ReflectBlockID(id)
+
+		assert.Equal(t, id.Owner, *block.Owner)
+		assert.Equal(t, id.DSeq, *block.DSeq)
+		assert.Equal(t, id.GSeq, *block.GSeq)
+		assert.Equal(t, id.OSeq, *block.OSeq)
+
+		pb, err := sdkutil.ParseBlockID(block.String())
+		assert.NoError(t, err)
+		assert.Equal(t, id.Owner, *pb.Owner)
+		assert.Equal(t, id.DSeq, *pb.DSeq)
+		assert.Equal(t, id.GSeq, *pb.GSeq)
+		assert.Equal(t, id.OSeq, *pb.OSeq)
+	})
+
+	t.Run("lease-id", func(t *testing.T) {
+		id := testutil.LeaseID(t)
+		block := sdkutil.ReflectBlockID(id)
+
+		assert.Equal(t, id.Owner, *block.Owner)
+		assert.Equal(t, id.DSeq, *block.DSeq)
+		assert.Equal(t, id.GSeq, *block.GSeq)
+		assert.Equal(t, id.OSeq, *block.OSeq)
+		assert.Equal(t, id.Provider, *block.Provider)
+
+		pb, err := sdkutil.ParseBlockID(block.String())
+		assert.NoError(t, err)
+		assert.Equal(t, id.Owner, *pb.Owner)
+		assert.Equal(t, id.DSeq, *pb.DSeq)
+		assert.Equal(t, id.GSeq, *pb.GSeq)
+		assert.Equal(t, id.OSeq, *pb.OSeq)
+		assert.Equal(t, id.Provider, *pb.Provider)
+	})
+
+	t.Run("bid-id", func(t *testing.T) {
+		id := testutil.BidID(t)
+		block := sdkutil.ReflectBlockID(id)
+
+		assert.Equal(t, id.Owner, *block.Owner)
+		assert.Equal(t, id.DSeq, *block.DSeq)
+		assert.Equal(t, id.GSeq, *block.GSeq)
+		assert.Equal(t, id.OSeq, *block.OSeq)
+		assert.Equal(t, id.Provider, *block.Provider)
+
+		pb, err := sdkutil.ParseBlockID(block.String())
+		assert.NoError(t, err)
+		assert.Equal(t, id.Owner, *pb.Owner)
+		assert.Equal(t, id.DSeq, *pb.DSeq)
+		assert.Equal(t, id.GSeq, *pb.GSeq)
+		assert.Equal(t, id.OSeq, *pb.OSeq)
+		assert.Equal(t, id.Provider, *pb.Provider)
+	})
+}
+
+func TestAddressLengths(t *testing.T) {
+	x := "akash1ncagkrcvqw0nn4jee5j5efl0ylguka2v36t7t7"
+	assert.Len(t, x, akashBech32Len)
+
+	y := testutil.AccAddress(t)
+	assert.Len(t, y, akashHexLen)
+}

--- a/sdkutil/query.go
+++ b/sdkutil/query.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	// ErrCouldNotRenderObject indicates response rendering error.
 	ErrCouldNotRenderObject = sdkerrors.New("sdkutil", 1, "could not render object")
 )
 

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -11,6 +11,12 @@ import (
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 )
 
+func init() {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(CoinDenom, CoinDenom)
+	config.Seal()
+}
+
 // CoinDenom provides ability to create coins in test functions and
 // pass them into testutil functionality.
 const CoinDenom = "akash"

--- a/x/deployment/types/id.go
+++ b/x/deployment/types/id.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ovrclk/akash/sdkutil"
 )
 
 // DeploymentID stores owner and sequence number
@@ -26,6 +27,11 @@ func (id DeploymentID) Validate() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "DeploymentID: Invalid Deployment Sequence")
 	}
 	return nil
+}
+
+// String method for deployment IDs
+func (id DeploymentID) String() string {
+	return sdkutil.FmtBlockID(&id.Owner, &id.DSeq, nil, nil, nil)
 }
 
 // GroupID stores owner, deployment sequence number and group sequence number
@@ -67,4 +73,9 @@ func (id GroupID) Validate() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "GroupID: Invalid Group Sequence")
 	}
 	return nil
+}
+
+// String method provides human readable representation of GroupID.
+func (id GroupID) String() string {
+	return sdkutil.FmtBlockID(&id.Owner, &id.DSeq, &id.GSeq, nil, nil)
 }

--- a/x/market/types/id.go
+++ b/x/market/types/id.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ovrclk/akash/sdkutil"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 )
 
@@ -51,6 +52,11 @@ func (id OrderID) Validate() error {
 	return nil
 }
 
+// String provides stringer interface to save reflected formatting.
+func (id OrderID) String() string {
+	return sdkutil.FmtBlockID(&id.Owner, &id.DSeq, &id.GSeq, &id.OSeq, nil)
+}
+
 // BidID stores owner, provider and all other seq numbers.
 // A successful bid becomes a Lease(ID).
 type BidID struct {
@@ -91,6 +97,11 @@ func (id BidID) OrderID() OrderID {
 		GSeq:  id.GSeq,
 		OSeq:  id.OSeq,
 	}
+}
+
+// String method for consistent output.
+func (id BidID) String() string {
+	return sdkutil.FmtBlockID(&id.Owner, &id.DSeq, &id.GSeq, &id.OSeq, nil)
 }
 
 // OrderIDString provides consistent conversion to string values for OrderID.
@@ -169,4 +180,9 @@ func (id LeaseID) GroupID() dtypes.GroupID {
 // DeploymentID method returns deployment details with specific lease details
 func (id LeaseID) DeploymentID() dtypes.DeploymentID {
 	return id.GroupID().DeploymentID()
+}
+
+// String method provides human readable representation of LeaseID.
+func (id LeaseID) String() string {
+	return sdkutil.FmtBlockID(&id.Owner, &id.DSeq, &id.GSeq, &id.OSeq, &id.Provider)
 }

--- a/x/provider/handler/handler.go
+++ b/x/provider/handler/handler.go
@@ -63,6 +63,7 @@ func handleMsgUpdate(ctx sdk.Context, keeper keeper.Keeper, mkeeper mkeeper.Keep
 	var err error
 
 	// all filtering code below is madness!. should make an index to not melt the cpu
+	// TODO: use WithActiveLeases, filter by lease.Provider
 	mkeeper.WithLeases(ctx, func(lease mtypes.Lease) bool {
 		if prov.Owner.Equals(lease.Provider) && (lease.State == mtypes.LeaseActive) {
 			var order mtypes.Order


### PR DESCRIPTION
Provide pretty printer for Block address types with AccAddress, DSeq,
GSeq, and OSeq fields which will be printed to logs and command
responses.

`sdkutil` package provides helper methods to format and parse values
from the human readable format.

```
Format: [Owner AccAddress]/[DSeq]/[GSeq]/[OSeq]/[Provider AccAddress]
eg: akash1vgv30hr8lel8r7270wywmak5c82es3njws3u4z/795423625/1/1/akash1pxqksfr60zc6uadht6300uavwl3s58ct0apt9w
```

fixes: #727