### PR TITLE
test(provider): fix race in test

### DIFF
--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -33,6 +33,9 @@ type order struct {
 }
 
 func newOrder(svc *service, oid mtypes.OrderID, bid *mtypes.Bid, pricingStrategy BidPricingStrategy) (*order, error) {
+	return newOrderInternal(svc, oid, bid, pricingStrategy, nil)
+}
+func newOrderInternal(svc *service, oid mtypes.OrderID, bid *mtypes.Bid, pricingStrategy BidPricingStrategy, reservationFulfilledNotify chan<- int) (*order, error) {
 	// Create a subscription that will see all events that have not been read from e.sub.Events()
 	sub, err := svc.sub.Clone()
 	if err != nil {
@@ -53,7 +56,7 @@ func newOrder(svc *service, oid mtypes.OrderID, bid *mtypes.Bid, pricingStrategy
 		log:                        log,
 		lc:                         lifecycle.New(),
 		pricingStrategy:            pricingStrategy,
-		reservationFulfilledNotify: nil, // Normally nil in production
+		reservationFulfilledNotify: reservationFulfilledNotify, // Normally nil in production
 	}
 
 	// Shut down when parent begins shutting down

--- a/testutil/channel_wait.go
+++ b/testutil/channel_wait.go
@@ -1,0 +1,39 @@
+package testutil
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func ChannelWaitForValueUpTo(t *testing.T, waitOn interface{}, waitFor time.Duration) interface{} {
+	cases := make([]reflect.SelectCase, 2)
+	cases[0] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(waitOn),
+		Send: reflect.Value{},
+	}
+
+	delayChan := time.After(waitFor)
+
+	cases[1] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(delayChan),
+		Send: reflect.Value{},
+	}
+
+	idx, v, ok := reflect.Select(cases)
+	if !ok {
+		t.Fatal("Channel has been closed")
+	}
+	if idx != 0 {
+		t.Fatalf("No message after waiting %v seconds", waitOn)
+	}
+
+	return v.Interface()
+}
+
+func ChannelWaitForValue(t *testing.T, waitOn interface{}) interface{} {
+	const waitForDefault = 10 * time.Second
+	return ChannelWaitForValueUpTo(t, waitOn, waitForDefault)
+}


### PR DESCRIPTION
I think in the process of fixing one race, I introduced another one. This refactor should fix that. I also made some changes suggested by @troian  to prevent non obvious timeouts in CI.

