### PR TITLE
ci: fix ci build when running on branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,14 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - name: branch name
-        id: branch_name
+      - name: detect network type
+        id: environment
         run: |
           echo ::set-output name=MAINNET::$(./script/mainnet-from-tag.sh ${GITHUB_REF#refs/tags/})
-      - run: echo "Building for MAINNET=${{ steps.branch_name.outputs.MAINNET }}"
+          is_tag=false
+          if [[ "${GITHUB_REF}" =~ "^refs/tags/v.+$" ]]; then
+              is_tag=true
+          fi
+          echo ::set-output name=GORELEASER_SNAPSHOT::${is_tag}
+      - run: echo "Building for MAINNET=${{ steps.environment.outputs.MAINNET }}"
       - uses: actions/setup-go@v2
       - name: release dry-run
         run: make release-dry-run
+        env:
+          MAINNET: ${{ steps.environment.outputs.MAINNET }}
+          GORELEASER_SNAPSHOT: ${{ steps.environment.outputs.GORELEASER_SNAPSHOT }}
       - if: startsWith(github.ref,'refs/tags/v') && github.repository == 'ovrclk/akash'
         name: setup release environment
         run: |-
@@ -38,4 +46,4 @@ jobs:
         name: release publish
         run: make release
         env:
-          MAINNET: ${{ steps.branch_name.outputs.MAINNET }}
+          MAINNET: ${{ steps.environment.outputs.MAINNET }}

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -1,4 +1,5 @@
 GORELEASER_SKIP_VALIDATE ?= false
+GORELEASER_SNAPSHOT      ?= false
 
 .PHONY: bins
 bins: $(BINS)
@@ -48,7 +49,7 @@ release-dry-run: modvendor
 		-v `pwd`:/go/src/github.com/ovrclk/akash \
 		-w /go/src/github.com/ovrclk/akash \
 		troian/golang-cross:${GOLANG_CROSS_VERSION} \
-		-f "$(GORELEASER_CONFIG)" --skip-validate=$(GORELEASER_SKIP_VALIDATE) --rm-dist --skip-publish
+		-f "$(GORELEASER_CONFIG)" --skip-validate=$(GORELEASER_SKIP_VALIDATE) --snapshot=$(GORELEASER_SNAPSHOT) --rm-dist --skip-publish
 
 .PHONY: release
 release: modvendor


### PR DESCRIPTION
goreleaser with --skip-validate=false fails
if head commit is not same ref as a tag
--snaphot fixed it, as these builds are actually snapshots