### PR TITLE
feat(kustomize): Allow use of a python 3 shell script for pricing in …

### DIFF
--- a/_build/Dockerfile.akash
+++ b/_build/Dockerfile.akash
@@ -1,5 +1,7 @@
 FROM debian:buster
 
+RUN apt-get update && apt-get --no-install-recommends -y install python3 && apt-get clean
+
 COPY ./akash /bin/
 
 EXPOSE 26656 26657 26658

--- a/_docs/kustomize/akash-provider/deployment.yaml
+++ b/_docs/kustomize/akash-provider/deployment.yaml
@@ -300,12 +300,6 @@ spec:
                   key: bid-script-process-timeout
                   optional: true
 
-            - name: AKASH_BID_PRICE_SCRIPT_CONTENTS
-              valueFrom:
-                 configMapKeyRef:
-                   name: akash-provider-config
-                   key: bid-price-script-contents
-                   optional: true
           ports:
             - name: http
               containerPort: 8080
@@ -316,10 +310,19 @@ spec:
             - name: keys
               mountPath: /boot-keys
               readOnly: true
+
       volumes:
         - name: boot
           configMap:
             name: akash-provider-boot
+            items:
+              - key: pricing.sh
+                path: pricing.sh
+                mode: 0555
+              - key: run.sh
+                path: run.sh
+                mode: 0555
+
         - name: keys
           secret:
             secretName: akash-provider-keys

--- a/_docs/kustomize/akash-provider/deployment.yaml
+++ b/_docs/kustomize/akash-provider/deployment.yaml
@@ -299,6 +299,13 @@ spec:
                   name: akash-provider-config
                   key: bid-script-process-timeout
                   optional: true
+
+            - name: AKASH_BID_PRICE_SCRIPT_CONTENTS
+              valueFrom:
+                 configMapKeyRef:
+                   name: akash-provider-config
+                   key: bid-price-script-contents
+                   optional: true
           ports:
             - name: http
               containerPort: 8080

--- a/_docs/kustomize/akash-provider/kustomization.yaml
+++ b/_docs/kustomize/akash-provider/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
   - name: akash-provider-boot
     files:
       - run.sh
+      - pricing.sh
 
   - name: akash-client-config
     literals:

--- a/_docs/kustomize/akash-provider/pricing.sh
+++ b/_docs/kustomize/akash-provider/pricing.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import math
+import sys
+import json
+import random
+
+cpu_rate = 1
+memory_rate = 2
+storage_base_rate = 3 # For smaller deployments
+storage_high_rate = 100 # For larger deployments
+# The point at which a deployment becomes large in terms of storage
+tier_threshold = 9.5 * (1024**3) # gigabytes
+
+# Read JSON from standard input
+order_data = json.load(sys.stdin)
+
+# Store the total counts in these variables
+total_cpu = 0
+total_memory = 0
+total_storage = 0
+
+total_endpoints = 0
+
+for group in order_data: # Iterate over the array
+  # Add up what is being ordered
+  total_cpu += group['cpu'] * group['count']
+  total_memory += group['memory'] * group['count']
+  total_storage += group['storage'] * group['count']
+  total_endpoints += group['endpoint-quantity'] * group['count']
+
+# Use the base rate by default
+storage_rate = storage_base_rate
+
+# If the deployment is large, then switch to the high rate
+if total_storage >= tier_threshold:
+  storage_rate = storage_high_rate
+
+# Use units of megabytes
+total_memory /= 1024**2
+total_storage /= 1024**2
+
+# Compute the final price that is used for the bid
+price = cpu_rate * total_cpu
+price += memory_rate * total_memory
+price += storage_rate * total_storage
+
+if total_endpoints > 2:
+  price += random.randint(50000, 300000)
+
+price += random.randint(-2, 2)
+
+price = max(price, 0)
+
+# Round upwards, then convert to an integer. Write to standard out as JSON
+json.dump(int(math.ceil(price)), sys.stdout)
+
+

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -n "${AKASH_BID_PRICE_SCRIPT_CONTENTS}" ]; then
+pricing_script_path="/boot/pricing.sh"
+pricing_script_size=$(stat -c%s ${pricing_script_path?})
+
+if [ $pricing_script_size > 0 ]; then
   echo 'setting up bid price script'
