### PR TITLE
fix(provider): Remove nodeport check in the deployment monitor, only …

### DIFF
--- a/provider/cluster/monitor.go
+++ b/provider/cluster/monitor.go
@@ -160,31 +160,7 @@ func (m *deploymentMonitor) doCheck() (bool, error) {
 			}
 		}
 
-		expectedPortCount := 0
-		foundPortCount := 0
-		for _, exposed := range spec.Expose {
-			if exposed.Global {
-				expectedPortCount++
-				// Get the list of all forwarded ports for this deployment
-				forwardedPorts := status.ForwardedPorts[spec.Name]
-				for _, forwarded := range forwardedPorts {
-					// Search for a match on port & protocol
-					if exposed.Port == forwarded.Port && exposed.Proto == forwarded.Proto {
-						foundPortCount++
-						if uint32(forwarded.Available) < spec.Count {
-							badsvc++
-							m.log.Debug("service available replicas below target",
-								"service", spec.Name,
-								"available", forwarded.Available,
-								"target", spec.Count,
-							)
-						}
-					}
-				}
-			}
-		}
-
-		if !foundService || foundPortCount != expectedPortCount {
+		if !foundService  {
 			badsvc++
 			m.log.Debug("service status not found", "service", spec.Name)
 		}


### PR DESCRIPTION
We don't need to check the nodeport presence on a service it isn't strictly necessary and has some bugs. 

My deployment seems to be stable after this change

![Screenshot from 2020-11-28 17-58-07](https://user-images.githubusercontent.com/130230/100528542-d18c5f80-31a3-11eb-96f4-7becaf6a83cb.png)
