### PR TITLE
network policies are blocking inter-pod connections

### DIFF
--- a/provider/cluster/kube/apply.go
+++ b/provider/cluster/kube/apply.go
@@ -49,6 +49,7 @@ func applyNetPolicies(ctx context.Context, kc kubernetes.Interface, b *netPolBui
 		}
 	}
 
+	// NOTE: When there are no policies, this will simply skip
 	for _, pol := range policies {
 		if err != nil {
 			break // short circuit running due to error returned

--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -16,6 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+
 	// TODO: re-enable.  see #946
 	// "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -432,212 +433,217 @@ func newNetPolBuilder(settings Settings, lid mtypes.LeaseID, group *manifest.Gro
 
 // Create a set of NetworkPolicies to restrict the ingress traffic to a Tenant's
 // Deployment namespace.
+// TODO: un-commment network policies onces Calico functional ones are working.
 func (b *netPolBuilder) create() ([]*netv1.NetworkPolicy, error) { // nolint:golint,unparam
 	return []*netv1.NetworkPolicy{
 		// INGRESS ---------------------------------------------------------------
-		{
-			// Deny all ingress to tenant namespace. Default rule which is opened up
-			// by subsequent rules.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolDefaultDenyIngress,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
+		/*
+			{
+				// Deny all ingress to tenant namespace. Default rule which is opened up
+				// by subsequent rules.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolDefaultDenyIngress,
+					Labels: b.labels(),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeIngress,
 					},
 				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeIngress,
-				},
 			},
-		},
 
-		{
-			// Allow ingress between services within namespace.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolIngressInternalAllow,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
-					},
+			{
+				// Allow ingress between services within namespace.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolIngressInternalAllow,
+					Labels: b.labels(),
 				},
-				Ingress: []netv1.NetworkPolicyIngressRule{
-					{ // Allow Network Connections from same Namespace
-						From: []netv1.NetworkPolicyPeer{
-							{
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										akashNetworkNamespace: lidNS(b.lid),
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{ // Allow Network Connections from same Namespace
+							From: []netv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											akashNetworkNamespace: lidNS(b.lid),
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeIngress,
-				},
-			},
-		},
-
-		{
-			// Allow valid ingress to the tentant namespace from ingress controller, by default ingress-nginx
-			// TODO: a generic selector should be used since some Providers may choose
-			// a different Ingress Controller.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolIngressAllowIngCtrl,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeIngress,
 					},
 				},
-				Ingress: []netv1.NetworkPolicyIngressRule{
-					{ // Allow Network Connections ingress-nginx Namespace
-						From: []netv1.NetworkPolicyPeer{
-							{
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										"name": "ingress-nginx",
+			},
+
+			{
+				// Allow valid ingress to the tentant namespace from ingress controller, by default ingress-nginx
+				// TODO: a generic selector should be used since some Providers may choose
+				// a different Ingress Controller.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolIngressAllowIngCtrl,
+					Labels: b.labels(),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{ // Allow Network Connections ingress-nginx Namespace
+							From: []netv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": "ingress-nginx",
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeIngress,
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeIngress,
+					},
 				},
 			},
-		},
+		*/
 
 		// EGRESS -----------------------------------------------------------------
-		{
-			// Deny all egress from tenant namespace. Default rule which is opened up
-			// by subsequent rules.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolDefaultDenyEgress,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
+		/*
+			{
+				// Deny all egress from tenant namespace. Default rule which is opened up
+				// by subsequent rules.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolDefaultDenyEgress,
+					Labels: b.labels(),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeEgress,
 					},
 				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeEgress,
-				},
 			},
-		},
 
-		{
-			// Allow egress between services within the namespace.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolEgressInternalAllow,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
-					},
+			{
+				// Allow egress between services within the namespace.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolEgressInternalAllow,
+					Labels: b.labels(),
 				},
-				Ingress: []netv1.NetworkPolicyIngressRule{
-					{ // Allow Network Connections from same Namespace
-						From: []netv1.NetworkPolicyPeer{
-							{
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										akashNetworkNamespace: lidNS(b.lid),
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{ // Allow Network Connections from same Namespace
+							From: []netv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											akashNetworkNamespace: lidNS(b.lid),
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeEgress,
-				},
-			},
-		},
-
-		{ // Allow egress to all IPs, EXCEPT local cluster.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolEgressAllowExternalCidr,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeEgress,
 					},
 				},
-				Egress: []netv1.NetworkPolicyEgressRule{
-					{ // Allow Network Connections to Internet, block access to internal IPs
-						To: []netv1.NetworkPolicyPeer{
-							{
-								IPBlock: &netv1.IPBlock{
-									CIDR: "0.0.0.0/0",
-									Except: []string{
-										// TODO: Full validation and correction required.
-										// Initial testing indicates that this exception is being ignored;
-										// eg: Internal k8s API is accessible from containers, but
-										// open Internet is made accessible by rule.
-										"10.0.0.0/8",
+			},
+
+			{ // Allow egress to all IPs, EXCEPT local cluster.
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolEgressAllowExternalCidr,
+					Labels: b.labels(),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
+						},
+					},
+					Egress: []netv1.NetworkPolicyEgressRule{
+						{ // Allow Network Connections to Internet, block access to internal IPs
+							To: []netv1.NetworkPolicyPeer{
+								{
+									IPBlock: &netv1.IPBlock{
+										CIDR: "0.0.0.0/0",
+										Except: []string{
+											// TODO: Full validation and correction required.
+											// Initial testing indicates that this exception is being ignored;
+											// eg: Internal k8s API is accessible from containers, but
+											// open Internet is made accessible by rule.
+											"10.0.0.0/8",
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeEgress,
-				},
-			},
-		},
-
-		{
-			// Allow egress to Kubernetes internal subnet for DNS
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   netPolEgressAllowKubeDNS,
-				Labels: b.labels(),
-			},
-			Spec: netv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						akashNetworkNamespace: lidNS(b.lid),
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeEgress,
 					},
 				},
-				Egress: []netv1.NetworkPolicyEgressRule{
-					{ // Allow Network Connections from same Namespace
-						Ports: []netv1.NetworkPolicyPort{
-							{
-								Protocol: &dnsProtocol,
-								Port:     &dnsPort,
-							},
+			},
+
+			{
+				// Allow egress to Kubernetes internal subnet for DNS
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   netPolEgressAllowKubeDNS,
+					Labels: b.labels(),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							akashNetworkNamespace: lidNS(b.lid),
 						},
-						To: []netv1.NetworkPolicyPeer{
-							{
-								IPBlock: &netv1.IPBlock{
-									CIDR: "10.0.0.0/8",
+					},
+					Egress: []netv1.NetworkPolicyEgressRule{
+						{ // Allow Network Connections from same Namespace
+							Ports: []netv1.NetworkPolicyPort{
+								{
+									Protocol: &dnsProtocol,
+									Port:     &dnsPort,
+								},
+							},
+							To: []netv1.NetworkPolicyPeer{
+								{
+									IPBlock: &netv1.IPBlock{
+										CIDR: "10.0.0.0/8",
+									},
 								},
 							},
 						},
 					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeEgress,
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeEgress,
+					},
 				},
 			},
-		},
+		*/
 	}, nil
 }
 


### PR DESCRIPTION
This change simply disables producing the list of Network policies to
apply, so the builder will effectively do nothing, and not quarantine
entwork traffic.

This change should be reverted once accurate network polices isolate
namespaces without blocking traffic.
