### PR TITLE
feat(provider): Set limits when configuring containers in kubernetes

### DIFF
--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -261,6 +261,11 @@ func (b *deploymentBuilder) container() corev1.Container {
 		kcontainer.Resources.Limits[corev1.ResourceMemory] = resource.NewQuantity(int64(mem.Quantity.Value()), resource.DecimalSI).DeepCopy()
 	}
 
+	if storage := b.service.Resources.Storage; storage != nil {
+		storageQuantity := storage.Quantity.Val.Int64()
+		kcontainer.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.NewQuantity(int64(storageQuantity), resource.DecimalSI).DeepCopy()
+	}
+
 	// TODO: this prevents over-subscription.  skip for now.
 
 	for _, env := range b.service.Env {

--- a/x/deployment/types/validation_config.go
+++ b/x/deployment/types/validation_config.go
@@ -29,7 +29,7 @@ var validationConfig = struct {
 }{
 	MaxUnitCPU:     1000,
 	MaxUnitMemory:  1073741824,
-	MaxUnitStorage: 1073741824,
+	MaxUnitStorage: 10 * 1073741824,
 	MaxUnitCount:   10,
 	MaxUnitPrice:   10000,
 


### PR DESCRIPTION
This bumps up the limit & enforces it on kubernetes containers. There is no such feature as a storage limit, only ephemeral storage limits. We don't create actual kubernetes storage that I see anywhere.



