### PR TITLE
Fix kustomize in the 'single' example #838

### DIFF
--- a/_docs/kustomize/akash-provider/deployment.yaml
+++ b/_docs/kustomize/akash-provider/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: akash-provider
-          image: ovrclk/akashctl:latest
+          image: ovrclk/akash:latest
           imagePullPolicy: IfNotPresent
           command: [ "/bin/sh", "/boot/run.sh" ]
           env:
@@ -26,7 +26,7 @@ spec:
             #
             # key.txt:      exported wallet key
             # key-pass.txt: password used to encrypt exported key
-            - name: AKASHCTL_BOOT_KEYS
+            - name: AKASH_BOOT_KEYS
               value: /boot-keys
 
             ##
@@ -34,42 +34,42 @@ spec:
             ##
 
             # --home
-            - name: AKASHCTL_HOME
+            - name: AKASH_HOME
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config
                   key: home
 
             # --from
-            - name: AKASHCTL_FROM
+            - name: AKASH_FROM
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config
                   key: from
 
             # --node
-            - name: AKASHCTL_NODE
+            - name: AKASH_NODE
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config
                   key: node
 
             # --chain-id
-            - name: AKASHCTL_CHAIN_ID
+            - name: AKASH_CHAIN_ID
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config
                   key: chain-id
 
             # --keyring-backend
-            - name: AKASHCTL_KEYRING_BACKEND
+            - name: AKASH_KEYRING_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config
                   key: keyring-backend
 
             # --trust-node
-            - name: AKASHCTL_TRUST_NODE
+            - name: AKASH_TRUST_NODE
               valueFrom:
                 configMapKeyRef:
                   name: akash-client-config

--- a/_docs/kustomize/akash-provider/ingress.yaml
+++ b/_docs/kustomize/akash-provider/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: akash-provider
@@ -7,6 +7,10 @@ spec:
     - host: akash-provider.localhost
       http:
         paths:
-          - backend: 
-              serviceName: akash-provider
-              servicePort: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: akash-provider
+                port:
+                  name: http

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -15,10 +15,10 @@ set -e
 ##
 # Import key
 ##
-/akashctl keys import "$AKASHCTL_FROM" \
+/akash --home=$AKASH_HOME keys import "$AKASHCTL_FROM" \
   "$AKASHCTL_BOOT_KEYS/key.txt" < "$AKASHCTL_BOOT_KEYS/key-pass.txt"
 
 ##
 # Run daemon
 ##
-/akashctl provider run --cluster-k8s
+/akash --home=$AKASH_HOME provider run --cluster-k8s

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -1,24 +1,31 @@
 #!/bin/sh
 
-set -e
+set -xe
 
 ##
 # Configuration sanity check
 ##
 
 # shellcheck disable=SC2015
