### PR TITLE
feat:762 Deployment Version Updating validation

### DIFF
--- a/_run/common-commands.mk
+++ b/_run/common-commands.mk
@@ -28,6 +28,12 @@ deployment-create:
 		--dseq "$(DSEQ)" 			   \
 		--from "$(KEY_NAME)"
 
+.PHONY: deployment-update
+deployment-update:
+	$(AKASHCTL) tx deployment update "$(SDL_PATH)" -y \
+		--dseq "$(DSEQ)" 			   \
+		--from "$(KEY_NAME)"
+
 .PHONY: deployment-close
 deployment-close:
 	$(AKASHCTL) tx deployment close -y \

--- a/_run/kube/README.md
+++ b/_run/kube/README.md
@@ -225,6 +225,20 @@ make provider-service-logs
 If you chose to use port 80 when setting up kind, you can browse to your
 deployed workload at http://hello.localhost
 
+## Update Deployment
+
+Updating active Deployments is a two step process. First edit the `deployment.yaml` with whatever changes are desired. Example; update the `image` field.
+ 1. Update the Akash Network to inform the Provider that a new Deployment declaration is expected.
+   * `make deployment-update`
+ 2. Send the updated manifest to the Provider to run.
+   * `make send-manifest`
+
+Between the first and second step, the prior deployment's containers will continue to run until the new manifest file is received, validated, and new container group operational. After health checks on updated group are passing; the prior containers will be terminated.
+
+#### Limitations
+
+Akash Groups are translated into Kubernetes Deployments, this means that only a few fields from the Akash SDL are mutable. For example `image`, `command`, `args`, `env` and exposed ports can be modified, but compute resources and placement criteria cannot.
+
 ## Terminate lease
 
 There are a number of ways that a lease can be terminated.

--- a/_run/single/README.md
+++ b/_run/single/README.md
@@ -223,6 +223,16 @@ make provider-lease-ping
 If you chose to use port 80 when setting up kind, you can browse to your
 deployed workload at http://hello.localhost
 
+## Update Deployment
+
+Updating active Deployments is a two step process. First edit the `deployment.yaml` with whatever changes are desired. Example; update the `image` field.
+ 1. Update the Akash Network to inform the Provider that a new Deployment declaration is expected.
+   * `make deployment-update`
+ 2. Send the updated manifest to the Provider to run.
+   * `make send-manifest`
+
+Between the first and second step, the prior deployment's containers will continue to run until the new manifest file is received, validated, and new container group operational. After health checks on updated group are passing; the prior containers will be terminated.
+
 ### Terminate lease
 
 There are a number of ways that a lease can be terminated.

--- a/client/client.go
+++ b/client/client.go
@@ -45,7 +45,7 @@ type Client interface {
 	Tx() TxClient
 }
 
-// NewClient creates new client instance
+// NewClient creates new client instance to interface with terndermint.
 func NewClient(
 	log log.Logger,
 	cctx ccontext.CLIContext,

--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -212,15 +212,13 @@ loop:
 			}
 
 		case dm := <-s.managerch:
-
 			s.log.Debug("manager done", "lease", dm.lease)
 
+			// unreserve resources
 			if _, err := s.inventory.unreserve(dm.lease.OrderID(), dm.mgroup); err != nil {
 				s.log.Error("unreserving inventory", "err", err,
 					"lease", dm.lease, "group-name", dm.mgroup.Name)
 			}
-
-			// todo: unreserve resources
 
 			delete(s.managers, mquery.LeasePath(dm.lease))
 		}

--- a/provider/event/events.go
+++ b/provider/event/events.go
@@ -15,6 +15,7 @@ type LeaseWon struct {
 }
 
 // ManifestReceived stores leaseID, manifest received, deployment and group details
