### PR TITLE
Command to listen for lease creation and send manifest automatically

### DIFF
--- a/cmd/akashctl/main.go
+++ b/cmd/akashctl/main.go
@@ -53,7 +53,7 @@ func main() {
 		txCmd(cdc),
 		lcd.ServeCommand(cdc, lcdRoutes),
 		keys.Commands(),
-		flags.PostCommands(deploy.CMD(cdc))[0],
+		deploy.CMD(cdc),
 		version.Cmd,
 		flags.NewCompletionCmd(root, true),
 	)

--- a/cmd/akashctl/main.go
+++ b/cmd/akashctl/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ovrclk/akash/app"
 	"github.com/ovrclk/akash/cmd/common"
+	"github.com/ovrclk/akash/deploy"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/go-amino"
@@ -52,6 +53,7 @@ func main() {
 		txCmd(cdc),
 		lcd.ServeCommand(cdc, lcdRoutes),
 		keys.Commands(),
+		flags.PostCommands(deploy.CMD(cdc))[0],
 		version.Cmd,
 		flags.NewCompletionCmd(root, true),
 	)

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -128,7 +128,7 @@ func CMD(cdc *codec.Codec) *cobra.Command {
 								return err
 							}
 
-							if leases = leases - 1; leases == 0 {
+							if leases--; leases == 0 {
 								fmt.Printf("Leases left %d...\n", leases)
 								sub.Close()
 								cancel()

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -1,0 +1,157 @@
+package deploy
+
+import (
+	ccontext "context"
+	"fmt"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/ovrclk/akash/events"
+	"github.com/ovrclk/akash/provider/gateway"
+	"github.com/ovrclk/akash/provider/manifest"
+	"github.com/ovrclk/akash/pubsub"
+	"github.com/ovrclk/akash/sdl"
+	dclient "github.com/ovrclk/akash/x/deployment/client/cli"
+	"github.com/ovrclk/akash/x/deployment/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	pmodule "github.com/ovrclk/akash/x/provider"
+)
+
+// CMD returns the command for deploy
+func CMD(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy [sdl-file]",
+		Short: fmt.Sprintf("Create a deployment, listen for order clearing and ensure provider has manifest"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Setup CLI context and transaction builder
+			ctx := context.NewCLIContext().WithCodec(cdc)
+			bldr := auth.NewTxBuilderFromCLI(os.Stdin).WithTxEncoder(utils.GetTxEncoder(cdc))
+			if err := ctx.Client.Start(); err != nil {
+				return err
+			}
+
+			// Read in manifest file
+			sdl, err := sdl.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Fetch deployment groups from the SDL file, each group maps to an individual order
+			groups, err := sdl.DeploymentGroups()
+			if err != nil {
+				return err
+			}
+
+			// Fetch the manifest from the SDL file
+			mani, err := sdl.Manifest()
+			if err != nil {
+				return err
+			}
+
+			// Get the deployment ID (defaults to height)
+			id, err := dclient.DeploymentIDFromFlags(cmd.Flags(), ctx.GetFromAddress().String())
+			if err != nil {
+				return err
+			}
+
+			// Default DSeq to the current block height
+			if id.DSeq == 0 {
+				if id.DSeq, err = dclient.CurrentBlockHeight(ctx); err != nil {
+					return err
+				}
+			}
+
+			// create a new pubsub bus to handle chain events
+			bus := pubsub.NewBus()
+			defer bus.Close()
+
+			// Create an error group to handle chain listener
+			group, cctx := errgroup.WithContext(ccontext.Background())
+			cctx, cancel := ccontext.WithCancel(cctx)
+
+			// Listen to the events on chain and publish them to the pubsub bus
+			group.Go(func() error {
+				return events.Publish(cctx, ctx.Client, "deployment-create", bus)
+			})
+
+			// expose event channel
+			sub, err := bus.Subscribe()
+			if err != nil {
+				return err
+			}
+
+			// start goroutine to listen for events
+			leases := len(groups)
+			group.Go(func() error {
+				for {
+					select {
+					case <-sub.Done():
+						return nil
+					case ev := <-sub.Events():
+						switch msg := ev.(type) {
+						case types.EventDeploymentCreated:
+							fmt.Printf("Deployment %d created...\n", msg.ID.DSeq)
+						case mtypes.EventOrderCreated:
+							fmt.Printf("Order %d for deployement %d created...\n", msg.ID.OSeq, msg.ID.DSeq)
+						case mtypes.EventBidCreated:
+							fmt.Printf("Bid of %s for order %d:%d created...\n", msg.Price, msg.ID.DSeq, msg.ID.OSeq)
+						case mtypes.EventLeaseCreated:
+							fmt.Printf("Lease for order %d:%d created...\n", msg.ID.DSeq, msg.ID.OSeq)
+							pclient := pmodule.AppModuleBasic{}.GetQueryClient(ctx)
+							provider, err := pclient.Provider(msg.ID.Provider)
+							if err != nil {
+								return err
+							}
+
+							gclient := gateway.NewClient()
+
+							fmt.Printf("Sending manifest to provider %s...\n", msg.ID.Provider)
+							if err = gclient.SubmitManifest(
+								ccontext.Background(),
+								provider.HostURI,
+								&manifest.SubmitRequest{
+									Deployment: msg.ID.DeploymentID(),
+									Manifest:   mani,
+								},
+							); err != nil {
+								return err
+							}
+
+							if leases = leases - 1; leases == 0 {
+								fmt.Printf("Leases left %d...\n", leases)
+								sub.Close()
+								cancel()
+								return nil
+							}
+						}
+					}
+				}
+			})
+
+			msg := types.NewMsgCreateDeployment(id, groups)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			// broadcast the message
+			// TODO: set transaction broadcast defaults on the ctx to ensure
+			// that GenerateOrBroadcastMsgs exits when tx is sent to chain
+			if err = utils.GenerateOrBroadcastMsgs(ctx, bldr, []sdk.Msg{msg}); err != nil {
+				return err
+			}
+
+			return group.Wait()
+		},
+	}
+	dclient.AddDeploymentIDFlags(cmd.Flags())
+
+	return cmd
+}

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	ccontext "context"
 	"fmt"
 	"os"
 
@@ -8,12 +9,19 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/ovrclk/akash/events"
+	"github.com/ovrclk/akash/provider/gateway"
+	"github.com/ovrclk/akash/provider/manifest"
+	"github.com/ovrclk/akash/pubsub"
 	"github.com/ovrclk/akash/sdl"
 	"github.com/ovrclk/akash/x/deployment/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	pmodule "github.com/ovrclk/akash/x/provider"
 
 	"github.com/spf13/cobra"
 )