-[ -f "$AKASHCTL_BOOT_KEYS/key.txt" ] && [ -f "$AKASHCTL_BOOT_KEYS/key-pass.txt" ] || {
-  echo "Key information not found; AKASHCTL_BOOT_KEYS is not configured properly"
+[ -f "$AKASH_BOOT_KEYS/key.txt" ] && [ -f "$AKASH_BOOT_KEYS/key-pass.txt" ] || {
+  echo "Key information not found; AKASH_BOOT_KEYS is not configured properly"
   exit 1
 }
+
+
+
+set -e
+
+env | sort
 
 ##
 # Import key
 ##
-/akash --home=$AKASH_HOME keys import "$AKASHCTL_FROM" \
-  "$AKASHCTL_BOOT_KEYS/key.txt" < "$AKASHCTL_BOOT_KEYS/key-pass.txt"
+/akash --home=$AKASH_HOME keys import --keyring-backend=$AKASH_KEYRING_BACKEND  "$AKASH_FROM" \
+  "$AKASH_BOOT_KEYS/key.txt" < "$AKASH_BOOT_KEYS/key-pass.txt"
 
 ##
 # Run daemon
 ##
-/akash --home=$AKASH_HOME provider run --cluster-k8s
+#/akash --home=$AKASH_HOME provider run --cluster-k8s
+/akash --home=$AKASH_HOME --node tcp://$AKASH_SERVICE_HOST:$AKASH_SERVICE_PORT --keyring-backend=$AKASH_KEYRING_BACKEND provider run --chain-id=$AKASH_CHAIN_ID --from "$AKASH_FROM"  --cluster-k8s

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -xe
+set -e
 
 ##
 # Configuration sanity check
@@ -14,18 +14,16 @@ set -xe
 
 
 
-set -e
-
 env | sort
 
 ##
 # Import key
 ##
-/akash --home="$AKASH_HOME" keys import --keyring-backend="$AKASH_KEYRING_BACKEND"  "$AKASH_FROM" \
+/bin/akash --home="$AKASH_HOME" keys import --keyring-backend="$AKASH_KEYRING_BACKEND"  "$AKASH_FROM" \
   "$AKASH_BOOT_KEYS/key.txt" < "$AKASH_BOOT_KEYS/key-pass.txt"
 
 ##
 # Run daemon
 ##
 #/akash --home=$AKASH_HOME provider run --cluster-k8s
-/akash --home="$AKASH_HOME" --node tcp://"$AKASH_SERVICE_HOST":"$AKASH_SERVICE_PORT" --keyring-backend="$AKASH_KEYRING_BACKEND" provider run --chain-id="$AKASH_CHAIN_ID" --from "$AKASH_FROM"  --cluster-k8s
+/bin/akash --home="$AKASH_HOME" --node tcp://"$AKASH_SERVICE_HOST":"$AKASH_SERVICE_PORT" --keyring-backend="$AKASH_KEYRING_BACKEND" provider run --chain-id="$AKASH_CHAIN_ID" --from "$AKASH_FROM"  --cluster-k8s

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -21,11 +21,11 @@ env | sort
 ##
 # Import key
 ##
-/akash --home=$AKASH_HOME keys import --keyring-backend=$AKASH_KEYRING_BACKEND  "$AKASH_FROM" \
+/akash --home="$AKASH_HOME" keys import --keyring-backend="$AKASH_KEYRING_BACKEND"  "$AKASH_FROM" \
   "$AKASH_BOOT_KEYS/key.txt" < "$AKASH_BOOT_KEYS/key-pass.txt"
 
 ##
 # Run daemon
 ##
 #/akash --home=$AKASH_HOME provider run --cluster-k8s
-/akash --home=$AKASH_HOME --node tcp://$AKASH_SERVICE_HOST:$AKASH_SERVICE_PORT --keyring-backend=$AKASH_KEYRING_BACKEND provider run --chain-id=$AKASH_CHAIN_ID --from "$AKASH_FROM"  --cluster-k8s
+/akash --home="$AKASH_HOME" --node tcp://"$AKASH_SERVICE_HOST":"$AKASH_SERVICE_PORT" --keyring-backend="$AKASH_KEYRING_BACKEND" provider run --chain-id="$AKASH_CHAIN_ID" --from "$AKASH_FROM"  --cluster-k8s

--- a/_docs/kustomize/akashd/ingress.yaml
+++ b/_docs/kustomize/akashd/ingress.yaml
@@ -13,4 +13,4 @@ spec:
               service:
                 name: akash
                 port:
-                  number: 26657
+                  name: akash-rpc

--- a/_docs/kustomize/akashd/ingress.yaml
+++ b/_docs/kustomize/akashd/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: akash
@@ -7,6 +7,10 @@ spec:
     - host: akash.localhost
       http:
         paths:
-          - backend: 
-              serviceName: akash
-              servicePort: akash-rpc
+          - path: /
+            pathType: Prefix
+            backend:  
+              service:
+                name: akash
+                port:
+                  number: 26657

--- a/_docs/kustomize/akashd/run.sh
+++ b/_docs/kustomize/akashd/run.sh
@@ -14,4 +14,4 @@ cp "$AKASH_BOOT_DATA/genesis.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/node_key.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/priv_validator_key.json" "$AKASH_HOME/config/"
 
-/akash start
+/akash start --home=$AKASH_HOME

--- a/_docs/kustomize/akashd/run.sh
+++ b/_docs/kustomize/akashd/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -xe
 
 env | sort
 
@@ -14,4 +14,4 @@ cp "$AKASH_BOOT_DATA/genesis.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/node_key.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/priv_validator_key.json" "$AKASH_HOME/config/"
 
-/akash start --home=$AKASH_HOME
+/akash --home=$AKASH_HOME start 

--- a/_docs/kustomize/akashd/run.sh
+++ b/_docs/kustomize/akashd/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -xe
+set -e
 
 env | sort
 
@@ -14,4 +14,4 @@ cp "$AKASH_BOOT_DATA/genesis.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/node_key.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/priv_validator_key.json" "$AKASH_HOME/config/"
 
-/akash --home="$AKASH_HOME" start
+/bin/akash --home="$AKASH_HOME" start

--- a/_docs/kustomize/akashd/run.sh
+++ b/_docs/kustomize/akashd/run.sh
@@ -14,4 +14,4 @@ cp "$AKASH_BOOT_DATA/genesis.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/node_key.json" "$AKASH_HOME/config/"
 cp "$AKASH_BOOT_KEYS/priv_validator_key.json" "$AKASH_HOME/config/"
 
-/akash --home=$AKASH_HOME start 
+/akash --home="$AKASH_HOME" start

--- a/_docs/kustomize/akashd/service.yaml
+++ b/_docs/kustomize/akashd/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: akash
 spec:
   selector:
-    app: akash
+    app: akashd
   ports:
     - name: akash-rpc
       port: 26657

--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -38,6 +38,15 @@ app-http-port:
 kind-k8s-ip:
 	@echo $(KIND_K8S_IP)
 
+.PHONY: kind-configure-image
+kind-configure-image:
+	echo "- op: replace\n  path: /spec/template/spec/containers/0/image\n  value: ${DOCKER_IMAGE}" > ./kustomize/akashd/docker-image.yaml && \
+    cp ./kustomize/akashd/docker-image.yaml ./kustomize/akash-provider/docker-image.yaml
+
+.PHONY: kind-upload-image
+kind-upload-image:
+	kind --name "$(KIND_NAME)" load docker-image "${DOCKER_IMAGE}"
+
 .PHONY: kind-port-bindings
 kind-port-bindings:
 	@echo $(KIND_PORT_BINDINGS)

--- a/_run/kube/deployment.yaml
+++ b/_run/kube/deployment.yaml
@@ -3,12 +3,12 @@ version: "2.0"
 
 services:
   web:
-    image: ropes/akash-app:v1
+    image: quay.io/ovrclk/demo-app
     expose:
-      - port: 8080
+      - port: 80
         as: 80
         accept:
-          - test.localhost
+          - hello.localhost
         to:
           - global: true
 

--- a/_run/single/Makefile
+++ b/_run/single/Makefile
@@ -10,7 +10,7 @@ KUSTOMIZE_AKASHD_CACHE   ?= $(KUSTOMIZE_AKASHD_DIR)/cache
 CLIENT_EXPORT_PASSWORD   ?= 12345678
 
 PROVIDER_HOSTNAME = akash-provider.localhost
-AKASHCTL_NODE     = "tcp://akashd.localhost:$(KIND_PORT_BINDINGS)"
+AKASHCTL_NODE     = "tcp://akash.localhost:$(KIND_PORT_BINDINGS)"
 GATEWAY_ENDPOINT ?= http://akash-provider.localhost
 
 AKASHCTL += --node $(AKASHCTL_NODE)

--- a/_run/single/Makefile
+++ b/_run/single/Makefile
@@ -56,7 +56,7 @@ provider-status:
 
 .PHONY: provider-lease-status
 provider-lease-status:
-	$(AKASHCTL) provider status lease-status \
+	$(AKASHCTL) provider lease-status \
 		--owner     "$(KEY_ADDRESS)" \
 		--dseq      "$(DSEQ)"        \
 		--gseq      "$(GSEQ)"        \

--- a/_run/single/Makefile
+++ b/_run/single/Makefile
@@ -63,6 +63,10 @@ provider-lease-status:
 		--oseq      "$(OSEQ)"        \
 		--provider  "$(PROVIDER_ADDRESS)"
 
+.PHONY: provider-lease-ping
+provider-lease-ping:
+	curl -sIH "Host: hello.localhost" localhost:$(KIND_HTTP_PORT)
+
 .PHONY:
 clean-all: clean
 	git clean -fdX

--- a/_run/single/README.md
+++ b/_run/single/README.md
@@ -76,6 +76,15 @@ make clean-all kind-cluster-clean
 make init kustomize-init
 ```
 
+The next step is to configure the docker image to be used. If you want to use a specific
+image, set `DOCKER_IMAGE` to the image reference in the command below. Otherwise
+use `ovrclk/akash:latest` to use the default image.
+
+__t1__
+```sh
+DOCKER_IMAGE=ovrclk/akash:latest make kind-configure-image
+```
+
 ### Initialize Cluster
 
 Start and initialize kind. There are two options for network manager; standard CNI, or Calico.
@@ -99,6 +108,16 @@ make kind-cluster-create
 make kind-cluster-calico-create
 ```
 
+# (Optional) Upload a local docker image
+
+If you specified a custom image in the earlier step you need to upload that image into the Kubernetes
+cluster created by the `kind` command. This uploads an image from your local docker into the Kubernetes
+clsuter.
+
+__t1__
+```sh
+DOCKER_IMAGE=ovrclk/akash:mycustomtag make kind-upload-image
+```
 
 ### Build Akash binaries and initialize network
 

--- a/_run/single/kustomize/akash-provider/.gitignore
+++ b/_run/single/kustomize/akash-provider/.gitignore
@@ -1,1 +1,2 @@
 /cache
+docker-image.yaml

--- a/_run/single/kustomize/akash-provider/kustomization.yaml
+++ b/_run/single/kustomize/akash-provider/kustomization.yaml
@@ -4,15 +4,6 @@ bases:
 
 namespace: akash-services
 
-images:
-  - name: ovrclk/akashctl
-
-    ##
-    # akashctl version
-    ##
-
-    newTag: 0.7.4
-
 configMapGenerator:
 
   ##
@@ -44,9 +35,15 @@ patchesJson6902:
   - path: gateway-host.yaml
     target:
       group: networking.k8s.io
-      version: v1beta1
+      version: v1
       kind: Ingress
       name: akash-provider
+  - path: docker-image.yaml
+    target:
+      kind: Deployment
+      group: apps
+      name: akash-provider
+      version: v1
 
 secretGenerator:
 
@@ -59,3 +56,4 @@ secretGenerator:
     files:
       - cache/key.txt
       - cache/key-pass.txt
+

--- a/_run/single/kustomize/akashd/.gitignore
+++ b/_run/single/kustomize/akashd/.gitignore
@@ -1,1 +1,2 @@
 /cache
+docker-image.yaml

--- a/_run/single/kustomize/akashd/kustomization.yaml
+++ b/_run/single/kustomize/akashd/kustomization.yaml
@@ -4,15 +4,6 @@ bases:
 
 namespace: akash-services
 
-images:
-  - name: ovrclk/akash
-
-    ##
-    # akashctl version
-    ##
-
-    newTag: latest
-
 configMapGenerator:
 
 
@@ -55,6 +46,13 @@ patchesJson6902:
   - path: gateway-host.yaml
     target:
       group: networking.k8s.io
-      version: v1beta1
+      version: v1
       kind: Ingress
       name: akash
+  - path: docker-image.yaml
+    target:
+      kind: Deployment
+      group: apps
+      name: akashd
+      version: v1
+


### PR DESCRIPTION
This is a bunch of changes I've made to get the example `single` working. I have it working with my custom hacked up docker image, once Cosmos SDK merges my fix it should be possible to have a working example again.

This is a brief summary of the changes

1. Fix things referencing `akashctl` & `AKASH_CTL` since those are obsolete
2. Update the `run.sh` scripts that are part of kustomize to set the correct flags
3. Add the ping command to the Makefile for this example
4. Allow uploading a custom image via Makefile commands
5. Remove some un-needed verbs in the Makefile
6. Update the Ingress declarations to be v1
 