### PR TITLE
fix: exported Makefile variables caused noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ APP_DIR               := ./app
 GO                    := GO111MODULE=on go
 GOBIN                 := $(shell go env GOPATH)/bin
 
-export KIND_APP_IP    ?= $(shell make -sC _run/kube kind-k8s-ip)
-export KIND_APP_PORT  ?= $(shell make -sC _run/kube app-http-port)
+KIND_APP_IP           ?= $(shell make -sC _run/kube kind-k8s-ip)
+KIND_APP_PORT         ?= $(shell make -sC _run/kube app-http-port)
 KIND_VARS             ?= KIND_APP_IP="$(KIND_APP_IP)" KIND_APP_PORT="$(KIND_APP_PORT)"
 
 UNAME_OS              := $(shell uname -s)


### PR DESCRIPTION
Setting the variables using 'export' causes them to execute the shell
commands for *every* make command. They are only useful for `kind` make
targets, so the error messages from their run in all other instances
produces a lot of irrelevant error log messages.

eg:
```
$make test-sublinters
docker run --rm -v github.com/ovrclk/akash:/workspace -w /workspace golangci/golangci-lint:v1.31.0-alpine golangci-lint run ./... --disable-all --deadline=5m --enable deadcode
Error: No such container: kube-control-plane
Error: No such container: kube-control-plane
docker run --rm -v /home/ropes/go/src/github.com/ovrclk/akash:/workspace -w /workspace golangci/golangci-lint:v1.31.0-alpine golangci-lint run ./... --disable-all --deadline=5m --enable misspell --no-config
Error: No such container: kube-control-plane
Error: No such container: kube-control-plane
docker run --rm -v /home/ropes/go/src/github.com/ovrclk/akash:/workspace -w /workspace golangci/golangci-lint:v1.31.0-alpine golangci-lint run ./... --disable-all --deadline=5m --enable goerr113
Error: No such container: kube-control-plane
Error: No such container: kube-control-plane
```
