### PR TITLE
feat(node): add telemetry via the cosmos SDK for basic activity on th…

### DIFF
--- a/x/deployment/handler/endblock.go
+++ b/x/deployment/handler/endblock.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ovrclk/akash/x/deployment/keeper"
 	"github.com/ovrclk/akash/x/deployment/types"
@@ -18,6 +19,7 @@ func OnEndBlock(ctx sdk.Context, keeper keeper.Keeper, mkeeper MarketKeeper) {
 
 		// set state to ordered
 		keeper.OnOrderCreated(ctx, group)
+		telemetry.IncrCounter(1.0, "akash.order_created")
 		return false
 	})
 }

--- a/x/deployment/handler/msg_server.go
+++ b/x/deployment/handler/msg_server.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
@@ -54,6 +55,7 @@ func (ms msgServer) CreateDeployment(goCtx context.Context, msg *types.MsgCreate
 	if err := ms.deployment.Create(ctx, deployment, groups); err != nil {
 		return nil, errors.Wrap(types.ErrInternal, err.Error())
 	}
+	telemetry.IncrCounter(1.0, "akash.deployment_created")
 
 	return &types.MsgCreateDeploymentResponse{}, nil
 }

--- a/x/market/handler/msg_server.go
+++ b/x/market/handler/msg_server.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -67,6 +68,7 @@ func (ms msgServer) CreateBid(goCtx context.Context, msg *types.MsgCreateBid) (*
 		return nil, err
 	}
 
+	telemetry.IncrCounter(1.0, "akash.bids")
 	return &types.MsgCreateBidResponse{}, nil
 }
 
@@ -105,6 +107,7 @@ func (ms msgServer) CloseBid(goCtx context.Context, msg *types.MsgCloseBid) (*ty
 	ms.keepers.Market.OnLeaseClosed(ctx, lease)
 	ms.keepers.Market.OnOrderClosed(ctx, order)
 	ms.keepers.Deployment.OnLeaseClosed(ctx, order.ID().GroupID())
+	telemetry.IncrCounter(1.0, "akash.order_closed")
 
 	return &types.MsgCloseBidResponse{}, nil
 }


### PR DESCRIPTION
After looking at the Cosmos SDK, this is pretty simple to add. I put everything in the handlers.

There are two questions around this

1. I don't see a way to test this? Maybe cosmos SDK can help us by adding some test provisions in the future?
2. How do end users actually hook up to this? Is it automagically exposed on the existing node when we run it?