### PR TITLE
feat(provider): Add deployment information to running containers

### DIFF
--- a/provider/cluster/kube/builder.go
+++ b/provider/cluster/kube/builder.go
@@ -297,11 +297,11 @@ func (b *deploymentBuilder) container() corev1.Container {
 }
 
 const (
-	envVarAkashGroupSequence = "AKASH_GROUP_SEQUENCE"
-	envVarAkashDeploymentSequence = "AKASH_DEPLOYMENT_SEQUENCE"
-	envVarAkashOrderSequence = "AKASH_ORDER_SEQUENCE"
-	envVarAkashOwner = "AKASH_OWDER"
-	envVarAkashProvider = "AKASH_PROVIDER"
+	envVarAkashGroupSequence         = "AKASH_GROUP_SEQUENCE"
+	envVarAkashDeploymentSequence    = "AKASH_DEPLOYMENT_SEQUENCE"
+	envVarAkashOrderSequence         = "AKASH_ORDER_SEQUENCE"
+	envVarAkashOwner                 = "AKASH_OWDER"
+	envVarAkashProvider              = "AKASH_PROVIDER"
 	envVarAkashClusterPublicHostname = "AKASH_CLUSTER_PUBLIC_HOSTNAME"
 )
 


### PR DESCRIPTION
This just adds in the deployment information for the running containers. Not required but can be useful in some circumstances.