@@ -32,7 +40,146 @@ func GetTxCmd(key string, cdc *codec.Codec) *cobra.Command {
 		cmdUpdate(key, cdc),
 		cmdClose(key, cdc),
 		cmdGroupClose(key, cdc),
+		makeItSoCommand(key, cdc),
 	)...)
+	return cmd
+}
+
+func makeItSoCommand(key string, cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "make-it-so [sdl-file]",
+		Short: fmt.Sprintf("Create %s", key),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Setup CLI context and transaction builder
+			ctx := context.NewCLIContext().WithCodec(cdc)
+			bldr := auth.NewTxBuilderFromCLI(os.Stdin).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			// Read in manifest file
+			sdl, err := sdl.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Fetch deployment groups from the SDL file, each group maps to an individual order
+			groups, err := sdl.DeploymentGroups()
+			if err != nil {
+				return err
+			}
+
+			// Fetch the manifest from the SDL file
+			mani, err := sdl.Manifest()
+			if err != nil {
+				return err
+			}
+
+			// Get the deployment ID (defaults to height)
+			id, err := DeploymentIDFromFlags(cmd.Flags(), ctx.GetFromAddress().String())
+			if err != nil {
+				return err
+			}
+
+			// Default DSeq to the current block height
+			if id.DSeq == 0 {
+				if id.DSeq, err = currentBlockHeight(ctx); err != nil {
+					return err
+				}
+			}
+
+			// create a new pubsub bus to handle chain events
+			bus := pubsub.NewBus()
+			defer bus.Close()
+
+			// Create an error group to handle chain listener
+			group, cctx := errgroup.WithContext(ccontext.Background())
+
+			group.Go(func() error {
+				// Listen to the events on chain and publish them to the pubsub bus
+				return events.Publish(cctx, ctx.Client, "deployment-create", bus)
+			})
+
+			// expose event channel
+			sub, err := bus.Subscribe()
+			if err != nil {
+				return err
+			}
+
+			// start goroutine to listen for events
+			leases := len(groups)
+			group.Go(func() error {
+				fmt.Println("Starting event listener")
+				for {
+					select {
+					case <-sub.Done():
+						return nil
+					case ev := <-sub.Events():
+						fmt.Println("getting event")
+						switch msg := ev.(type) {
+						case types.EventDeploymentCreated:
+							fmt.Printf("Deployment %d created...\n", msg.ID)
+						case mtypes.EventOrderCreated:
+							fmt.Printf("Order %d for deployement %d created...\n", msg.ID.OSeq, msg.ID.DSeq)
+						case mtypes.EventBidCreated:
+							fmt.Printf("Bid of %s for order %d:%d created...\n", msg.Price, msg.ID.DSeq, msg.ID.OSeq)
+						case mtypes.EventLeaseCreated:
+							fmt.Printf("Lease for order %d:%d created...\n", msg.ID.DSeq, msg.ID.OSeq)
+							pclient := pmodule.AppModuleBasic{}.GetQueryClient(ctx)
+							provider, err := pclient.Provider(msg.ID.Provider)
+							if err != nil {
+								return err
+							}
+
+							gclient := gateway.NewClient()
+
+							fmt.Printf("Sending manifest to provider %s...\n", msg.ID.Provider)
+							if err = gclient.SubmitManifest(
+								ccontext.Background(),
+								provider.HostURI,
+								&manifest.SubmitRequest{
+									Deployment: msg.ID.DeploymentID(),
+									Manifest:   mani,
+								},
+							); err != nil {
+								return err
+							}
+
+							if leases += -1; leases == 0 {
+								sub.Close()
+							}
+						}
+					}
+				}
+			})
+
+			// Create the deployment message
+			msg := types.MsgCreateDeployment{
+				ID: id,
+				// Version:  []byte{0x1, 0x2},
+				Groups: make([]types.GroupSpec, 0, len(groups)),
+			}
+
+			// Append the groups to the message
+			for _, group := range groups {
+				msg.Groups = append(msg.Groups, *group)
+			}
+
+			// validate
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			// broadcast the message
+			// TODO: set transaction broadcast defaults on the ctx to ensure
+			// that GenerateOrBroadcastMsgs exits when tx is sent to chain
+			if err = utils.GenerateOrBroadcastMsgs(ctx, bldr, []sdk.Msg{msg}); err != nil {
+				return err
+			}
+
+			return group.Wait()
+		},
+	}
+	AddDeploymentIDFlags(cmd.Flags())
+
 	return cmd
 }
 

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -95,6 +95,7 @@ func makeItSoCommand(key string, cdc *codec.Codec) *cobra.Command {
 
 			// Create an error group to handle chain listener
 			group, cctx := errgroup.WithContext(ccontext.Background())
+			cctx, cancel := ccontext.WithCancel(cctx)
 
 			// Listen to the events on chain and publish them to the pubsub bus
 			group.Go(func() error {
@@ -147,6 +148,7 @@ func makeItSoCommand(key string, cdc *codec.Codec) *cobra.Command {
 							if leases = leases - 1; leases == 0 {
 								fmt.Printf("Leases left %d...\n", leases)
 								sub.Close()
+								cancel()
 								return nil
 							}
 						}

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	ccontext "context"
 	"fmt"
 	"os"
 
@@ -9,19 +8,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
-	"github.com/ovrclk/akash/events"
-	"github.com/ovrclk/akash/provider/gateway"
-	"github.com/ovrclk/akash/provider/manifest"
-	"github.com/ovrclk/akash/pubsub"
 	"github.com/ovrclk/akash/sdl"
 	"github.com/ovrclk/akash/x/deployment/types"
-	mtypes "github.com/ovrclk/akash/x/market/types"
-	pmodule "github.com/ovrclk/akash/x/provider"
 
 	"github.com/spf13/cobra"
 )
@@ -40,151 +32,7 @@ func GetTxCmd(key string, cdc *codec.Codec) *cobra.Command {
 		cmdUpdate(key, cdc),
 		cmdClose(key, cdc),
 		cmdGroupClose(key, cdc),
-		makeItSoCommand(key, cdc),
 	)...)
-	return cmd
-}
-
-func makeItSoCommand(key string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "make-it-so [sdl-file]",
-		Short: fmt.Sprintf("Create %s", key),
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Setup CLI context and transaction builder
-			ctx := context.NewCLIContext().WithCodec(cdc)
-			bldr := auth.NewTxBuilderFromCLI(os.Stdin).WithTxEncoder(utils.GetTxEncoder(cdc))
-			if err := ctx.Client.Start(); err != nil {
-				return err
-			}
-
-			// Read in manifest file
-			sdl, err := sdl.ReadFile(args[0])
-			if err != nil {
-				return err
-			}
-
-			// Fetch deployment groups from the SDL file, each group maps to an individual order
-			groups, err := sdl.DeploymentGroups()
-			if err != nil {
-				return err
-			}
-
-			// Fetch the manifest from the SDL file
-			mani, err := sdl.Manifest()
-			if err != nil {
-				return err
-			}
-
-			// Get the deployment ID (defaults to height)
-			id, err := DeploymentIDFromFlags(cmd.Flags(), ctx.GetFromAddress().String())
-			if err != nil {
-				return err
-			}
-
-			// Default DSeq to the current block height
-			if id.DSeq == 0 {
-				if id.DSeq, err = currentBlockHeight(ctx); err != nil {
-					return err
-				}
-			}
-
-			// create a new pubsub bus to handle chain events
-			bus := pubsub.NewBus()
-			defer bus.Close()
-
-			// Create an error group to handle chain listener
-			group, cctx := errgroup.WithContext(ccontext.Background())
-			cctx, cancel := ccontext.WithCancel(cctx)
-
-			// Listen to the events on chain and publish them to the pubsub bus
-			group.Go(func() error {
-				return events.Publish(cctx, ctx.Client, "deployment-create", bus)
-			})
-
-			// expose event channel
-			sub, err := bus.Subscribe()
-			if err != nil {
-				return err
-			}
-
-			// start goroutine to listen for events
-			leases := len(groups)
-			group.Go(func() error {
-				for {
-					select {
-					case <-sub.Done():
-						return nil
-					case ev := <-sub.Events():
-						switch msg := ev.(type) {
-						case types.EventDeploymentCreated:
-							fmt.Printf("Deployment %d created...\n", msg.ID.DSeq)
-						case mtypes.EventOrderCreated:
-							fmt.Printf("Order %d for deployement %d created...\n", msg.ID.OSeq, msg.ID.DSeq)
-						case mtypes.EventBidCreated:
-							fmt.Printf("Bid of %s for order %d:%d created...\n", msg.Price, msg.ID.DSeq, msg.ID.OSeq)
-						case mtypes.EventLeaseCreated:
-							fmt.Printf("Lease for order %d:%d created...\n", msg.ID.DSeq, msg.ID.OSeq)
-							pclient := pmodule.AppModuleBasic{}.GetQueryClient(ctx)
-							provider, err := pclient.Provider(msg.ID.Provider)
-							if err != nil {
-								return err
-							}
-
-							gclient := gateway.NewClient()
-
-							fmt.Printf("Sending manifest to provider %s...\n", msg.ID.Provider)
-							if err = gclient.SubmitManifest(
-								ccontext.Background(),
-								provider.HostURI,
-								&manifest.SubmitRequest{
-									Deployment: msg.ID.DeploymentID(),
-									Manifest:   mani,
-								},
-							); err != nil {
-								return err
-							}
-
-							if leases = leases - 1; leases == 0 {
-								fmt.Printf("Leases left %d...\n", leases)
-								sub.Close()
-								cancel()
-								return nil
-							}
-						}
-					}
-				}
-			})
-
-			// Create the deployment message
-			msg := types.MsgCreateDeployment{
-				ID: id,
-				// Version:  []byte{0x1, 0x2},
-				Groups: make([]types.GroupSpec, 0, len(groups)),
-			}
-
-			// Append the groups to the message
-			for _, group := range groups {
-				msg.Groups = append(msg.Groups, *group)
-			}
-
-			// validate
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-
-			// broadcast the message
-			// TODO: set transaction broadcast defaults on the ctx to ensure
-			// that GenerateOrBroadcastMsgs exits when tx is sent to chain
-			if err = utils.GenerateOrBroadcastMsgs(ctx, bldr, []sdk.Msg{msg}); err != nil {
-				return err
-			}
-
-			return group.Wait()
-		},
-	}
-	AddDeploymentIDFlags(cmd.Flags())
-
 	return cmd
 }
 
