### PR TITLE
Fix buildfile issues around Docker, switch to Golang base image

### DIFF
--- a/_build/Dockerfile.akash
+++ b/_build/Dockerfile.akash
@@ -1,5 +1,7 @@
-FROM busybox:glibc
+FROM golang:1.15.2-buster
 
 COPY ./akash .
 
 EXPOSE 26656 26657 26658
+
+

--- a/make/mod.mk
+++ b/make/mod.mk
@@ -1,11 +1,12 @@
 # Golang modules and vendoring
+
 .PHONY: deps-install
 deps-install:
 	$(GO) mod download
 
 .PHONY: deps-tidy
 deps-tidy:
-	$(GO) mod tid
+	$(GO) mod tidy
 
 .PHONY: deps-vendor
 deps-vendor:

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -41,7 +41,7 @@ release-dry-run: modvendor
 		-v `pwd`:/go/src/github.com/ovrclk/akash \
 		-w /go/src/github.com/ovrclk/akash \
 		troian/golang-cross:${GOLANG_CROSS_VERSION} \
-		--rm-dist --skip-validate --skip-publish
+		-f .goreleaser-docker.yaml --rm-dist --skip-validate --skip-publish
 
 .PHONY: release
 release: modvendor
@@ -60,4 +60,4 @@ release: modvendor
 		-v `pwd`:/go/src/github.com/ovrclk/akash \
 		-w /go/src/github.com/ovrclk/akash \
 		troian/golang-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist
+		-f .goreleaser-docker.yaml release --rm-dist

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -41,7 +41,7 @@ release-dry-run: modvendor
 		-v `pwd`:/go/src/github.com/ovrclk/akash \
 		-w /go/src/github.com/ovrclk/akash \
 		troian/golang-cross:${GOLANG_CROSS_VERSION} \
-		-f .goreleaser-docker.yaml --rm-dist --skip-validate --skip-publish
+		-f .goreleaser.yaml --rm-dist --skip-validate --skip-publish
 
 .PHONY: release
 release: modvendor
@@ -60,4 +60,4 @@ release: modvendor
 		-v `pwd`:/go/src/github.com/ovrclk/akash \
 		-w /go/src/github.com/ovrclk/akash \
 		troian/golang-cross:${GOLANG_CROSS_VERSION} \
-		-f .goreleaser-docker.yaml release --rm-dist
+		-f .goreleaser.yaml release --rm-dist


### PR DESCRIPTION
Changes

1. Fix a typo, I think you meant `mod tidy` not `mod tid` here
2. Switch to Golang as base image to fix issue around dynamic libraries like `librt`. Tried alpine but Go binaries on alpine have other issues. My locally built container can run the `akash` binary after this change.
3. Pass the `-f` command to all the invocations of the golang-cross container. Not 100% sure on this one but `release-dry-run` was failing for me.