### PR TITLE
K8s Provider Documentation update

### DIFF
--- a/_docs/examples/provider/README.md
+++ b/_docs/examples/provider/README.md
@@ -13,6 +13,7 @@ Installed commands:
 * [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 * [`jq`](https://stedolan.github.io/jq/)
 * [`curl`](https://curl.haxx.se/)
+* [`kustomize`](https://kubernetes-sigs.github.io/kustomize/installation/)
 
 ### Working Directory
 
@@ -36,6 +37,8 @@ In this tutorial, we will be using the domain `akashian.io`.
 ```sh
 PROVIDER_DOMAIN=akashian.io
 ```
+
+This `PROVIDER_DOMAIN` variable is used to configure the Kubernetes Ingress Controller domain, so for this example, a Deployment's requests will be routed via a random subdomain, eg: `kswtibraxfdhlflhrg6ahe.akashian.io`. A wildcard subdomain DNS entr is necessary to support this, eg `*.akashian.io`. This address can be customized in the [Configure provider services](#configure-provider-services) file's `ingress-domain` field, eg: `ingress-domain=ingress.akashian.io`.
 
 ### Akash Network
 

--- a/_docs/examples/provider/kustomization.yaml
+++ b/_docs/examples/provider/kustomization.yaml
@@ -9,7 +9,7 @@ images:
     # akashctl version
     ##
 
-    newTag: lastest
+    newTag: latest
 
 configMapGenerator:
 


### PR DESCRIPTION
Documentation to provide more context for configuration parameters to
create a Provider.

* `DOMAIN_INGRESS` envvar caused some issues with the test cluster which
traced back to this configuration of the Provider Deployment.
    * Required updating Cloudflare DNS as well.
* Tiny typo fixed in kustomize template.
* `kustomize` added to README required tool list.