@@ -214,21 +62,12 @@ func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 
 			// Default DSeq to the current block height
 			if id.DSeq == 0 {
-				if id.DSeq, err = currentBlockHeight(ctx); err != nil {
+				if id.DSeq, err = CurrentBlockHeight(ctx); err != nil {
 					return err
 				}
 			}
 
-			msg := types.MsgCreateDeployment{
-				ID: id,
-				// Version:  []byte{0x1, 0x2},
-				Groups: make([]types.GroupSpec, 0, len(groups)),
-			}
-
-			for _, group := range groups {
-				msg.Groups = append(msg.Groups, *group)
-			}
-
+			msg := types.NewMsgCreateDeployment(id, groups)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/deployment/client/cli/util.go
+++ b/x/deployment/client/cli/util.go
@@ -2,7 +2,7 @@ package cli
 
 import "github.com/cosmos/cosmos-sdk/client/context"
 
-func currentBlockHeight(ctx context.CLIContext) (uint64, error) {
+func CurrentBlockHeight(ctx context.CLIContext) (uint64, error) {
 	client, err := ctx.GetNode()
 	if err != nil {
 		return 0, err

--- a/x/deployment/types/msgs.go
+++ b/x/deployment/types/msgs.go
@@ -11,6 +11,23 @@ const (
 	msgTypeCloseGroup       = "close-group"
 )
 
+// NewMsgCreateDeployment constructor for MsgCreateDeployment
+func NewMsgCreateDeployment(id DeploymentID, groups []*GroupSpec) MsgCreateDeployment {
+	// Create the deployment message
+	msg := MsgCreateDeployment{
+		ID: id,
+		// Version:  []byte{0x1, 0x2},
+		Groups: make([]GroupSpec, 0, len(groups)),
+	}
+
+	// Append the groups to the message
+	for _, group := range groups {
+		msg.Groups = append(msg.Groups, *group)
+	}
+
+	return msg
+}
+
 // MsgCreateDeployment defines an SDK message for creating deployment
 type MsgCreateDeployment struct {
 	ID DeploymentID `json:"id"`


### PR DESCRIPTION
I'm having an issue seeing the events. Nothing is printing after transaction gets sent. Repro for testing (from /_run/kube):

T1:  KIND_CONFIG=kind-config-80.yaml make kind-cluster-delete kind-cluster-create
T2: make clean init node-run
T3: make provider-create provider-run
T4: make bins && ../../akashctl --home ./cache/client/ tx deployment make-it-so deployment.yaml --from main