### PR TITLE
fix(node): only count service as endpoints when they are global

### DIFF
--- a/provider/cluster/inventory.go
+++ b/provider/cluster/inventory.go
@@ -263,6 +263,7 @@ loop:
 			req.ch <- inventoryResponse{err: errNotFound}
 
 		case req := <-is.unreservech:
+			is.log.Debug("unreserving capacity", "order", req.order)
 			// remove reservation
 
 			for idx, res := range reservations {
@@ -276,6 +277,7 @@ loop:
 				reservations = append(reservations[:idx], reservations[idx+1:]...)
 
 				req.ch <- inventoryResponse{value: res}
+				is.log.Info("unreserve capacity complete", "order", req.order)
 				continue loop
 			}
 

--- a/provider/cluster/kube/apply.go
+++ b/provider/cluster/kube/apply.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"context"
-
 	akashv1 "github.com/ovrclk/akash/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"

--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -186,7 +186,7 @@ func (c *client) Deploy(ctx context.Context, lid mtypes.LeaseID, group *manifest
 
 		for expIdx := range service.Expose {
 			expose := service.Expose[expIdx]
-			if !util.ShouldExpose(expose) {
+			if !util.ShouldBeIngress(expose) {
 				continue
 			}
 			if err := applyIngress(ctx, c.kc, newIngressBuilder(c.log, c.settings, c.host, lid, group, service, &service.Expose[expIdx])); err != nil {

--- a/provider/cluster/util/util.go
+++ b/provider/cluster/util/util.go
@@ -2,7 +2,7 @@ package util
 
 import "github.com/ovrclk/akash/manifest"
 
-func ShouldExpose(expose manifest.ServiceExpose) bool {
+func ShouldBeIngress(expose manifest.ServiceExpose) bool {
 	return expose.Proto == manifest.TCP && expose.Global && 80 == ExposeExternalPort(expose)
 }
 

--- a/provider/cluster/util/util_test.go
+++ b/provider/cluster/util/util_test.go
@@ -7,30 +7,30 @@ import (
 	"testing"
 )
 
-func TestShouldExpose(t *testing.T) {
+func TestShouldBeIngress(t *testing.T) {
 	// Should not create ingress for something on port 81
-	require.False(t, util.ShouldExpose(manifest.ServiceExpose{
+	require.False(t, util.ShouldBeIngress(manifest.ServiceExpose{
 		Global: true,
 		Proto:  manifest.TCP,
 		Port:   81,
 	}))
 
 	// Should create ingress for something on port 80
-	require.True(t, util.ShouldExpose(manifest.ServiceExpose{
+	require.True(t, util.ShouldBeIngress(manifest.ServiceExpose{
 		Global: true,
 		Proto:  manifest.TCP,
 		Port:   80,
 	}))
 
 	// Should not create ingress for something on port 80 that is not Global
-	require.False(t, util.ShouldExpose(manifest.ServiceExpose{
+	require.False(t, util.ShouldBeIngress(manifest.ServiceExpose{
 		Global: false,
 		Proto:  manifest.TCP,
 		Port:   80,
 	}))
 
 	// Should not create ingress for something on port 80 that is UDP
-	require.False(t, util.ShouldExpose(manifest.ServiceExpose{
+	require.False(t, util.ShouldBeIngress(manifest.ServiceExpose{
 		Global: true,
 		Proto:  manifest.UDP,
 		Port:   80,

--- a/sdl/_testdata/private_service.yaml
+++ b/sdl/_testdata/private_service.yaml
@@ -1,0 +1,64 @@
+---
+version: "2.0"
+services:
+  bind:
+    image: bind9
+    expose:
+      - port: 53
+        proto: udp
+        to:
+          - global: true
+
+  pg:
+    image: postgresql
+    expose: 
+      - port: 5463
+        to:
+          - service: bind
+
+profiles:
+  compute:
+    bind:
+      resources:
+        cpu:
+          units: "50m"
+        memory:
+          size: "64Mi"
+        storage:
+          size: "16Mi"
+    pg:
+      resources:
+        cpu:
+          units: "500m"
+        memory:
+          size: "512Mi"
+        storage:
+          size: "1000Mi"
+
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        pg:
+          denom: uakt
+          amount: 1000
+        bind:
+          denom: uakt
+          amount: 333
+deployment:
+  pg:
+    westcoast:
+      profile: pg
+      count: 1
+  bind:
+    westcoast:
+      profile: bind
+      count: 8

--- a/sdl/_testdata/profile-svc-name-mismatch.yaml
+++ b/sdl/_testdata/profile-svc-name-mismatch.yaml
@@ -7,6 +7,8 @@ services:
     expose:
       - port: 80
         as: 80
+        accept:
+          - thehostname.com
         to:
           - global: true
 

--- a/sdl/_testdata/simple.yaml
+++ b/sdl/_testdata/simple.yaml
@@ -5,6 +5,8 @@ services:
     image: nginx
     expose:
       - port: 80
+        accept:
+          - ahostname.com
         to:
           - global: true
       - port: 12345

--- a/sdl/v2.go
+++ b/sdl/v2.go
@@ -121,20 +121,22 @@ func (sdl *v2) DeploymentGroups() ([]*dtypes.GroupSpec, error) {
 			endpointCount := 0
 			for _, expose := range sdl.Services[svcdepl.Profile].Expose {
 				for _, to := range expose.To {
-					proto, err := manifest.ParseServiceProtocol(expose.Proto)
-					if err != nil {
-						return nil, err
-					}
-					v := manifest.ServiceExpose{
-						Port:         expose.Port,
-						ExternalPort: expose.As,
-						Proto:        proto,
-						Service:      to.Service,
-						Global:       to.Global,
-						Hosts:        expose.Accept.Items,
-					}
-					if !providerUtil.ShouldExpose(v) {
-						endpointCount++
+					if to.Global {
+						proto, err := manifest.ParseServiceProtocol(expose.Proto)
+						if err != nil {
+							return nil, err
+						}
+						v := manifest.ServiceExpose{
+							Port:         expose.Port,
+							ExternalPort: expose.As,
+							Proto:        proto,
+							Service:      to.Service,
+							Global:       to.Global,
+							Hosts:        expose.Accept.Items,
+						}
+						if !providerUtil.ShouldExpose(v) {
+							endpointCount++
+						}
 					}
 				}
 			}

--- a/sdl/v2_test.go
+++ b/sdl/v2_test.go
@@ -90,6 +90,19 @@ func Test_V2_Cross_Validates(t *testing.T) {
 	err = validation.ValidateManifestWithGroupSpecs(&manifest, dgroups)
 	require.NoError(t, err)
 
+	// Repeat the same test with another file
+	sdl2, err = ReadFile("./_testdata/private_service.yaml")
+	require.NoError(t, err)
+	dgroups, err = sdl2.DeploymentGroups()
+	require.NoError(t, err)
+	manifest, err = sdl2.Manifest()
+	require.NoError(t, err)
+
+	// This is a single document producing both the manifest & deployment groups
+	// These should always agree with each other
+	err = validation.ValidateManifestWithGroupSpecs(&manifest, dgroups)
+	require.NoError(t, err)
+
 }
 
 func Test_v1_Parse_simple(t *testing.T) {

--- a/sdl/v2_test.go
+++ b/sdl/v2_test.go
@@ -144,6 +144,8 @@ func Test_v1_Parse_simple(t *testing.T) {
 
 	assert.Len(t, mani.GetGroups(), 1)
 
+	expectedHosts := make([]string, 1)
+	expectedHosts[0] = "ahostname.com"
 	assert.Equal(t, manifest.Group{
 		Name: "westcoast",
 		Services: []manifest.Service{
@@ -163,7 +165,7 @@ func Test_v1_Parse_simple(t *testing.T) {
 				},
 				Count: 2,
 				Expose: []manifest.ServiceExpose{
-					{Port: 80, Global: true, Proto: manifest.TCP},
+					{Port: 80, Global: true, Proto: manifest.TCP, Hosts: expectedHosts},
 					{Port: 12345, Global: true, Proto: manifest.UDP},
 				},
 			},

--- a/validation/manifest.go
+++ b/validation/manifest.go
@@ -103,6 +103,10 @@ func validateServiceExpose(serviceName string, serviceExpose manifest.ServiceExp
 		helper.globalServiceCount++
 	}
 
+	if util.ShouldBeIngress(serviceExpose) && 0 == len(serviceExpose.Hosts) {
+		return fmt.Errorf("%w: service %q has no hosts declared", ErrInvalidManifest, serviceName)
+	}
+
 	for _, host := range serviceExpose.Hosts {
 		if !isValidHostname(host) {
 			return fmt.Errorf("%w: service %q has invalid hostname %q", ErrInvalidManifest, serviceName, host)
@@ -230,7 +234,7 @@ deploymentGroupLoop:
 	endpointsCountForManifestGroup := 0
 	for _, service := range mgroup.Services {
 		for _, serviceExpose := range service.Expose {
-			if serviceExpose.Global && !util.ShouldExpose(serviceExpose) {
+			if serviceExpose.Global && !util.ShouldBeIngress(serviceExpose) {
 				endpointsCountForManifestGroup++
 			}
 		}


### PR DESCRIPTION
Changes 

1. Only count as an endpoint whenever the "expose" is global
2. HTTP services (kube ingress) need at least one host - this avoids an error in kubernetes
3. If there is no "to" in SDL still define a kube service
4. Put HTTP services in ClusterIP service in kube, not NodePort