-  echo "${AKASH_BID_PRICE_SCRIPT_CONTENTS}" > /bin/pricing.sh
-  chmod 555 /bin/pricing.sh
-  AKASH_BID_PRICE_SCRIPT_PATH=/bin/pricing.sh
-  export AKASH_BID_PRICE_SCRIPT_PATH
-  export AKASH_BID_PRICE_STRATEGY=shellScript
+  export AKASH_BID_PRICE_SCRIPT_PATH=$pricing_script_path
+  export 'AKASH_BID_PRICE_STRATEGY'='shellScript'
 fi
 
 ##

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -5,7 +5,7 @@ set -e
 pricing_script_path="/boot/pricing.sh"
 pricing_script_size=$(stat -c%s ${pricing_script_path?})
 
-if [ $pricing_script_size > 0 ]; then
+if [ "$pricing_script_size" -gt 0 ]; then
   echo 'setting up bid price script'
   export AKASH_BID_PRICE_SCRIPT_PATH=$pricing_script_path
   export 'AKASH_BID_PRICE_STRATEGY'='shellScript'

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -3,13 +3,7 @@
 set -e
 
 pricing_script_path="/boot/pricing.sh"
-pricing_script_size=$(stat -c%s ${pricing_script_path?})
-
-if [ "$pricing_script_size" -gt 0 ]; then
-  echo 'setting up bid price script'
-  export AKASH_BID_PRICE_SCRIPT_PATH=$pricing_script_path
-  export 'AKASH_BID_PRICE_STRATEGY'='shellScript'
-fi
+export AKASH_BID_PRICE_SCRIPT_PATH="$pricing_script_path"
 
 ##
 # Configuration sanity check

--- a/_docs/kustomize/akash-provider/run.sh
+++ b/_docs/kustomize/akash-provider/run.sh
@@ -1,6 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+
+if [ -n "${AKASH_BID_PRICE_SCRIPT_CONTENTS}" ]; then
+  echo 'setting up bid price script'
+  echo "${AKASH_BID_PRICE_SCRIPT_CONTENTS}" > /bin/pricing.sh
+  chmod 555 /bin/pricing.sh
+  AKASH_BID_PRICE_SCRIPT_PATH=/bin/pricing.sh
+  export AKASH_BID_PRICE_SCRIPT_PATH
+  export AKASH_BID_PRICE_STRATEGY=shellScript
+fi
 
 ##
 # Configuration sanity check

--- a/_run/single/kustomize/akash-provider/kustomization.yaml
+++ b/_run/single/kustomize/akash-provider/kustomization.yaml
@@ -25,7 +25,29 @@ configMapGenerator:
       - cluster-public-hostname=app.localhost
       - cluster-node-port-quantity=100
       - bid-price-strategy=randomRange
+      - "bid-price-script-contents=#!/usr/bin/env python3\nimport math\nimport sys\nimport\
+          \ json\nimport random\n\ncpu_rate = 1\nmemory_rate = 2\nstorage_base_rate = 3 #\
+          \ For smaller deployments\nstorage_high_rate = 100 # For larger deployments\n# The\
+          \ point at which a deployment becomes large in terms of storage\ntier_threshold\
+          \ = 9.5 * (1024**3) # gigabytes\n\n# Read JSON from standard input\norder_data =\
+          \ json.load(sys.stdin)\n\n# Store the total counts in these variables\ntotal_cpu\
+          \ = 0\ntotal_memory = 0\ntotal_storage = 0\n\ntotal_endpoints = 0\n\nfor group in\
+          \ order_data: # Iterate over the array\n  # Add up what is being ordered\n  total_cpu\
+          \ += group['cpu'] * group['count']\n  total_memory += group['memory'] * group['count']\n\
+          \  total_storage += group['storage'] * group['count']\n  total_endpoints += group['endpoint-quantity']\
+          \ * group['count']\n\n# Use the base rate by default\nstorage_rate = storage_base_rate\n\
+          \n# If the deployment is large, then switch to the high rate\nif total_storage >=\
+          \ tier_threshold:\n  storage_rate = storage_high_rate\n\n# Use units of megabytes\n\
+          total_memory /= 1024**2\ntotal_storage /= 1024**2\n\n# Compute the final price that\
+          \ is used for the bid\nprice = cpu_rate * total_cpu\nprice += memory_rate * total_memory\n\
+          price += storage_rate * total_storage\n\nif total_endpoints > 2:\n  price += random.randint(50000,\
+          \ 300000)\n\nprice += random.randint(-2, 2)\n\nprice = max(price, 0)\n\n# Round\
+          \ upwards, then convert to an integer. Write to standard out as JSON\njson.dump(int(math.ceil(price)),\
+          \ sys.stdout)\n\n\n"
+
       # - ingress-static-hosts=false
