### PR TITLE
Cleanup provider error response handling

### DIFF
--- a/client/broadcaster/serial.go
+++ b/client/broadcaster/serial.go
@@ -27,7 +27,7 @@ var (
 
 	// errors are of the form:
 	// "account sequence mismatch, expected 25, got 27: incorrect account sequence"
-	recoverRegexp = regexp.MustCompile("^account sequence mismatch, expected (\\d+), got (\\d+):")
+	recoverRegexp = regexp.MustCompile(`^account sequence mismatch, expected (\\d+), got (\\d+):`)
 )
 
 type SerialClient interface {

--- a/client/broadcaster/serial.go
+++ b/client/broadcaster/serial.go
@@ -27,7 +27,7 @@ var (
 
 	// errors are of the form:
 	// "account sequence mismatch, expected 25, got 27: incorrect account sequence"
-	recoverRegexp = regexp.MustCompile(`^account sequence mismatch, expected (\\d+), got (\\d+):`)
+	recoverRegexp = regexp.MustCompile(`^account sequence mismatch, expected (\d+), got (\d+):`)
 )
 
 type SerialClient interface {

--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -242,7 +242,10 @@ func (s *service) teardownLease(lid mtypes.LeaseID) {
 	// unreserve resources if no manager present yet.
 	if lid.Provider == s.session.Provider().Owner {
 		s.log.Info("unreserving unmanaged order", "lease", lid)
-		s.inventory.unreserve(lid.OrderID())
+		err := s.inventory.unreserve(lid.OrderID())
+		if err != nil {
+			s.log.Error("unreserve failed", "lease", lid, "err", err)
+		}
 	}
 }
 

--- a/provider/cmd/leaseStatus.go
+++ b/provider/cmd/leaseStatus.go
@@ -55,7 +55,7 @@ func doLeaseStatus(cmd *cobra.Command) error {
 
 	result, err := gclient.LeaseStatus(context.Background(), provider.HostURI, lid)
 	if err != nil {
-		return err
+		return showErrorToUser(err)
 	}
 	return cmdcommon.PrintJSONStdout(result)
 }

--- a/provider/cmd/manifest.go
+++ b/provider/cmd/manifest.go
@@ -59,12 +59,12 @@ func doSendManifest(cmd *cobra.Command, sdlpath string) error {
 	provider := &res.Provider
 	gclient := gateway.NewClient()
 
-	return gclient.SubmitManifest(
+	return showErrorToUser(gclient.SubmitManifest(
 		context.Background(),
 		provider.HostURI,
 		&manifest.SubmitRequest{
 			Deployment: lid.DeploymentID(),
 			Manifest:   mani,
 		},
-	)
+	))
 }

--- a/provider/cmd/root.go
+++ b/provider/cmd/root.go
@@ -9,8 +9,9 @@ import (
 
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "provider",
-		Short: "Akash provider commands",
+		Use:          "provider",
+		Short:        "Akash provider commands",
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().String(flags.FlagNode, "http://localhost:26657", "The node address")

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -382,3 +382,13 @@ func createClusterClient(log log.Logger, _ *cobra.Command, host string, settings
 	}
 	return kube.NewClient(log, host, ns, settings)
 }
+
+func showErrorToUser(err error) error {
+	// If the error has a complete message associated with it then show it
+	clientResponseError, ok := err.(gateway.ClientResponseError)
+	if ok && 0 != len(clientResponseError.Message) {
+		fmt.Fprintf(os.Stderr, "provider error messsage:\n%v\n", clientResponseError.Message)
+	}
+
+	return err
+}

--- a/provider/cmd/serviceLogs.go
+++ b/provider/cmd/serviceLogs.go
@@ -18,8 +18,9 @@ import (
 
 func serviceLogsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "service-logs",
-		Short: "get service status",
+		Use:          "service-logs",
+		Short:        "get service status",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doServiceLogs(cmd)
 		},
@@ -92,7 +93,7 @@ func doServiceLogs(cmd *cobra.Command) error {
 
 	result, err := gclient.ServiceLogs(context.Background(), provider.HostURI, lid, svcName, follow, tailLines)
 	if err != nil {
-		return err
+		return showErrorToUser(err)
 	}
 
 	printFn := func(msg gateway.ServiceLogMessage) error {

--- a/provider/cmd/serviceStatus.go
+++ b/provider/cmd/serviceStatus.go
@@ -17,8 +17,9 @@ const FlagService = "service"
 
 func serviceStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "service-status",
-		Short: "get service status",
+		Use:          "service-status",
+		Short:        "get service status",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doServiceStatus(cmd)
 		},
@@ -65,7 +66,7 @@ func doServiceStatus(cmd *cobra.Command) error {
 
 	result, err := gclient.ServiceStatus(context.Background(), provider.HostURI, lid, svcName)
 	if err != nil {
-		return err
+		return showErrorToUser(err)
 	}
 
 	return cmdcommon.PrintJSONStdout(result)

--- a/provider/cmd/status.go
+++ b/provider/cmd/status.go
@@ -14,8 +14,9 @@ import (
 
 func statusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "get provider status",
+		Use:          "status",
+		Short:        "get provider status",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doStatus(cmd)
 		},
@@ -47,7 +48,7 @@ func doStatus(cmd *cobra.Command) error {
 
 	result, err := gclient.Status(context.Background(), provider.HostURI)
 	if err != nil {
-		return err
+		return showErrorToUser(err)
 	}
 
 	return cmdcommon.PrintJSONStdout(result)

--- a/provider/gateway/router_test.go
+++ b/provider/gateway/router_test.go
@@ -359,9 +359,10 @@ func TestRouteLeaseStatusErr(t *testing.T) {
 	require.Regexp(t, "^generic test error(?s:.)*$", scaffold.w.Body.String())
 }
 
+const serviceName = "database"
+
 func TestRouteServiceStatusOK(t *testing.T) {
 	scaffold := newRouterForTest(t)
-	serviceName := "database"
 
 	owner := testutil.AccAddress(t)
 	provider := testutil.AccAddress(t)
@@ -400,7 +401,6 @@ func TestRouteServiceStatusOK(t *testing.T) {
 
 func TestRouteServiceStatusNoDeployment(t *testing.T) {
 	scaffold := newRouterForTest(t)
-	serviceName := "database"
 
 	owner := testutil.AccAddress(t)
 	provider := testutil.AccAddress(t)
@@ -425,7 +425,6 @@ func TestRouteServiceStatusNoDeployment(t *testing.T) {
 
 func TestRouteServiceStatusKubernetesNotFound(t *testing.T) {
 	scaffold := newRouterForTest(t)
-	serviceName := "database"
 
 	owner := testutil.AccAddress(t)
 	provider := testutil.AccAddress(t)
@@ -462,7 +461,6 @@ func TestRouteServiceStatusKubernetesNotFound(t *testing.T) {
 
 func TestRouteServiceStatusError(t *testing.T) {
 	scaffold := newRouterForTest(t)
-	serviceName := "database"
 
 	owner := testutil.AccAddress(t)
 	provider := testutil.AccAddress(t)

--- a/provider/gateway/router_test.go
+++ b/provider/gateway/router_test.go
@@ -1,0 +1,486 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/ovrclk/akash/provider"
+	kubeClient "github.com/ovrclk/akash/provider/cluster/kube"
+	clusterMocks "github.com/ovrclk/akash/provider/cluster/mocks"
+	clustertypes "github.com/ovrclk/akash/provider/cluster/types"
+	ctypes "github.com/ovrclk/akash/provider/cluster/types"
+	"github.com/ovrclk/akash/provider/manifest"
+	manifestMocks "github.com/ovrclk/akash/provider/manifest/mocks"
+	"github.com/ovrclk/akash/provider/mocks"
+	"github.com/ovrclk/akash/sdl"
+	"github.com/ovrclk/akash/testutil"
+	manifestValidation "github.com/ovrclk/akash/validation"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	"github.com/ovrclk/akash/x/market/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testScaffold struct {
+	w                  *httptest.ResponseRecorder
+	mockClient         *mocks.Client
+	manifestClientMock *manifestMocks.Client
+	clusterClientMock  *clusterMocks.Client
+	router             *mux.Router
+}
+
+func newRouterForTest(t *testing.T) *testScaffold {
+	logger := testutil.Logger(t)
+	mockClient := &mocks.Client{}
+	manifestMocks := &manifestMocks.Client{}
+	clusterMocks := &clusterMocks.Client{}
+
+	mockClient.On("Manifest").Return(manifestMocks)
+	mockClient.On("Cluster").Return(clusterMocks)
+
+	r := newRouter(logger, mockClient)
+
+	scaffold := &testScaffold{
+		w:                  httptest.NewRecorder(),
+		mockClient:         mockClient,
+		manifestClientMock: manifestMocks,
+		clusterClientMock:  clusterMocks,
+		router:             r,
+	}
+
+	return scaffold
+}
+
+func (s *testScaffold) serveHTTP(method string, target string, body io.Reader) {
+	s.router.ServeHTTP(s.w, httptest.NewRequest(method, target, body))
+}
+
+func TestRouteDoesNotExist(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	scaffold.serveHTTP("GET", "/foobar", nil)
+	require.Equal(t, scaffold.w.Code, http.StatusNotFound)
+}
+
+func TestRouteStatusOK(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	status := &provider.Status{
+		Cluster:               nil,
+		Bidengine:             nil,
+		Manifest:              nil,
+		ClusterPublicHostname: "foobar",
+	}
+	scaffold.mockClient.On("Status", mock.Anything).Return(status, nil)
+
+	scaffold.serveHTTP("GET", "/status", nil)
+	require.Equal(t, scaffold.w.Code, http.StatusOK)
+	data := make(map[string]interface{})
+	decoder := json.NewDecoder(scaffold.w.Body)
+	err := decoder.Decode(&data)
+	require.NoError(t, err)
+	cph, ok := data["cluster-public-hostname"].(string)
+	require.True(t, ok)
+	require.Equal(t, cph, "foobar")
+}
+
+var errGeneric = errors.New("generic test error")
+
+func TestRouteStatusFails(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	scaffold.mockClient.On("Status", mock.Anything).Return(nil, errGeneric)
+
+	scaffold.serveHTTP("GET", "/status", nil)
+	require.Equal(t, scaffold.w.Code, http.StatusInternalServerError)
+	require.Regexp(t, "^generic test error(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRoutePutManifestOK(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	scaffold.manifestClientMock.On("Submit", mock.Anything, mock.AnythingOfType("*manifest.SubmitRequest")).Return(nil)
+
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	owner := testutil.AccAddress(t)
+	path := fmt.Sprintf("/deployment/%v/%v/manifest", owner.String(), dseq)
+
+	sdl, err := sdl.ReadFile("../../sdl/_testdata/simple.yaml")
+	require.NoError(t, err)
+
+	mani, err := sdl.Manifest()
+	require.NoError(t, err)
+
+	submitRequest := manifest.SubmitRequest{
+		Deployment: dtypes.DeploymentID{
+			Owner: owner.String(),
+			DSeq:  dseq,
+		},
+		Manifest: mani,
+	}
+
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	err = enc.Encode(submitRequest)
+	require.NoError(t, err)
+
+	scaffold.serveHTTP("PUT", path, body)
+
+	require.Equal(t, scaffold.w.Code, http.StatusOK)
+	require.Equal(t, scaffold.w.Body.String(), "")
+}
+
+func TestRoutePutManifestDSeqMismatch(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	owner := testutil.AccAddress(t)
+	path := fmt.Sprintf("/deployment/%v/%v/manifest", owner.String(), dseq)
+
+	sdl, err := sdl.ReadFile("../../sdl/_testdata/simple.yaml")
+	require.NoError(t, err)
+
+	mani, err := sdl.Manifest()
+	require.NoError(t, err)
+
+	submitRequest := manifest.SubmitRequest{
+		Deployment: dtypes.DeploymentID{
+			Owner: owner.String(),
+			DSeq:  dseq + 1,
+		},
+		Manifest: mani,
+	}
+
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	err = enc.Encode(submitRequest)
+	require.NoError(t, err)
+
+	scaffold.serveHTTP("PUT", path, body)
+
+	require.Equal(t, scaffold.w.Code, http.StatusBadRequest)
+	require.Regexp(t, "^deployment ID in request body does not match this resource(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRoutePutManifestOwnerMismatch(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	owner := testutil.AccAddress(t)
+	path := fmt.Sprintf("/deployment/%v/%v/manifest", owner.String(), dseq)
+
+	sdl, err := sdl.ReadFile("../../sdl/_testdata/simple.yaml")
+	require.NoError(t, err)
+
+	mani, err := sdl.Manifest()
+	require.NoError(t, err)
+
+	submitRequest := manifest.SubmitRequest{
+		Deployment: dtypes.DeploymentID{
+			Owner: owner.String() + "a",
+			DSeq:  dseq,
+		},
+		Manifest: mani,
+	}
+
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	err = enc.Encode(submitRequest)
+	require.NoError(t, err)
+
+	scaffold.serveHTTP("PUT", path, body)
+
+	require.Equal(t, scaffold.w.Code, http.StatusBadRequest)
+	require.Regexp(t, "^deployment ID in request body does not match this resource(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRoutePutInvalidManifest(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	scaffold.manifestClientMock.On("Submit", mock.Anything, mock.AnythingOfType("*manifest.SubmitRequest")).Return(manifestValidation.ErrInvalidManifest)
+
+	dseq := uint64(33)
+	owner := testutil.AccAddress(t)
+	path := fmt.Sprintf("/deployment/%v/%v/manifest", owner.String(), dseq)
+
+	sdl, err := sdl.ReadFile("../../sdl/_testdata/simple.yaml")
+	require.NoError(t, err)
+
+	mani, err := sdl.Manifest()
+	require.NoError(t, err)
+
+	submitRequest := manifest.SubmitRequest{
+		Deployment: dtypes.DeploymentID{
+			Owner: owner.String(),
+			DSeq:  dseq,
+		},
+		Manifest: mani,
+	}
+
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	err = enc.Encode(submitRequest)
+	require.NoError(t, err)
+
+	scaffold.serveHTTP("PUT", path, body)
+
+	require.Equal(t, scaffold.w.Code, http.StatusUnprocessableEntity)
+	require.Regexp(t, "^invalid manifest(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRouteLeaseStatusOk(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	status := &clustertypes.LeaseStatus{
+		Services:       nil,
+		ForwardedPorts: nil,
+	}
+
+	scaffold.clusterClientMock.On("LeaseStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}).Return(status, nil)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/status", owner.String(), dseq, gseq, oseq, provider.String())
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusOK)
+	data := make(map[string]interface{})
+	dec := json.NewDecoder(scaffold.w.Body)
+	err := dec.Decode(&data)
+	require.NoError(t, err)
+}
+
+func TestRouteLeaseStatusNoGlobalServices(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	scaffold.clusterClientMock.On("LeaseStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}).Return(nil, kubeClient.ErrNoGlobalServicesForLease)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/status", owner.String(), dseq, gseq, oseq, provider.String())
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusServiceUnavailable)
+	require.Regexp(t, "^kube: no global services(?s:.)*$", scaffold.w.Body.String())
+}
+
+type fakeKubernetesStatusError struct {
+	status metav1.Status
+}
+
+func (fkse fakeKubernetesStatusError) Status() metav1.Status {
+	return fkse.status
+}
+
+func (fkse fakeKubernetesStatusError) Error() string {
+	return "fake error"
+}
+
+func TestRouteLeaseNotInKubernetes(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	kubeStatus := fakeKubernetesStatusError{
+		status: metav1.Status{
+			TypeMeta: metav1.TypeMeta{},
+			ListMeta: metav1.ListMeta{},
+			Status:   "",
+			Message:  "",
+			Reason:   metav1.StatusReasonNotFound,
+			Details:  nil,
+			Code:     0,
+		},
+	}
+
+	scaffold.clusterClientMock.On("LeaseStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}).Return(nil, kubeStatus)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/status", owner.String(), dseq, gseq, oseq, provider.String())
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusNotFound)
+}
+
+func TestRouteLeaseStatusErr(t *testing.T) {
+	scaffold := newRouterForTest(t)
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	scaffold.clusterClientMock.On("LeaseStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}).Return(nil, errGeneric)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/status", owner.String(), dseq, gseq, oseq, provider.String())
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusInternalServerError)
+	require.Regexp(t, "^generic test error(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRouteServiceStatusOK(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	serviceName := "database"
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	status := &ctypes.ServiceStatus{
+		Name:               "",
+		Available:          0,
+		Total:              0,
+		URIs:               nil,
+		ObservedGeneration: 0,
+		Replicas:           0,
+		UpdatedReplicas:    0,
+		ReadyReplicas:      0,
+		AvailableReplicas:  0,
+	}
+	scaffold.clusterClientMock.On("ServiceStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}, serviceName).Return(status, nil)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/service/%v/status", owner.String(), dseq, gseq, oseq, provider.String(), serviceName)
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusOK)
+	data := make(map[string]interface{})
+	dec := json.NewDecoder(scaffold.w.Body)
+	err := dec.Decode(&data)
+	require.NoError(t, err)
+}
+
+func TestRouteServiceStatusNoDeployment(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	serviceName := "database"
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	scaffold.clusterClientMock.On("ServiceStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}, serviceName).Return(nil, kubeClient.ErrNoDeploymentForLease)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/service/%v/status", owner.String(), dseq, gseq, oseq, provider.String(), serviceName)
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusNotFound)
+	require.Regexp(t, "^kube: no deployment(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRouteServiceStatusKubernetesNotFound(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	serviceName := "database"
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	kubeStatus := fakeKubernetesStatusError{
+		status: metav1.Status{
+			TypeMeta: metav1.TypeMeta{},
+			ListMeta: metav1.ListMeta{},
+			Status:   "",
+			Message:  "",
+			Reason:   metav1.StatusReasonNotFound,
+			Details:  nil,
+			Code:     0,
+		},
+	}
+
+	scaffold.clusterClientMock.On("ServiceStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}, serviceName).Return(nil, kubeStatus)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/service/%v/status", owner.String(), dseq, gseq, oseq, provider.String(), serviceName)
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusNotFound)
+	require.Regexp(t, "^fake error(?s:.)*$", scaffold.w.Body.String())
+}
+
+func TestRouteServiceStatusError(t *testing.T) {
+	scaffold := newRouterForTest(t)
+	serviceName := "database"
+
+	owner := testutil.AccAddress(t)
+	provider := testutil.AccAddress(t)
+	dseq := uint64(testutil.RandRangeInt(1, 1000))
+	oseq := uint32(testutil.RandRangeInt(2000, 3000))
+	gseq := uint32(testutil.RandRangeInt(4000, 5000))
+
+	scaffold.clusterClientMock.On("ServiceStatus", mock.Anything, types.LeaseID{
+		Owner:    owner.String(),
+		DSeq:     dseq,
+		GSeq:     gseq,
+		OSeq:     oseq,
+		Provider: provider.String(),
+	}, serviceName).Return(nil, errGeneric)
+
+	path := fmt.Sprintf("/lease/%v/%v/%v/%v/%v/service/%v/status", owner.String(), dseq, gseq, oseq, provider.String(), serviceName)
+
+	scaffold.serveHTTP("GET", path, nil)
+	require.Equal(t, scaffold.w.Code, http.StatusInternalServerError)
+	require.Regexp(t, "^generic test error(?s:.)*$", scaffold.w.Body.String())
+}

--- a/validation/manifest.go
+++ b/validation/manifest.go
@@ -90,7 +90,7 @@ func validateManifestService(service manifest.Service, helper *validateManifestG
 
 func validateServiceExpose(serviceName string, serviceExpose manifest.ServiceExpose, helper *validateManifestGroupsHelper) error {
 	if serviceExpose.Port == 0 {
-		return ErrServiceExposePortZero
+		return fmt.Errorf("%w: service %q port is zero", ErrInvalidManifest, serviceName)
 	}
 
 	switch serviceExpose.Proto {

--- a/validation/manifest_validation_errors.go
+++ b/validation/manifest_validation_errors.go
@@ -6,6 +6,5 @@ import (
 
 var (
 	ErrInvalidManifest         = errors.New("invalid manifest")
-	ErrServiceExposePortZero   = errors.New("The service port is zero")
 	ErrManifestCrossValidation = errors.New("manifest cross validation error")
 )


### PR DESCRIPTION
Changes

1. Suppress showing the usage when we have an internal failure (like 404 from the remote). Still shows up if the user does a `help`command
2. Refactor the way the gateway router handles errors & check for all the special cases I could find
3. Add tests around the gateway router
4. Refactor the way the provider client handles errors from the remote. They get returned to cobra, but beforehand the actual HTTP body is captured and displayed to the user. This should contain useful information from the provider i.e. `send-manifest` fails due to an invalid manifest.
5. Fix some errors that I think came in from master?
6. Rename `ensureManger` to `ensureManager` !