### PR TITLE
feat:565 Deployment Version Field

### DIFF
--- a/events/publish_test.go
+++ b/events/publish_test.go
@@ -15,8 +15,8 @@ import (
 func Test_processEvent(t *testing.T) {
 	tests := []sdkutil.ModuleEvent{
 		// x/deployment events
-		dtypes.NewEventDeploymentCreated(testutil.DeploymentID(t)),
-		dtypes.NewEventDeploymentUpdated(testutil.DeploymentID(t)),
+		dtypes.NewEventDeploymentCreated(testutil.DeploymentID(t), testutil.DeploymentVersion(t)),
+		dtypes.NewEventDeploymentUpdated(testutil.DeploymentID(t), testutil.DeploymentVersion(t)),
 		dtypes.NewEventDeploymentClosed(testutil.DeploymentID(t)),
 		dtypes.NewEventGroupClosed(testutil.GroupID(t)),
 

--- a/integration/deployment_test.go
+++ b/integration/deployment_test.go
@@ -50,6 +50,16 @@ func TestDeployment(t *testing.T) {
 	require.NoError(t, err, "Error when fetching deployments with owner filter")
 	require.Len(t, deployments, 1)
 
+	// test updating deployment
+	execSuccess, stdOut, stdErr := f.TxUpdateDeployment(fmt.Sprintf("--from=%s --dseq=%d",
+		keyFoo, deployment.DeploymentID.DSeq), "-y")
+	require.True(t, execSuccess)
+	require.Empty(t, stdErr)
+	require.NotEmpty(t, stdOut)
+
+	deploymentV2 := f.QueryDeployment(createdDep.Deployment.DeploymentID)
+	require.NotEqual(t, deployment.Version, deploymentV2.Version)
+
 	// test query deployments with wrong owner value
 	deployments, err = f.QueryDeployments("--owner=cosmos102ruvpv2srmunfffxavttxnhezln6fnc3pf7tt")
 	require.Error(t, err)

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -31,17 +31,18 @@ import (
 )
 
 const (
-	denom              = "akash"
-	denomStartValue    = 150
-	keyFoo             = "foo"
-	keyBar             = "bar"
-	keyBaz             = "baz"
-	fooDenom           = "footoken"
-	fooStartValue      = 1000
-	feeDenom           = "stake"
-	feeStartValue      = 1000000
-	deploymentFilePath = "./../x/deployment/testdata/deployment.yaml"
-	providerFilePath   = "./../x/provider/testdata/provider.yaml"
+	denom                = "akash"
+	denomStartValue      = 150
+	keyFoo               = "foo"
+	keyBar               = "bar"
+	keyBaz               = "baz"
+	fooDenom             = "footoken"
+	fooStartValue        = 1000
+	feeDenom             = "stake"
+	feeStartValue        = 1000000
+	deploymentFilePath   = "./../x/deployment/testdata/deployment.yaml"
+	deploymentV2FilePath = "./../x/deployment/testdata/deployment-v2.yaml"
+	providerFilePath     = "./../x/provider/testdata/provider.yaml"
 )
 
 var (
@@ -349,13 +350,19 @@ func (f *Fixtures) TxSend(from string, to sdk.AccAddress, amount sdk.Coin, flags
 //___________________________________________________________________________________
 // akash tx deployment
 
-// TxCreateDeployment is akash create deployment
+// TxCreateDeployment is akashctl create deployment
 func (f *Fixtures) TxCreateDeployment(flags ...string) (bool, string, string) {
 	cmd := fmt.Sprintf("%s tx deployment create %s %v %s", f.AkashBinary, deploymentFilePath, f.Flags(), f.KeyFlags())
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags))
 }
 
-// TxCloseDeployment is akash close deployment
+// TxUpdateDeployment is akashctl update deployment
+func (f *Fixtures) TxUpdateDeployment(flags ...string) (bool, string, string) {
+	cmd := fmt.Sprintf("%s tx deployment update %s %v %s", f.AkashBinary, deploymentV2FilePath, f.Flags(), f.KeyFlags())
+	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags))
+}
+
+// TxCloseDeployment is akashctl close deployment
 func (f *Fixtures) TxCloseDeployment(flags ...string) (bool, string, string) {
 	cmd := fmt.Sprintf("%s tx deployment close %v %s", f.AkashBinary, f.Flags(), f.KeyFlags())
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags))

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -1,12 +1,17 @@
 package sdl
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ovrclk/akash/manifest"
 	"github.com/ovrclk/akash/validation"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // SDL is the interface which wraps Validate, Deployment and Manifest methods
@@ -27,7 +32,7 @@ func ReadFile(path string) (SDL, error) {
 
 // Read reads buffer data and returns SDL instance
 func Read(buf []byte) (SDL, error) {
-	// TODO: handle versions
+	// TODO: handle versions; read 'version' field and switch
 	obj := &v1{}
 	if err := yaml.Unmarshal(buf, obj); err != nil {
 		return nil, err
@@ -55,6 +60,8 @@ func Read(buf []byte) (SDL, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: Determine if worth repairing ValidateManifest; functionality is commented out
 	if err := validation.ValidateManifest(m); err != nil {
 		return nil, err
 	}
@@ -63,4 +70,26 @@ func Read(buf []byte) (SDL, error) {
 	// }
 
 	return obj, nil
+}
+
+// Version creates the deterministic Deployment Version hash from the SDL.
+// Sha256 returns 32 byte  sum of the SDL.
+func Version(s SDL) ([]byte, error) {
+	manifest, err := s.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	sortedBytes, err := sdk.SortJSON(m)
+	if err != nil {
+		return nil, err
+	}
+
+	sum := sha256.Sum256(sortedBytes)
+	return []byte(sum[:]), nil
 }

--- a/sdl/v1.go
+++ b/sdl/v1.go
@@ -17,8 +17,10 @@ var (
 	allowedVersion = semver.MustParse("1.5.0")
 )
 
+var _ SDL = (*v1)(nil) // Assert interface implementation
+
 type v1 struct {
-	Version  string
+	Version  string   `yaml:"version"`
 	Include  []string `yaml:",omitempty"`
 	Services map[string]v1Service
 	Profiles v1Profiles

--- a/sdl/v1_test.go
+++ b/sdl/v1_test.go
@@ -3,7 +3,7 @@ package sdl_test
 import (
 	"testing"
 
-	"github.com/ovrclk/akash/sdl"
+	sdlv1 "github.com/ovrclk/akash/sdl"
 	"github.com/ovrclk/akash/types"
 	"github.com/ovrclk/akash/types/unit"
 	"github.com/stretchr/testify/assert"
@@ -16,18 +16,34 @@ const (
 	randStorage uint64 = 1 * unit.Gi
 )
 
-func Test_v1_Parse_docs(t *testing.T) {
-	sdl, err := sdl.ReadFile("../x/deployment/testdata/deployment.yaml")
+func Test_v1_Parse_Deployments(t *testing.T) {
+	sdl1, err := sdlv1.ReadFile("../x/deployment/testdata/deployment.yaml")
 	require.NoError(t, err)
-	_, err = sdl.DeploymentGroups()
+	_, err = sdl1.DeploymentGroups()
 	require.NoError(t, err)
 
-	_, err = sdl.Manifest()
+	_, err = sdl1.Manifest()
 	require.NoError(t, err)
+
+	sha1, err := sdlv1.Version(sdl1)
+	require.NoError(t, err)
+	assert.Len(t, sha1, 32)
+
+	sha2, err := sdlv1.Version(sdl1)
+	require.NoError(t, err)
+	assert.Len(t, sha2, 32)
+
+	require.Equal(t, sha1, sha2)
+
+	sdl2, err := sdlv1.ReadFile("../x/deployment/testdata/deployment-v2.yaml")
+	require.NoError(t, err)
+	sha3, err := sdlv1.Version(sdl2)
+	require.NoError(t, err)
+	require.NotEqual(t, sha1, sha3)
 }
 
 func Test_v1_Parse_simple(t *testing.T) {
-	sdl, err := sdl.ReadFile("./_testdata/simple.yaml")
+	sdl, err := sdlv1.ReadFile("./_testdata/simple.yaml")
 	require.NoError(t, err)
 
 	groups, err := sdl.DeploymentGroups()
@@ -80,7 +96,7 @@ func Test_v1_Parse_simple(t *testing.T) {
 }
 
 func Test_v1_Parse_ProfileNameNotServiceName(t *testing.T) {
-	sdl, err := sdl.ReadFile("./_testdata/profile-svc-name-mismatch.yaml")
+	sdl, err := sdlv1.ReadFile("./_testdata/profile-svc-name-mismatch.yaml")
 	require.NoError(t, err)
 
 	dgroups, err := sdl.DeploymentGroups()

--- a/testutil/deployment.go
+++ b/testutil/deployment.go
@@ -1,11 +1,18 @@
 package testutil
 
 import (
+	"crypto/sha256"
 	"math/rand"
 	"testing"
 
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 )
+
+// sum256Seed provides a consistent sha256 value for initial Deployment.Version
+const sum256Seed = "hihi"
+
+// DefaultDeploymentVersion provides consistent sha256 sum for initial Deployment.Version
+var DefaultDeploymentVersion = sha256.Sum256([]byte(sum256Seed))
 
 // Deployment generates a dtype.Deployment in state `DeploymentActive`
 func Deployment(t testing.TB) dtypes.Deployment {
@@ -13,6 +20,7 @@ func Deployment(t testing.TB) dtypes.Deployment {
 	return dtypes.Deployment{
 		DeploymentID: DeploymentID(t),
 		State:        dtypes.DeploymentActive,
+		Version:      DefaultDeploymentVersion[:],
 	}
 }
 

--- a/testutil/ids.go
+++ b/testutil/ids.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	cryptorand "crypto/rand"
+	"crypto/sha256"
 	"math/rand"
 	"testing"
 
@@ -31,6 +33,18 @@ func DeploymentID(t testing.TB) dtypes.DeploymentID {
 		Owner: AccAddress(t),
 		DSeq:  uint64(rand.Uint32()),
 	}
+}
+
+// DeploymentVersion provides a random sha256 sum for simulating Deployments.
+func DeploymentVersion(t testing.TB) []byte {
+	t.Helper()
+	src := make([]byte, 128)
+	_, err := cryptorand.Read(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(src)
+	return sum[:]
 }
 
 func GroupID(t testing.TB) dtypes.GroupID {

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -45,12 +45,12 @@ func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 			ctx := context.NewCLIContext().WithCodec(cdc)
 			bldr := auth.NewTxBuilderFromCLI(os.Stdin).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			sdl, err := sdl.ReadFile(args[0])
+			sdlManifest, err := sdl.ReadFile(args[0])
 			if err != nil {
 				return err
 			}
 
-			groups, err := sdl.DeploymentGroups()
+			groups, err := sdlManifest.DeploymentGroups()
 			if err != nil {
 				return err
 			}
@@ -67,10 +67,15 @@ func cmdCreate(key string, cdc *codec.Codec) *cobra.Command {
 				}
 			}
 
+			version, err := sdl.Version(sdlManifest)
+			if err != nil {
+				return err
+			}
+
 			msg := types.MsgCreateDeployment{
-				ID: id,
-				// Version:  []byte{0x1, 0x2},
-				Groups: make([]types.GroupSpec, 0, len(groups)),
+				ID:      id,
+				Version: version,
+				Groups:  make([]types.GroupSpec, 0, len(groups)),
 			}
 
 			for _, group := range groups {
@@ -126,8 +131,28 @@ func cmdUpdate(key string, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
+			sdlManifest, err := sdl.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			groups, err := sdlManifest.DeploymentGroups()
+			if err != nil {
+				return err
+			}
+
+			version, err := sdl.Version(sdlManifest)
+			if err != nil {
+				return err
+			}
+
 			msg := types.MsgUpdateDeployment{
-				ID: id,
+				ID:      id,
+				Version: version,
+				Groups:  make([]types.GroupSpec, 0, len(groups)),
+			}
+
+			for _, group := range groups {
+				msg.Groups = append(msg.Groups, *group)
 			}
 
 			return utils.GenerateOrBroadcastMsgs(ctx, bldr, []sdk.Msg{msg})

--- a/x/deployment/client/cli/util.go
+++ b/x/deployment/client/cli/util.go
@@ -1,6 +1,8 @@
 package cli
 
-import "github.com/cosmos/cosmos-sdk/client/context"
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+)
 
 func currentBlockHeight(ctx context.CLIContext) (uint64, error) {
 	client, err := ctx.GetNode()

--- a/x/deployment/handler/handler.go
+++ b/x/deployment/handler/handler.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/pkg/errors"
@@ -36,8 +38,7 @@ func handleMsgCreate(ctx sdk.Context, keeper keeper.Keeper, _ MarketKeeper, msg 
 	deployment := types.Deployment{
 		DeploymentID: msg.ID,
 		State:        types.DeploymentActive,
-		// TODO: version
-		// Version: sdk.Address.Bytes(),
+		Version:      msg.Version,
 	}
 
 	if err := validation.ValidateDeploymentGroups(msg.Groups); err != nil {
@@ -69,8 +70,9 @@ func handleMsgUpdate(ctx sdk.Context, keeper keeper.Keeper, _ MarketKeeper, msg 
 		return nil, types.ErrDeploymentNotFound
 	}
 
-	// TODO: version
-	// deployment.Version = msg.Version
+	if bytes.Compare(msg.Version, deployment.Version) != 0 {
+		deployment.Version = msg.Version
+	}
 
 	if err := keeper.UpdateDeployment(ctx, deployment); err != nil {
 		return nil, errors.Wrap(types.ErrInternal, err.Error())

--- a/x/deployment/keeper/keeper.go
+++ b/x/deployment/keeper/keeper.go
@@ -126,7 +126,7 @@ func (k Keeper) Create(ctx sdk.Context, deployment types.Deployment, groups []ty
 	}
 
 	ctx.EventManager().EmitEvent(
-		types.NewEventDeploymentCreated(deployment.ID()).
+		types.NewEventDeploymentCreated(deployment.ID(), deployment.Version).
 			ToSDKEvent(),
 	)
 
@@ -143,7 +143,7 @@ func (k Keeper) UpdateDeployment(ctx sdk.Context, deployment types.Deployment) e
 	}
 
 	ctx.EventManager().EmitEvent(
-		types.NewEventDeploymentUpdated(deployment.ID()).
+		types.NewEventDeploymentUpdated(deployment.ID(), deployment.Version).
 			ToSDKEvent(),
 	)
 

--- a/x/deployment/testdata/deployment-v2.yaml
+++ b/x/deployment/testdata/deployment-v2.yaml
@@ -1,0 +1,30 @@
+---
+version: "1.5"
+
+services:
+  web:
+    image: bubuntux/riot-web:v2
+    expose:
+      - port: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      cpu: "0.01"
+      memory: "128Mi"
+      storage: "512Mi"
+
+  placement:
+    global:
+      pricing:
+        web:
+          denom: akash
+          amount: 30
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1

--- a/x/deployment/types/msgs.go
+++ b/x/deployment/types/msgs.go
@@ -13,9 +13,9 @@ const (
 
 // MsgCreateDeployment defines an SDK message for creating deployment
 type MsgCreateDeployment struct {
-	ID DeploymentID `json:"id"`
-	// Version []byte      `json:"version"`
-	Groups []GroupSpec `json:"groups"`
+	ID      DeploymentID `json:"id"`
+	Groups  []GroupSpec  `json:"groups"`
+	Version []byte       `json:"version"`
 }
 
 // Route implements the sdk.Msg interface
@@ -42,14 +42,17 @@ func (msg MsgCreateDeployment) ValidateBasic() error {
 	if len(msg.Groups) == 0 {
 		return ErrInvalidGroups
 	}
-	// TODO: version
+	if len(msg.Version) == 0 {
+		return ErrEmptyVersion
+	}
 	return nil
 }
 
 // MsgUpdateDeployment defines an SDK message for updating deployment
 type MsgUpdateDeployment struct {
 	ID      DeploymentID
-	Version sdk.AccAddress
+	Groups  []GroupSpec
+	Version []byte
 }
 
 // Route implements the sdk.Msg interface
@@ -64,7 +67,7 @@ func (msg MsgUpdateDeployment) ValidateBasic() error {
 		return err
 	}
 
-	if err := sdk.VerifyAddressFormat(msg.Version); err != nil {
+	if len(msg.Version) == 0 {
 		return ErrEmptyVersion
 	}
 


### PR DESCRIPTION
Implementation of passing a Deployment manifest's Version from Create and Update commands and messages.

* `sdl.VersionSha` package produces deterministic version hash from SDL struct.
* `akashctl tx deployment [create|update]` generates and sets Version field.
* `testutil` package updated to provide a consistent Deployment.Version value.
  * `testutil.DeploymentVersion()` provides random version sums.
* Assertions/test that the Version is passed to the keeper via
`MsgUpdateDeployment` & `MsgCreateDeployment`.
  * MsgUpdateDeployment passes GroupSpec to update image tags
* Test integration tests for `deployment update`.
  * New deployment-v2.yaml with tag change.
  * Assert's Version field is changed post update.
* Tests to validate different deployment Versions
  * Compare differing deployment yaml sha256 sums in tests.
* Deployment* SDKEvent types carry Version field.
  * `EventDeploymentCreated` & `EventDeploymentUpdated`
  * Structs and constructors updated with Version field.
  * Tests updated to create and pass Versions for Create & Update.
* Test Simulations execute Update Deployments with different manifest
file.

fixes: #565