+// to be provisioned by the Provider.
 type ManifestReceived struct {
 	LeaseID    mtypes.LeaseID
 	Manifest   *manifest.Manifest

--- a/provider/manifest/manager.go
+++ b/provider/manifest/manager.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/ovrclk/akash/provider/event"
 	"github.com/ovrclk/akash/provider/session"
 	"github.com/ovrclk/akash/pubsub"
+	"github.com/ovrclk/akash/sdl"
 	"github.com/ovrclk/akash/util/runner"
 	"github.com/ovrclk/akash/validation"
 	dquery "github.com/ovrclk/akash/x/deployment/query"
@@ -20,7 +22,11 @@ import (
 )
 
 var (
+	// ErrShutdownTimerExpired for a terminating deployment
 	ErrShutdownTimerExpired = errors.New("shutdown timer expired")
+	// ErrManifestVersion indicates that the given manifest's version does not
+	// match the blockchain Version value.
+	ErrManifestVersion = errors.New("manifest version validation failed")
 )
 
 func newManager(h *service, daddr dtypes.DeploymentID) (*manager, error) {
@@ -51,6 +57,7 @@ func newManager(h *service, daddr dtypes.DeploymentID) (*manager, error) {
 	return m, nil
 }
 
+// 'manager' facilitates operations around a configured Deployment.
 type manager struct {
 	config  config
 	daddr   dtypes.DeploymentID
@@ -171,7 +178,6 @@ loop:
 
 		case version := <-m.updatech:
 			m.log.Info("received version", "version", version)
-
 			m.versions = append(m.versions, version)
 			if m.data != nil {
 				m.data.Version = version
@@ -228,6 +234,7 @@ func (m *manager) fetchData(ctx context.Context) <-chan runner.Result {
 	})
 }
 
+// query the blockchain to get Deployment data
 func (m *manager) doFetchData(_ context.Context) (*dquery.Deployment, error) {
 	deployment, err := m.session.Client().Query().Deployment(m.daddr)
 	if err != nil {
@@ -301,7 +308,16 @@ func (m *manager) validateRequests() {
 }
 
 func (m *manager) validateRequest(req manifestRequest) error {
-	// TODO: hash(manifest) == m.data.Version
+	// ensure that an uploaded manifest matches the hash declared on
+	// the Akash Deployment.Version
+	version, err := sdl.ManifestVersion(req.value.Manifest)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(version, m.data.Version) {
+		return ErrManifestVersion
+	}
+
 	if err := validation.ValidateManifestWithDeployment(&req.value.Manifest, m.data.Groups); err != nil {
 		return err
 	}

--- a/provider/manifest/service.go
+++ b/provider/manifest/service.go
@@ -163,7 +163,6 @@ loop:
 				s.handleLease(ev)
 
 			case dtypes.EventDeploymentUpdated:
-
 				s.session.Log().Info("update received", "deployment", ev.ID, "version", ev.Version)
 
 				key := dquery.DeploymentPath(ev.ID)

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -73,13 +73,17 @@ func Read(buf []byte) (SDL, error) {
 }
 
 // Version creates the deterministic Deployment Version hash from the SDL.
-// Sha256 returns 32 byte  sum of the SDL.
 func Version(s SDL) ([]byte, error) {
 	manifest, err := s.Manifest()
 	if err != nil {
 		return nil, err
 	}
+	return ManifestVersion(manifest)
+}
 
+// ManifestVersion calculates the identifying deterministic hash for an SDL.
+// Sha256 returns 32 byte  sum of the SDL.
+func ManifestVersion(manifest manifest.Manifest) ([]byte, error) {
 	m, err := json.Marshal(manifest)
 	if err != nil {
 		return nil, err

--- a/validation/manifest.go
+++ b/validation/manifest.go
@@ -35,7 +35,7 @@ func ValidateManifestWithGroupSpecs(m *manifest.Manifest, gspecs []*dtypes.Group
 
 // ValidateManifestWithDeployment does basic validation and returns nil
 func ValidateManifestWithDeployment(m *manifest.Manifest, dgroups []dtypes.Group) error {
-	// TODO
+	// TODO: re-enable
 	// rlists := make([]types.ResourceList, 0, len(dgroups))
 	// for _, dgroup := range dgroups {
 	// 	rlists = append(rlists, dgroup)


### PR DESCRIPTION
* ~~Performance improvements to Active Lease lookup~~
* Code Documentation in the `provider` codebase
* Validation of manifest version to blockchain Deployment version
  * Asserts that manifest object provided is correct.
* ManifestVersion() method to extract Version from Manifest type.
* Makefile `deployment-update` command added
* Document Deployment update and (re)sending manifest.

fixes: #762
