### PR TITLE
fix: GH release syntax

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: branch name
         id: branch_name
         run: |
-          echo ::set-output name=MAINNET::$([[ $(./script/semver.sh get minor ${GITHUB_REF#refs/tags/) % 2 ]] && echo true || echo false)
+          echo ::set-output name=MAINNET::$([[ $(./script/semver.sh get minor $GITHUB_REF#refs/tags/) % 2 ]] && echo true || echo false)
       - uses: actions/setup-go@v2
       - name: release dry-run
         run: make release-dry-run


### PR DESCRIPTION
Attempt to fix the `release` GH action which is
[currently](https://github.com/ovrclk/akash/runs/1281859108?check_suite_focus=true) resulting in
an error:

```
Run echo ::set-output name=MAINNET::$([[ $(./script/semver.sh get minor ${GITHUB_REF#refs/tags/) % 2 ]] && echo true || echo false)
/home/runner/work/_temp/41120ada-b8f4-460f-b416-db488976ea0b.sh: line 1: unexpected EOF while looking for matching `}'
Error: Process completed with exit code 2.
```

Fix: remove unbalanced and unnecessary `{`

[GH Documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables) indicates no curly braces are needed.
