### PR TITLE
Goreleaser whitespace eradication

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,12 +29,12 @@ archives:
       - none*
 
 dockers:
-  - binaries: 
+  - binaries:
     - akash
     dockerfile: _build/Dockerfile.akash
     goos: linux
     goarch: amd64
-    image_templates:  
+    image_templates:
     - "ovrclk/akash:{{if eq .Env.MAINNET "true"}}stable{{else}}latest{{end}}"
     - "ovrclk/akash:{{ .ShortCommit }}"
     - "ovrclk/akash:{{ .Version }}"


### PR DESCRIPTION
Debugging problems with #808 tags not getting built. Plausibly due to
whitespace breaking the map of arguments in YAML preparsing.

related: #794
