### PR TITLE
808 fixes to _run/single

### DIFF
--- a/_run/single/Makefile
+++ b/_run/single/Makefile
@@ -31,7 +31,7 @@ kustomize-init-provider:
 	( \
 		cat "$(KUSTOMIZE_PROVIDER_CACHE)/key-pass.txt" ; \
 		cat "$(KUSTOMIZE_PROVIDER_CACHE)/key-pass.txt"   \
-	) | $(AKASHCTL_NONODE) keys export provider 2> "$(KUSTOMIZE_PROVIDER_CACHE)/key.txt"
+	) | $(AKASHCTL_NONODE) $(KEY_OPTS) keys export provider 2> "$(KUSTOMIZE_PROVIDER_CACHE)/key.txt"
 
 .PHONY: kustomize-install-akashd
 kustomize-install-akashd:

--- a/_run/single/kustomize/akashd/kustomization.yaml
+++ b/_run/single/kustomize/akashd/kustomization.yaml
@@ -57,4 +57,4 @@ patchesJson6902:
       group: networking.k8s.io
       version: v1beta1
       kind: Ingress
-      name: akashd
+      name: akash


### PR DESCRIPTION
* Makefile script missing KEY_OPT arguments
* Kustomize needed to be updated to reference new binary name.

Work to get #794 back up and running.

fixes: #808 (hopefully)