+
+
 
 patchesJson6902:
 

--- a/_run/single/kustomize/akash-provider/kustomization.yaml
+++ b/_run/single/kustomize/akash-provider/kustomization.yaml
@@ -25,29 +25,7 @@ configMapGenerator:
       - cluster-public-hostname=app.localhost
       - cluster-node-port-quantity=100
       - bid-price-strategy=randomRange
-      - "bid-price-script-contents=#!/usr/bin/env python3\nimport math\nimport sys\nimport\
-          \ json\nimport random\n\ncpu_rate = 1\nmemory_rate = 2\nstorage_base_rate = 3 #\
-          \ For smaller deployments\nstorage_high_rate = 100 # For larger deployments\n# The\
-          \ point at which a deployment becomes large in terms of storage\ntier_threshold\
-          \ = 9.5 * (1024**3) # gigabytes\n\n# Read JSON from standard input\norder_data =\
-          \ json.load(sys.stdin)\n\n# Store the total counts in these variables\ntotal_cpu\
-          \ = 0\ntotal_memory = 0\ntotal_storage = 0\n\ntotal_endpoints = 0\n\nfor group in\
-          \ order_data: # Iterate over the array\n  # Add up what is being ordered\n  total_cpu\
-          \ += group['cpu'] * group['count']\n  total_memory += group['memory'] * group['count']\n\
-          \  total_storage += group['storage'] * group['count']\n  total_endpoints += group['endpoint-quantity']\
-          \ * group['count']\n\n# Use the base rate by default\nstorage_rate = storage_base_rate\n\
-          \n# If the deployment is large, then switch to the high rate\nif total_storage >=\
-          \ tier_threshold:\n  storage_rate = storage_high_rate\n\n# Use units of megabytes\n\
-          total_memory /= 1024**2\ntotal_storage /= 1024**2\n\n# Compute the final price that\
-          \ is used for the bid\nprice = cpu_rate * total_cpu\nprice += memory_rate * total_memory\n\
-          price += storage_rate * total_storage\n\nif total_endpoints > 2:\n  price += random.randint(50000,\
-          \ 300000)\n\nprice += random.randint(-2, 2)\n\nprice = max(price, 0)\n\n# Round\
-          \ upwards, then convert to an integer. Write to standard out as JSON\njson.dump(int(math.ceil(price)),\
-          \ sys.stdout)\n\n\n"
-
       # - ingress-static-hosts=false
-
-
 
 patchesJson6902:
 

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -23,7 +23,7 @@ test-k8s-integration:
 ###############################################################################
 
 shellcheck:
-	docker run --rm \
+	docker run -e SHELLCHECK_OPTS="-e SC1071" --rm \
 	--volume ${PWD}:/shellcheck \
 	--entrypoint sh \
 	koalaman/shellcheck-alpine:stable \


### PR DESCRIPTION
This changes the following

1. Adds python3 to the docker container for akash
2. Adds another env. var. to kustomize
3. If the env. var. is set when the provider is launched the contents are placed into a shell script and the provider is set to use that as the pricing strategy.

I ran this locally with kind and it worked 

