### PR TITLE
Add provider e2e tests

### DIFF
--- a/cmd/common/util.go
+++ b/cmd/common/util.go
@@ -3,10 +3,10 @@ package common
 import (
 	"bytes"
 	"encoding/json"
-	"os"
+	"github.com/cosmos/cosmos-sdk/client"
 )
 
-func PrintJSONStdout(v interface{}) error {
+func PrintJSON(ctx client.Context, v interface{}) error {
 	marshaled, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -24,6 +24,5 @@ func PrintJSONStdout(v interface{}) error {
 		return err
 	}
 
-	_, err = os.Stdout.Write(buf.Bytes())
-	return err
+	return ctx.PrintString(buf.String())
 }

--- a/cmd/common/util_test.go
+++ b/cmd/common/util_test.go
@@ -1,30 +1,34 @@
 package common
 
 import (
+	"github.com/cosmos/cosmos-sdk/client"
 	"testing"
 )
 
 func TestPrintJSONStdoutStruct(t *testing.T) {
+	ctx := client.Context{}
 	var x struct{ foo int }
 	x.foo = 55
-	err := PrintJSONStdout(x)
+	err := PrintJSON(ctx, x)
 	if err != nil {
-		t.Errorf("PrintJSONStdout failed:[%T] %v", err, err)
+		t.Errorf("PrintJSON failed:[%T] %v", err, err)
 	}
 }
 
 func TestPrintJSONStdoutInt(t *testing.T) {
+	ctx := client.Context{}
 	x := 123
-	err := PrintJSONStdout(x)
+	err := PrintJSON(ctx, x)
 	if err != nil {
-		t.Errorf("PrintJSONStdout failed:[%T] %v", err, err)
+		t.Errorf("PrintJSON failed:[%T] %v", err, err)
 	}
 }
 
 func TestPrintJSONStdoutNil(t *testing.T) {
+	ctx := client.Context{}
 	var x interface{} // implicitly nil
-	err := PrintJSONStdout(x)
+	err := PrintJSON(ctx, x)
 	if err != nil {
-		t.Errorf("PrintJSONStdout failed:[%T] %v", err, err)
+		t.Errorf("PrintJSON failed:[%T] %v", err, err)
 	}
 }

--- a/events/cmd/root.go
+++ b/events/cmd/root.go
@@ -64,7 +64,7 @@ func getEvents(ctx context.Context, cmd *cobra.Command, _ []string) error {
 			case <-subscriber.Done():
 				return nil
 			case ev := <-subscriber.Events():
-				if err := cmdcommon.PrintJSONStdout(ev); err != nil {
+				if err := cmdcommon.PrintJSON(cctx, ev); err != nil {
 					return err
 				}
 			}

--- a/provider/cmd/leaseStatus.go
+++ b/provider/cmd/leaseStatus.go
@@ -57,5 +57,5 @@ func doLeaseStatus(cmd *cobra.Command) error {
 	if err != nil {
 		return showErrorToUser(err)
 	}
-	return cmdcommon.PrintJSONStdout(result)
+	return cmdcommon.PrintJSON(cctx, result)
 }

--- a/provider/cmd/serviceLogs.go
+++ b/provider/cmd/serviceLogs.go
@@ -103,7 +103,7 @@ func doServiceLogs(cmd *cobra.Command) error {
 
 	if outputFormat == "json" {
 		printFn = func(msg gateway.ServiceLogMessage) error {
-			return cmdcommon.PrintJSONStdout(msg)
+			return cmdcommon.PrintJSON(cctx, msg)
 		}
 	}
 

--- a/provider/cmd/serviceStatus.go
+++ b/provider/cmd/serviceStatus.go
@@ -69,5 +69,5 @@ func doServiceStatus(cmd *cobra.Command) error {
 		return showErrorToUser(err)
 	}
 
-	return cmdcommon.PrintJSONStdout(result)
+	return cmdcommon.PrintJSON(cctx, result)
 }

--- a/provider/cmd/status.go
+++ b/provider/cmd/status.go
@@ -51,5 +51,5 @@ func doStatus(cmd *cobra.Command) error {
 		return showErrorToUser(err)
 	}
 
-	return cmdcommon.PrintJSONStdout(result)
+	return cmdcommon.PrintJSON(cctx, result)
 }

--- a/provider/cmd/test_helpers.go
+++ b/provider/cmd/test_helpers.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	sdktest "github.com/cosmos/cosmos-sdk/testutil"
+	testutilcli "github.com/ovrclk/akash/testutil/cli"
+)
+
+func ProviderLeaseStatusExec(clientCtx client.Context, extraArgs ...string) (sdktest.BufferWriter, error) {
+	return testutilcli.ExecTestCLICmd(clientCtx, leaseStatusCmd(), extraArgs...)
+}
+
+func ProviderServiceStatusExec(clientCtx client.Context, extraArgs ...string) (sdktest.BufferWriter, error) {
+	return testutilcli.ExecTestCLICmd(clientCtx, serviceStatusCmd(), extraArgs...)
+}
+
+func ProviderStatusExec(clientCtx client.Context, extraArgs ...string) (sdktest.BufferWriter, error) {
+	return testutilcli.ExecTestCLICmd(clientCtx, statusCmd(), extraArgs...)
+}
+
+func ProviderServiceLogs(clientCtx client.Context, extraArgs ...string) (sdktest.BufferWriter, error) {
+	return testutilcli.ExecTestCLICmd(clientCtx, serviceLogsCmd(), extraArgs...)
+}

--- a/x/market/client/cli/lease.go
+++ b/x/market/client/cli/lease.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/ovrclk/akash/x/market/types"
@@ -59,6 +58,7 @@ func cmdGetLease() *cobra.Command {
 		Short: "Query order",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			clientCtx, err := client.ReadQueryCommandFlags(clientCtx, cmd.Flags())
 			if err != nil {


### PR DESCRIPTION
Changes

1. Add provider e2e tests
2. Fix some issues I found around service-status & lease-status having missing data
3. Refactor the common function I had to use the cosmos SDK context so the tests can capture
the output & test against it