### PR TITLE
feat(provider): Use per megabyte for scale of storage & memory pricin…

### DIFF
--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -104,17 +104,17 @@ func RunCmd() *cobra.Command {
 		return nil
 	}
 
-	cmd.Flags().Uint64(FlagBidPriceCPUScale, 0, "cpu pricing scale in uakt")
+	cmd.Flags().Uint64(FlagBidPriceCPUScale, 0, "cpu pricing scale in uakt per millicpu")
 	if err := viper.BindPFlag(FlagBidPriceCPUScale, cmd.Flags().Lookup(FlagBidPriceCPUScale)); err != nil {
 		return nil
 	}
 
-	cmd.Flags().Uint64(FlagBidPriceMemoryScale, 0, "memory pricing scale in uakt")
+	cmd.Flags().Uint64(FlagBidPriceMemoryScale, 0, "memory pricing scale in uakt per megabyte")
 	if err := viper.BindPFlag(FlagBidPriceMemoryScale, cmd.Flags().Lookup(FlagBidPriceMemoryScale)); err != nil {
 		return nil
 	}
 
-	cmd.Flags().Uint64(FlagBidPriceStorageScale, 0, "storage pricing scale in uakt")
+	cmd.Flags().Uint64(FlagBidPriceStorageScale, 0, "storage pricing scale in uakt per megabyte")
 	if err := viper.BindPFlag(FlagBidPriceStorageScale, cmd.Flags().Lookup(FlagBidPriceStorageScale)); err != nil {
 		return nil
 	}


### PR DESCRIPTION
This makes the memory & storage pricing per megabyte instead of per byte. I added some additional tests to cover the logic I implemented to get this working.