### PR TITLE
Network Policy corrected for Ingress-Nginx

### DIFF
--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -421,7 +421,7 @@ func (b *netPolBuilder) create() ([]*netv1.NetworkPolicy, error) { // nolint:gol
 							{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app.kubernetes.io/name": "ingress-nginx",
+										"name": "ingress-nginx",
 									},
 								},
 							},


### PR DESCRIPTION
An incorrect Network Policy namespace selector for Nginx's Ingress
controller was blocking connections. This small fix corrects the
selector allowing traffic to pass through Ingress.

fixes: #911
