### PR TITLE
feat: E2E provider integration test

### DIFF
--- a/.github/workflows/k8s-integration.yaml
+++ b/.github/workflows/k8s-integration.yaml
@@ -10,13 +10,24 @@ on:
       - provider/cluster/kube/*
 
 jobs:
-  crd:
+  crd-e2e:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
       - uses: engineerd/setup-kind@v0.4.0
-      - name: Setup K8S
-        run: ./script/setup-kind.sh
-      - name: Run Tests
+        with:
+            config: ./_run/kube/kind-config.yaml
+      - name: Setup Ingress K8S
+        run: make -s -C _run/kube kind-ingress-setup
+      - name: k8s-ingress
+        run: make -s -C _run/kube kind-k8s-ip
+      - name: Kube Environment
+        run: |
+          kubectl config view
+          kubectl cluster-info
+          kubectl get pods,ingress,svc -A
+      - name: Run E2E Tests
+        run: make test-e2e-integration
+      - name: Run K8s Tests
         run: make test-k8s-integration

--- a/.github/workflows/k8s-integration.yaml
+++ b/.github/workflows/k8s-integration.yaml
@@ -11,13 +11,17 @@ on:
 
 jobs:
   crd-e2e:
+    env:
+      KIND_NAME: kind
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
       - uses: engineerd/setup-kind@v0.4.0
         with:
-            config: ./_run/kube/kind-config.yaml
+          config: ./_run/kube/kind-config.yaml
+      - name: Docker Status
+        run: docker ps -a
       - name: Setup Ingress K8S
         run: make -s -C _run/kube kind-ingress-setup
       - name: k8s-ingress

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ APP_DIR := ./app
 GO := GO111MODULE=on go
 GOBIN := $(shell go env GOPATH)/bin
 
-KIND_API_IP ?= $(shell make -sC _run/kube kind-k8s-ip)
-KIND_HTTP_PORT ?= $(shell make -sC _run/kube app-http-port)
-KIND_VARS ?= KIND_APP_PORT="$(KIND_HTTP_PORT)" KIND_K8S_IP="$(KIND_API_IP)"
+KIND_APP_IP ?= $(shell make -sC _run/kube kind-k8s-ip)
+KIND_APP_PORT ?= $(shell make -sC _run/kube app-http-port)
+KIND_VARS ?= KIND_APP_IP="$(KIND_APP_IP)" KIND_APP_PORT="$(KIND_APP_PORT)"
 
 # Setting mainnet flag based on env value
 # export MAINNET=true to set build tag mainnet

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ APP_DIR := ./app
 GO := GO111MODULE=on go
 GOBIN := $(shell go env GOPATH)/bin
 
+KIND_API_IP ?= $(shell make -sC _run/kube kind-k8s-ip)
+KIND_HTTP_PORT ?= $(shell make -sC _run/kube app-http-port)
+KIND_VARS ?= KIND_APP_PORT="$(KIND_HTTP_PORT)" KIND_K8S_IP="$(KIND_API_IP)"
+
 # Setting mainnet flag based on env value
 # export MAINNET=true to set build tag mainnet
 ifeq ($(MAINNET),true)
@@ -150,6 +154,16 @@ devdeps-install:
 test-integration: $(BINS)
 	cp akashctl akashd ./_build
 	go test -mod=readonly -p 4 -tags "integration $(BUILD_MAINNET)" -v ./integration/...
+
+test-e2e-integration: $(BINS)
+	# ASSUMES:
+	# 1. cluster created - `kind create cluster --config=_run/kube/kind-config.yaml`
+	# 2. cluster setup - `make -s -C _run/kube kind-ingress-setup`
+	cp akashctl akashd ./_build
+	$(KIND_VARS) go test -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestE2EApp
+
+test-query-app: $(BINS)
+	 $(KIND_VARS) go test -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestQueryApp
 
 test-k8s-integration:
 	# ASSUMES:

--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -1,5 +1,8 @@
+# KIND_NAME NOTE: 'kind' string literal is default for the GH actions 
+# KinD, it's fine to use other names locally, however in GH container name 
+# is configured by engineerd/setup-kind. `kind-control-plane` is the docker
+# image's name in GH Actions.
 KIND_NAME      ?= $(shell basename $$PWD)
-# 'kind' matches the configuration of the GH actions KinD. 
 K8S_CONTEXT    ?= $(shell kubectl config current-context)
 KIND_HTTP_PORT  ?= $(shell docker inspect \
 										--type container "$(KIND_NAME)-control-plane" \
@@ -19,7 +22,7 @@ KIND_PORT_BINDINGS ?= $(shell docker inspect "$(KIND_NAME)-control-plane" \
 KIND_CONFIG       ?= kind-config.yaml
 
 PROVIDER_HOSTNAME ?= localhost
-PROVIDER_HOST     ?= $(PROVIDER_HOSTNAME):$(APP_HTTP_PORT)
+PROVIDER_HOST     ?= $(PROVIDER_HOSTNAME):$(KIND_HTTP_PORT)
 PROVIDER_ENDPOINT ?= http://$(PROVIDER_HOST)
 
 # TODO: referencing master/latest on a k8s repository is prone to breaking at some point.

--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -1,25 +1,52 @@
 KIND_NAME      ?= $(shell basename $$PWD)
+# 'kind' matches the configuration of the GH actions KinD. 
 K8S_CONTEXT    ?= $(shell kubectl config current-context)
-KIND_HTTP_PORT  = $(shell docker inspect \
+KIND_HTTP_PORT  ?= $(shell docker inspect \
 										--type container "$(KIND_NAME)-control-plane" \
-										--format '{{index .HostConfig.PortBindings "80/tcp" 0 "HostPort"}}')
+										--format '{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort"}}')
+
+KIND_HTTP_IP  ?= $(shell docker inspect \
+										--type container "$(KIND_NAME)-control-plane" \
+										--format '{{index .NetworkSettings.Ports "80/tcp" 0 "HostIp"}}')
+
+KIND_K8S_IP ?= $(shell docker inspect \
+										--type container "$(KIND_NAME)-control-plane" \
+										--format '{{index .NetworkSettings.Ports "6443/tcp" 0 "HostIp"}}')
+
+KIND_PORT_BINDINGS ?= $(shell docker inspect "$(KIND_NAME)-control-plane" \
+										--format '{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort"}}')
 
 KIND_CONFIG       ?= kind-config.yaml
 
 PROVIDER_HOSTNAME ?= localhost
-PROVIDER_HOST     ?= $(PROVIDER_HOSTNAME):$(KIND_HTTP_PORT)
+PROVIDER_HOST     ?= $(PROVIDER_HOSTNAME):$(APP_HTTP_PORT)
 PROVIDER_ENDPOINT ?= http://$(PROVIDER_HOST)
 
+# TODO: referencing master/latest on a k8s repository is prone to breaking at some point.
 INGRESS_CONFIG_PATH ?= https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
 
-kind-port:
-	echo $(KIND_HTTP_PORT)
+.PHONY: app-http-port
+app-http-port:
+	@echo $(KIND_HTTP_PORT)
+
+.PHONY: kind-k8s-ip
+kind-k8s-ip:
+	@echo $(KIND_K8S_IP)
+
+.PHONY: kind-port-bindings
+kind-port-bindings:
+	@echo $(KIND_PORT_BINDINGS)
 
 .PHONY: kind-cluster-create
 kind-cluster-create:
 	kind create cluster \
 		--config "$(KIND_CONFIG)" \
 		--name "$(KIND_NAME)"
+	kubectl apply -f "$(INGRESS_CONFIG_PATH)"
+	"$(AKASH_ROOT)/script/setup-kind.sh"
+
+.PHONY: kind-ingress-setup
+kind-ingress-setup:
 	kubectl apply -f "$(INGRESS_CONFIG_PATH)"
 	"$(AKASH_ROOT)/script/setup-kind.sh"
 

--- a/integration/cosmostests/LICENSE
+++ b/integration/cosmostests/LICENSE
@@ -1,0 +1,204 @@
+Cosmos-SDK
+License: Apache2.0
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 All in Bits, Inc
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integration/cosmostests/gobash.go
+++ b/integration/cosmostests/gobash.go
@@ -1,0 +1,114 @@
+package cosmostests
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ExecuteT executes the command, pipes any input to STDIN and return STDOUT,
+// logging STDOUT/STDERR to t.
+func ExecuteT(t *testing.T, cmd, input string, envs []string) (stdout, stderr string) {
+	t.Log("Running", cmd)
+
+	// split cmd to name and args
+	split := strings.Split(cmd, " ")
+	require.True(t, len(split) > 0, "no command provided")
+	name, args := split[0], []string(nil)
+	if len(split) > 1 {
+		args = split[1:]
+	}
+
+	proc, err := StartProcess("", name, args, envs)
+	require.NoError(t, err)
+
+	// if input is provided, pass it to STDIN and close the pipe
+	if input != "" {
+		_, err = io.WriteString(proc.StdinPipe, input)
+		require.NoError(t, err)
+		proc.StdinPipe.Close()
+	}
+
+	outbz, errbz, err := proc.ReadAll()
+	if err != nil {
+		fmt.Println("Err on proc.ReadAll()", err, args)
+	}
+
+	proc.Wait()
+
+	if len(outbz) > 0 {
+		t.Log("Stdout:", string(outbz))
+	}
+
+	if len(errbz) > 0 {
+		t.Log("Stderr:", string(errbz))
+	}
+
+	stdout = strings.Trim(string(outbz), "\n")
+	stderr = strings.Trim(string(errbz), "\n")
+
+	return stdout, stderr
+}
+
+// Execute the command, launch goroutines to log stdout/err to t.
+// Caller should wait for .Wait() or .Stop() to terminate.
+func GoExecuteT(t *testing.T, cmd string, envs []string) (proc *Process) {
+	t.Log("Running", cmd)
+
+	// Split cmd to name and args.
+	split := strings.Split(cmd, " ")
+	require.True(t, len(split) > 0, "no command provided")
+	name, args := split[0], []string(nil)
+	if len(split) > 1 {
+		args = split[1:]
+	}
+
+	// Start process.
+	proc, err := StartProcess("", name, args, envs)
+	require.NoError(t, err)
+	return proc
+}
+
+// Same as GoExecuteT but spawns a go routine to ReadAll off stdout.
+func GoExecuteTWithStdout(t *testing.T, cmd string) (proc *Process) {
+	t.Log("Running", cmd)
+
+	// Split cmd to name and args.
+	split := strings.Split(cmd, " ")
+	require.True(t, len(split) > 0, "no command provided")
+	name, args := split[0], []string(nil)
+	if len(split) > 1 {
+		args = split[1:]
+	}
+
+	// Start process.
+	proc, err := CreateProcess("", name, args, []string{})
+	require.NoError(t, err)
+
+	// Without this, the test halts ?!
+	// (theory: because stdout and/or err aren't connected to anything the process halts)
+	go func(proc *Process) {
+		_, err := ioutil.ReadAll(proc.StdoutPipe)
+		if err != nil {
+			fmt.Println("-------------ERR-----------------------", err)
+			return
+		}
+	}(proc)
+
+	go func(proc *Process) {
+		_, err := ioutil.ReadAll(proc.StderrPipe)
+		if err != nil {
+			fmt.Println("-------------ERR-----------------------", err)
+			return
+		}
+	}(proc)
+
+	err = proc.Cmd.Start()
+	require.NoError(t, err)
+	proc.Pid = proc.Cmd.Process.Pid
+	return proc
+}

--- a/integration/cosmostests/process.go
+++ b/integration/cosmostests/process.go
@@ -1,0 +1,120 @@
+package cosmostests
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// execution process
+type Process struct {
+	ExecPath   string
+	Args       []string
+	EnvVars    []string
+	Pid        int
+	StartTime  time.Time
+	EndTime    time.Time
+	Cmd        *exec.Cmd        `json:"-"`
+	ExitState  *os.ProcessState `json:"-"`
+	StdinPipe  io.WriteCloser   `json:"-"`
+	StdoutPipe io.ReadCloser    `json:"-"`
+	StderrPipe io.ReadCloser    `json:"-"`
+}
+
+// dir: The working directory. If "", os.Getwd() is used.
+// name: Command name
+// args: Args to command. (should not include name)
+func StartProcess(dir string, name string, args []string, envs []string) (*Process, error) {
+	proc, err := CreateProcess(dir, name, args, envs)
+	if err != nil {
+		return nil, err
+	}
+	// cmd start
+	if err := proc.Cmd.Start(); err != nil {
+		return nil, err
+	}
+	proc.Pid = proc.Cmd.Process.Pid
+
+	return proc, nil
+}
+
+// Same as StartProcess but doesn't start the process
+func CreateProcess(dir string, name string, args []string, envs []string) (*Process, error) {
+	var cmd = exec.Command(name, args...) // is not yet started.
+	cmd.Env = append(os.Environ(), envs...)
+	// cmd dir
+	if dir == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		cmd.Dir = pwd
+	} else {
+		cmd.Dir = dir
+	}
+	// cmd stdin
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	proc := &Process{
+		ExecPath:   name,
+		Args:       args,
+		EnvVars:    envs,
+		StartTime:  time.Now(),
+		Cmd:        cmd,
+		ExitState:  nil,
+		StdinPipe:  stdin,
+		StdoutPipe: stdout,
+		StderrPipe: stderr,
+	}
+	return proc, nil
+}
+
+// stop the process
+func (proc *Process) Stop(kill bool) error {
+	if kill {
+		// fmt.Printf("Killing process %v\n", proc.Cmd.Process)
+		return proc.Cmd.Process.Kill()
+	}
+	return proc.Cmd.Process.Signal(os.Interrupt)
+}
+
+// wait for the process
+func (proc *Process) Wait() {
+	err := proc.Cmd.Wait()
+	if err != nil {
+		// fmt.Printf("Process exit: %v\n", err)
+		if exitError, ok := err.(*exec.ExitError); ok {
+			proc.ExitState = exitError.ProcessState
+		}
+	}
+	proc.ExitState = proc.Cmd.ProcessState
+	proc.EndTime = time.Now() // TODO make this goroutine-safe
+}
+
+// ReadAll calls ioutil.ReadAll on the StdoutPipe and StderrPipe.
+func (proc *Process) ReadAll() (stdout []byte, stderr []byte, err error) {
+	outbz, err := ioutil.ReadAll(proc.StdoutPipe)
+	if err != nil {
+		return nil, nil, err
+	}
+	errbz, err := ioutil.ReadAll(proc.StderrPipe)
+	if err != nil {
+		return nil, nil, err
+	}
+	return outbz, errbz, nil
+}

--- a/integration/deployment_test.go
+++ b/integration/deployment_test.go
@@ -31,7 +31,7 @@ func TestDeployment(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create deployment
-	f.TxCreateDeployment(fmt.Sprintf("--from=%s", keyFoo), "-y")
+	f.TxCreateDeployment(deploymentFilePath, fmt.Sprintf("--from=%s", keyFoo), "-y")
 	tests.WaitForNextNBlocksTM(1, f.Port)
 
 	// test query deployments

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -19,11 +19,7 @@ import (
 )
 
 func TestE2EApp(t *testing.T) {
-	// Assert that there is an addressable docker container for KinD
-	host := os.Getenv("KIND_K8S_IP")
-	require.NotEmpty(t, host)
-	appPort := os.Getenv("KIND_APP_PORT")
-	require.NotEmpty(t, appPort)
+	host, appPort := appEnv(t)
 
 	t.Parallel()
 	f := InitFixtures(t)
@@ -142,8 +138,16 @@ func TestE2EApp(t *testing.T) {
 
 	// Close deployment to clean up container
 	//  Teardown/cleanup
-	f.TxCloseDeployment(fmt.Sprintf("--from=%s --dseq=%v", keyBar, createdDep.Deployment.DeploymentID.DSeq), "-y")
-	tests.WaitForNextNBlocksTM(3, f.Port)
+	// TODO: uncomment
+	//f.TxCloseDeployment(fmt.Sprintf("--from=%s --dseq=%v", keyBar, createdDep.Deployment.DeploymentID.DSeq), "-y")
+	//tests.WaitForNextNBlocksTM(3, f.Port)
+}
+
+func TestQueryApp(t *testing.T) {
+	host, appPort := appEnv(t)
+
+	appURL := fmt.Sprintf("http://%s:%s/", host, appPort)
+	queryApp(t, appURL)
 }
 
 // Assert provider launches app in kind cluster
@@ -185,12 +189,11 @@ func queryApp(t *testing.T, appURL string) {
 	assert.Contains(t, string(bytes), "The Future of The Cloud is Decentralized")
 }
 
-func TestQueryApp(t *testing.T) {
-	host := os.Getenv("KIND_K8S_IP")
+// appEnv asserts that there is an addressable docker container for KinD
+func appEnv(t *testing.T) (string, string) {
+	host := os.Getenv("KIND_APP_IP")
 	require.NotEmpty(t, host)
 	appPort := os.Getenv("KIND_APP_PORT")
 	require.NotEmpty(t, appPort)
-
-	appURL := fmt.Sprintf("http://%s:%s/", host, appPort)
-	queryApp(t, appURL)
+	return host, appPort
 }

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -1,0 +1,196 @@
+// +build e2e,integration,!mainnet
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/tests"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2EApp(t *testing.T) {
+	// Assert that there is an addressable docker container for KinD
+	host := os.Getenv("KIND_K8S_IP")
+	require.NotEmpty(t, host)
+	appPort := os.Getenv("KIND_APP_PORT")
+	require.NotEmpty(t, appPort)
+
+	t.Parallel()
+	f := InitFixtures(t)
+	defer f.Cleanup() // NOTE: defer statement ordering matters.
+
+	// start akashd server
+	proc := f.AkashdStart()
+	defer func() { // shutdown akashd
+		err := proc.Stop(false)
+		require.NoError(t, err)
+		so, se, err := proc.ReadAll()
+		require.NoError(t, err)
+		assert.Empty(t, se, "akashd output", so)
+	}()
+
+	// Save key addresses for later use
+	fooAddr := f.KeyAddress(keyFoo)
+	barAddr := f.KeyAddress(keyBar)
+
+	fooAcc := f.QueryAccount(fooAddr)
+	startTokens := sdk.TokensFromConsensusPower(denomStartValue)
+	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
+
+	// address for provider to listen on
+	_, port, err := server.FreeTCPAddr()
+	require.NoError(t, err)
+	provHost := fmt.Sprintf("localhost:%s", port)
+	provURL := url.URL{
+		Host:   provHost,
+		Scheme: "http",
+	}
+
+	provFileStr := fmt.Sprintf(providerTemplate, provURL.String())
+	tmpFile, err := ioutil.TempFile(f.RootDir, "provider.yaml")
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString(provFileStr)
+	require.NoError(t, err)
+	defer func() {
+		err = tmpFile.Close()
+		require.NoError(t, err)
+	}()
+	fstat, err := tmpFile.Stat()
+	require.NoError(t, err)
+	tfilePath := fmt.Sprintf("%s/%s", f.RootDir, fstat.Name())
+
+	// Create provider
+	f.TxCreateProviderFromFile(tfilePath, fmt.Sprintf("--from=%s", keyFoo), "-y")
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	// test query providers
+	providers := f.QueryProviders()
+	require.Len(t, providers, 1, "Creating provider failed")
+	require.Equal(t, fooAddr.String(), providers[0].Owner.String())
+
+	// test query provider
+	createdProvider := providers[0]
+	provider := f.QueryProvider(createdProvider.Owner.String())
+	require.Equal(t, createdProvider, provider)
+
+	// Run provider service
+	provProc, provHost := f.ProviderStart(keyFoo, provHost)
+	defer func() { // shutdown provider
+		err := provProc.Stop(true)
+		require.NoError(t, err)
+		so, se, err := provProc.ReadAll()
+		require.NoError(t, err)
+		assert.Empty(t, se, "provider output", so)
+	}()
+
+	// Apply SDL to provider
+	// Create deployment for `keyBar`
+	f.TxCreateDeployment(deploymentOvrclkApp, fmt.Sprintf("--from=%s", keyBar), "-y")
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	// test query deployments
+	deployments, err := f.QueryDeployments()
+	require.NoError(t, err)
+	require.Len(t, deployments, 1, "Deployment Create Failed")
+	require.Equal(t, barAddr.String(), deployments[0].Deployment.DeploymentID.Owner.String())
+
+	// test query deployment
+	createdDep := deployments[0]
+	deployment := f.QueryDeployment(createdDep.Deployment.DeploymentID)
+	require.Equal(t, createdDep, deployment)
+
+	tests.WaitForNextNBlocksTM(1, f.Port)
+	orders, err := f.QueryOrders()
+	require.NoError(t, err)
+	require.Len(t, orders, 1, "Order creation failed")
+	require.Equal(t, barAddr.String(), orders[0].OrderID.Owner.String())
+
+	// Assert that there are no leases yet
+	leases, err := f.QueryLeases()
+	require.NoError(t, err)
+	require.Len(t, leases, 0, "no Leases should be created yet")
+
+	// Wait for then EndBlock to handle bidding and creating lease
+	tests.WaitForNextNBlocksTM(5, f.Port)
+
+	// Assert provider made bid
+	leases, err = f.QueryLeases()
+	require.NoError(t, err)
+	require.Len(t, leases, 1, "Lease should be created after bidding completes")
+	lease := leases[0]
+
+	// Provide manifest to provider service
+	f.SendManifest(lease, deploymentOvrclkApp)
+
+	// Wait for App to deploy
+	tests.WaitForNextNBlocksTM(5, f.Port)
+
+	// Assert provider launches app in kind
+	appURL := fmt.Sprintf("http://%s:%s/", host, appPort)
+	queryApp(t, appURL)
+
+	// Close deployment to clean up container
+	//  Teardown/cleanup
+	f.TxCloseDeployment(fmt.Sprintf("--from=%s --dseq=%v", keyBar, createdDep.Deployment.DeploymentID.DSeq), "-y")
+	tests.WaitForNextNBlocksTM(3, f.Port)
+}
+
+// Assert provider launches app in kind cluster
+func queryApp(t *testing.T, appURL string) {
+	req, err := http.NewRequest("GET", appURL, nil)
+	require.NoError(t, err)
+	req.Host = "hello.localhost" // NOTE: cannot be inserted as a req.Header element, that is overwritten by this req.Host field.
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("Connection", "keep-alive")
+	req.Header.Add("Accept", "text/html,application/xhtml+xml,*/*")
+	// Assert that the service is accessible. Unforetunately brittle single request.
+	tr := &http.Transport{
+		DisableKeepAlives: false,
+	}
+	client := &http.Client{
+		Transport: tr,
+	}
+
+	// retry mechanism
+	var resp *http.Response
+	for i := 0; i < 50; i++ {
+		time.Sleep(1 * time.Second) // reduce absurdly long wait period
+		resp, err = client.Do(req)
+		if err != nil {
+			t.Log(err)
+			continue
+		}
+		if resp != nil && resp.StatusCode == http.StatusOK {
+			err = nil
+			break
+		}
+	}
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(bytes), "The Future of The Cloud is Decentralized")
+}
+
+func TestQueryApp(t *testing.T) {
+	host := os.Getenv("KIND_K8S_IP")
+	require.NotEmpty(t, host)
+	appPort := os.Getenv("KIND_APP_PORT")
+	require.NotEmpty(t, appPort)
+
+	appURL := fmt.Sprintf("http://%s:%s/", host, appPort)
+	queryApp(t, appURL)
+}

