### PR TITLE
Restrictive K8s PodSecurityPolicy applied to tenant namespaces

### DIFF
--- a/provider/cluster/kube/apply.go
+++ b/provider/cluster/kube/apply.go
@@ -57,6 +57,23 @@ func applyNetPolicies(ctx context.Context, kc kubernetes.Interface, b *netPolBui
 	return err
 }
 
+func applyRestrictivePodSecPoliciesToNS(ctx context.Context, kc kubernetes.Interface, p *pspRestrictedBuilder) error {
+	obj, err := kc.PolicyV1beta1().PodSecurityPolicies().Get(ctx, p.name(), metav1.GetOptions{})
+	switch {
+	case err == nil:
+		obj, err = p.update(obj)
+		if err == nil {
+			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Update(ctx, obj, metav1.UpdateOptions{})
+		}
+	case errors.IsNotFound(err):
+		obj, err = p.create()
+		if err == nil {
+			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Create(ctx, obj, metav1.CreateOptions{})
+		}
+	}
+	return err
+}
+
 func applyDeployment(ctx context.Context, kc kubernetes.Interface, b *deploymentBuilder) error {
 	obj, err := kc.AppsV1().Deployments(b.ns()).Get(ctx, b.name(), metav1.GetOptions{})
 	switch {

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/api/extensions/v1beta1"
 	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -70,6 +71,82 @@ func (b *nsBuilder) create() (*corev1.Namespace, error) { // nolint:golint,unpar
 func (b *nsBuilder) update(obj *corev1.Namespace) (*corev1.Namespace, error) { // nolint:golint,unparam
 	obj.Name = b.ns()
 	obj.Labels = b.labels()
+	return obj, nil
+}
+
+// pspRestrictedBuilder produces restrictive PodSecurityPolicies for tenant Namespaces.
+// Restricted PSP source: https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml
+type pspRestrictedBuilder struct {
+	builder
+}
+
+func newPspBuilder(settings settings, lid mtypes.LeaseID, group *manifest.Group) *pspRestrictedBuilder { // nolint:golint,unparam
+	return &pspRestrictedBuilder{builder: builder{settings: settings, lid: lid, group: group}}
+}
+
+func (p *pspRestrictedBuilder) name() string {
+	return p.ns()
+}
+
+func (p *pspRestrictedBuilder) create() (*v1beta1.PodSecurityPolicy, error) { // nolint:golint,unparam
+	falseVal := false
+	return &v1beta1.PodSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name(),
+			Namespace: p.name(),
+			Labels:    p.labels(),
+			Annotations: map[string]string{
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "docker/default,runtime/default",
+				"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+				"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+			},
+		},
+		Spec: v1beta1.PodSecurityPolicySpec{
+			Privileged:               false,
+			AllowPrivilegeEscalation: &falseVal,
+			RequiredDropCapabilities: []corev1.Capability{
+				"ALL",
+			},
+			Volumes: []v1beta1.FSType{
+				v1beta1.EmptyDir,
+				v1beta1.PersistentVolumeClaim, // Maybe?
+			},
+			HostNetwork: false,
+			HostIPC:     false,
+			HostPID:     false,
+			RunAsUser: v1beta1.RunAsUserStrategyOptions{
+				Rule: v1beta1.RunAsUserStrategyMustRunAsNonRoot,
+			},
+			SELinux: v1beta1.SELinuxStrategyOptions{
+				Rule: v1beta1.SELinuxStrategyRunAsAny,
+			},
+			SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+				Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
+				Ranges: []v1beta1.IDRange{
+					{
+						Min: int64(1),
+						Max: int64(65535),
+					},
+				},
+			},
+			FSGroup: v1beta1.FSGroupStrategyOptions{
+				Rule: v1beta1.FSGroupStrategyMustRunAs,
+				Ranges: []v1beta1.IDRange{
+					{
+						Min: int64(1),
+						Max: int64(65535),
+					},
+				},
+			},
+			ReadOnlyRootFilesystem: false,
+		},
+	}, nil
+}
+
+func (p *pspRestrictedBuilder) update(obj *v1beta1.PodSecurityPolicy) (*v1beta1.PodSecurityPolicy, error) { // nolint:golint,unparam
+	obj.Name = p.ns()
+	obj.Labels = p.labels()
 	return obj, nil
 }
 

--- a/provider/cluster/kube/builder_test.go
+++ b/provider/cluster/kube/builder_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/ovrclk/akash/manifest"
@@ -24,7 +25,7 @@ func TestLidNsSanity(t *testing.T) {
 
 	m, err := mb.create()
 	assert.NoError(t, err)
-	assert.Equal(t, m.Spec.LeaseID, leaseID)
+	assert.Equal(t, m.Spec.LeaseID.DSeq, strconv.FormatUint(leaseID.DSeq, 10))
 
 	assert.Equal(t, ns, m.Name)
 }
@@ -36,10 +37,10 @@ func TestNetworkPolicies(t *testing.T) {
 	np := newNetPolBuilder(settings{}, leaseID, g)
 	netPolicies, err := np.create()
 	assert.NoError(t, err)
-	assert.Len(t, netPolicies, 4)
+	assert.Len(t, netPolicies, 7)
 
 	pol0 := netPolicies[0]
-	assert.Equal(t, pol0.Name, "ingress-deny-all")
+	assert.Equal(t, pol0.Name, "default-deny-ingress")
 
 	// Change the DSeq ID
 	np.lid.DSeq = uint64(100)

--- a/provider/cluster/kube/k8s_integration_test.go
+++ b/provider/cluster/kube/k8s_integration_test.go
@@ -33,6 +33,11 @@ func TestNewClient(t *testing.T) {
 
 	ac, err := newClientWithSettings(testutil.Logger(t), "localhost", ns, settings)
 	require.NoError(t, err)
+	oc, ok := kubeClient.(*client)
+	if !ok {
+		require.True(t, ok, "failed interface type conversion")
+	}
+	kc := oc.kc
 
 	cc, ok := ac.(*client)
 	require.True(t, ok)
@@ -64,6 +69,11 @@ func TestNewClient(t *testing.T) {
 	deployment := deployments[0]
 
 	assert.Equal(t, lid, deployment.LeaseID())
+
+	// query namespace and pod security policies
+	psp, err := kc.PolicyV1beta1().PodSecurityPolicies().Get(ctx, b.ns(), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, psp)
 
 	svcname := group.Services[0].Name
 
@@ -124,7 +134,7 @@ func TestNewClient(t *testing.T) {
 
 	// ensure inventory used
 	// XXX: not working with kind. might be a delay issue?
-	// curnodes, err := client.Inventory(ctx)
+	// curnodes, err := kubeClient.Inventory(ctx)
 	// require.NoError(t, err)
 	// require.Len(t, curnodes, 1)
 	// curnode := curnodes[0]


### PR DESCRIPTION
* Used Kubernetes 'restrictive' pod security policy as default for now. Ideally we'll make this a 
    * Main change: No running as root in various configured setups.
    * No privilege escalation allowed by k8s.
* Applied to all namespaces created for tenants by the `manifestBuilder` type.
    * This should be tuned by SDL settings
* Passes integration testing.
* Update to tests to match namespace names for tests. The previously
created Namespace isn't used by downstream builders, which is a bit confusing and needs more debugging.

