### PR TITLE
Base Network Policies for Akash Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ found in the [design documentation](_docs/design.md); and the target workload de
 
 # NOTE
 
-The `master` branch is currently unstable as we migrate to [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) from the previous tendermint-core implementation.   The previous, stable branch can be found at [stable](https://github.com/ovrclk/akash/tree/stable).
+The `master` branch is currently unstable as we migrate to [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) from the previous tendermint-core implementation, and to subsequent protobuf RPC implementation. The previous, stable branch can be found at [stable](https://github.com/ovrclk/akash/tree/stable).
 
 ## Akash Suite
 

--- a/_docs/examples/provider/README.md
+++ b/_docs/examples/provider/README.md
@@ -158,6 +158,14 @@ echo "password" > key-pass.txt
 (cat key-pass.txt; cat key-pass.txt) | ./bin/akashctl keys export provider 2> key.txt
 ```
 
+### Configure Kubernetes Akash Namespace
+
+Create the `akash-services` namespace for running Provider.
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/ovrclk/akash/master/_docs/kustomize/namespace.yaml
+```
+
 ### Configure Akash Kubernetes CRDs
 
 ```sh

--- a/_docs/kustomize/README.md
+++ b/_docs/kustomize/README.md
@@ -1,0 +1,29 @@
+Kustomize Kubernetes
+--------------------
+
+Directory contains templates and files to configure a Kubernetes cluster to support Akash Provider services.
+
+## `networking/`
+
+Normal Kubernetes declaration files to be `kubectl apply -f networking/`
+
+* `akash-services` namespace declaration
+* Default-deny Network policies for the `default` namespace to cripple the potential of malicious containers being run there.
+
+## `akash-services/`
+
+[Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) directory for configuring Network Policies to support `akash-services` namespace of Akash apps.
+
+`kubectl kustomize akash-services/ | kubectl apply -f -`
+
+## `akashd/` 
+
+Kustomize directory to configure running the `akash` blockchain node service.
+
+`kubectl kustomize akashd/ | kubectl apply -f -`
+
+## `akash-provider/`
+
+Kustomize directory to configure running the `akash-provider` instance which manages tenant workloads within the cluster.
+
+`kubectl kustomize akash-provider/ | kubectl apply -f -`

--- a/_docs/kustomize/akash-provider/kustomization.yaml
+++ b/_docs/kustomize/akash-provider/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - service.yaml
   - ingress.yaml
 
+namespace: akash-services
+
 commonLabels:
   app: akash-provider
   akash.network/component: akash-provider

--- a/_docs/kustomize/akash-provider/rbac.yaml
+++ b/_docs/kustomize/akash-provider/rbac.yaml
@@ -5,7 +5,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/_docs/kustomize/akash-services/kustomization.yaml
+++ b/_docs/kustomize/akash-services/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - network-policies.yaml
+
+namespace: akash-services

--- a/_docs/kustomize/akash-services/network-policies.yaml
+++ b/_docs/kustomize/akash-services/network-policies.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: akash-services-default-deny-ingress
+spec:
+  podSelector: 
+    matchLabels: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: akash-services-allow-akash-services
+spec:
+  podSelector: 
+    matchLabels: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          akash.network/name: akash-services
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: akash-services-allow-ingress-nginx
+spec:
+  podSelector: 
+    matchLabels: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx

--- a/_docs/kustomize/akashd/kustomization.yaml
+++ b/_docs/kustomize/akashd/kustomization.yaml
@@ -6,6 +6,8 @@ commonLabels:
   app: akashd
   akash.network/component: akashd
 
+namespace: akash-services
+
 configMapGenerator:
 
   - name: akashd-boot

--- a/_docs/kustomize/networking/namespace.yaml
+++ b/_docs/kustomize/networking/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: akash-services
+  labels:
+    name: akash-services
+    akash.network/name: akash-services

--- a/_docs/kustomize/networking/network-policy-default-ns-deny.yaml
+++ b/_docs/kustomize/networking/network-policy-default-ns-deny.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: default
+spec:
+  podSelector: 
+    matchLabels: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/_run/kube/README.md
+++ b/_run/kube/README.md
@@ -126,9 +126,9 @@ __t1 status__
 make query-provider
 ```
 
-## Run provider services
+## Run Provider
 
-In a third terminal, run the Provider service with command:
+To run Provider as a simple binary connecting to the cluster, in a third terminal, run the command:
 
 ### __t3 Step: 5__
 ```sh

--- a/_run/single/Makefile
+++ b/_run/single/Makefile
@@ -10,11 +10,10 @@ KUSTOMIZE_AKASHD_CACHE   ?= $(KUSTOMIZE_AKASHD_DIR)/cache
 CLIENT_EXPORT_PASSWORD   ?= 12345678
 
 PROVIDER_HOSTNAME = akash-provider.localhost
-AKASHCTL_NODE     = tcp://akashd.localhost:80
-
+AKASHCTL_NODE     = "tcp://akashd.localhost:$(KIND_PORT_BINDINGS)"
 GATEWAY_ENDPOINT ?= http://akash-provider.localhost
 
-AKASHCTL += --node "$(AKASHCTL_NODE)"
+AKASHCTL += --node $(AKASHCTL_NODE)
 
 .PHONY: kustomize-init
 kustomize-init: kustomize-init-akashd kustomize-init-provider
@@ -38,6 +37,10 @@ kustomize-init-provider:
 kustomize-install-akashd:
 	kubectl kustomize kustomize/akashd | kubectl apply -f-
 
+.PHONY: kustomize-install-provider
+kustomize-install-provider:
+	kubectl kustomize kustomize/akash-provider | kubectl apply -f-
+
 .PHONY: send-manifest
 send-manifest:
 	$(AKASHCTL) provider send-manifest "$(SDL_PATH)" \
@@ -49,7 +52,7 @@ send-manifest:
 
 .PHONY: provider-status
 provider-status:
-	$(AKASHCTL) provider status
+	$(AKASHCTL) provider status --provider "$(PROVIDER_ADDRESS)"
 
 .PHONY: provider-lease-status
 provider-lease-status:

--- a/_run/single/kind-config-calico.yaml
+++ b/_run/single/kind-config-calico.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  #podSubnet: 192.168.0.0/16 # Default Calico subnet
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    protocol: TCP

--- a/_run/single/kustomize/akash-provider/kustomization.yaml
+++ b/_run/single/kustomize/akash-provider/kustomization.yaml
@@ -2,6 +2,8 @@ bases:
   # - github.com/ovrclk/akash/_docs/kustomize/akash-provider?ref=boz/kustomize
   - ../../../../_docs/kustomize/akash-provider
 
+namespace: akash-services
+
 images:
   - name: ovrclk/akashctl
 

--- a/_run/single/kustomize/akashd/kustomization.yaml
+++ b/_run/single/kustomize/akashd/kustomization.yaml
@@ -2,6 +2,8 @@ bases:
   # - github.com/ovrclk/akash/_docs/kustomize/akashd?ref=boz/kustomize
   - ../../../../_docs/kustomize/akashd
 
+namespace: akash-services
+
 images:
   - name: ovrclk/akashd
     ##


### PR DESCRIPTION
* Calico up and running inside of _run/single KinD
  * Configuration to utilize Calico as network manager.
  * Updated Makefile targets adding `kind-cluster-calico-create`
* `akash-services` Namespace Defined for Akash services
  * Requires Namespace to be created as preflight to Calico launch.
  * Network policies enforce denying ingress traffic to `akash-services`
  namespace except from system and ingress namespaces.(protect from
  tenant mischief)
  * Kustomize templates for Akashd & Provider updated to use Namespace.