--- a/integration/market_test.go
+++ b/integration/market_test.go
@@ -31,7 +31,7 @@ func TestMarket(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create deployment
-	f.TxCreateDeployment(fmt.Sprintf("--from=%s", keyFoo), "-y")
+	f.TxCreateDeployment(deploymentFilePath, fmt.Sprintf("--from=%s", keyFoo), "-y")
 	tests.WaitForNextNBlocksTM(1, f.Port)
 
 	// test query deployments

--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -49,7 +49,7 @@ type client struct {
 	log      log.Logger
 }
 
-// NewClient returns new Client instance with provided logger, host and ns. Returns error incase of failure
+// NewClient returns new Kubernetes Client instance with provided logger, host and ns. Returns error incase of failure
 func NewClient(log log.Logger, host, ns string) (Client, error) {
 	var settings settings
 	if err := env.Parse(&settings); err != nil {


### PR DESCRIPTION
Functional integration test of the Provider running against a KinD cluster locally or in GH Actions. Uses previous `integration` test functionality of bootstraping a blockchain, data, keys, and runs an Akash node. A KinD k8s cluster is created, and a `provider` service is connected to it and run.

A tenant creates a Akash demo-app Deployment, and sends the manifest to Provider. The Provider manages the deployment and runs it in KinD. The integration test then requests the static web page from the k8s external IP:Port and validates that the App is running.
    
fixes: #777
