### PR TITLE
fix: `tx` commands missing --keyring-backend

### DIFF
--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -217,6 +217,8 @@ func txCmd() *cobra.Command {
 	// add modules' tx commands
 	app.ModuleBasics().AddTxCommands(cmd)
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
+	cmd.PersistentFlags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend,
+		"Select keyring's backend (os|file|kwallet|pass|test)")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes problems related to using keys not hosted in the `os` keyring
backend. This comes up with managing keys for testnets in the
`tx` subcommands. Enables management of remote resources using
local keys.

By adding the flag, `akash` can be correctly directed to reference a
`test` keyring in directories where sets of keys are created and not
stored in the OS keyring.

