### PR TITLE
Allow testing via K8S running in vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOBIN                 := $(shell go env GOPATH)/bin
 
 KIND_APP_IP           ?= $(shell make -sC _run/kube kind-k8s-ip)
 KIND_APP_PORT         ?= $(shell make -sC _run/kube app-http-port)
-KIND_VARS             ?= KIND_APP_IP="$(KIND_APP_IP)" KIND_APP_PORT="$(KIND_APP_PORT)"
+KIND_VARS             ?= KUBE_INGRESS_IP="$(KIND_APP_IP)" KUBE_INGRESS_PORT="$(KIND_APP_PORT)"
 
 UNAME_OS              := $(shell uname -s)
 UNAME_ARCH            := $(shell uname -m)

--- a/README_e2e.md
+++ b/README_e2e.md
@@ -1,0 +1,67 @@
+# End to End tests
+
+This software contains end-to-end tests which can run in an automated manner. These tests try and cover as much of the
+expected use cases as possible.
+
+## Running with KIND
+
+Prerequisites: You need docker installed & kind installed
+
+This runs a Kubernetes cluster using KIND, which allows it to run entirely within Docker
+
+Running:
+```
+cd _run/kube
+make kind-cluster-create
+cd ../..
+make test-e2e-integration
+```
+
+
+Cleanup:
+```
+cd _run/kube
+make kind-cluster-delete
+```
+
+## Running with K8S in Vagrant
+
+Prerequisites:
+
+1. Vagrant
+2. VirtualBox
+3. The ovrclk/kubespray project checked out at the same level as this project
+
+This starts a complete K8S cluster that is provisioned by kubespray. This uses at least 6 gigabytes of system memory
+when ran.
+
+### Start the K8S cluster
+
+Note this process can take a very long time (15 minutes+) even under ideal circumstances. There are multiple points
+where Vagrant waits for a VM to be boot or to respond to SSH. If this fails, you can always run the stop script
+then start over.
+
+```
+pushd ../kubespray && ./vagrant_up.sh && popd
+```
+
+The result of this is multiple VMs running under Virtualbox that form a complete kubernetes cluster. Your
+kube config is automatically updated (the old file is backed up under ~/.kube) so you can do `kubectl get nodes`
+to see the status of the nodes. Additionally, port 10080 on the host machine is forwarded to port 80 on the
+master node, so the Kubernetes ingress controller is reachable at `localhost:10080`.
+
+### Run the tests
+
+```
+make test-e2e-integration-k8s
+```
+
+### Stop the K8S cluster
+
+This just destroys the VMs, so this should only take a few seconds
+
+
+```
+pushd ../kubespray && ./vagrant_down.sh && popd
+```
+

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -92,9 +92,9 @@ func queryApp(t *testing.T, appURL string, limit int) {
 
 // appEnv asserts that there is an addressable docker container for KinD
 func appEnv(t *testing.T) (string, string) {
-	host := os.Getenv("KIND_APP_IP")
+	host := os.Getenv("KUBE_INGRESS_IP")
 	require.NotEmpty(t, host)
-	appPort := os.Getenv("KIND_APP_PORT")
+	appPort := os.Getenv("KUBE_INGRESS_PORT")
 	require.NotEmpty(t, appPort)
 	return host, appPort
 }

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -5,7 +5,10 @@ COVER_PACKAGES = $(shell go list ./... | grep -v mock)
 
 test-e2e-integration:
 	# Assumes cluster created: `make -s -C _run/kube kind-cluster-create`
-	$(KIND_VARS) go test -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
+	$(KIND_VARS) go test -count=1 -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
+
+test-e2e-integration-k8s:
+	KUBE_INGRESS_IP=127.0.0.1 KUBE_INGRESS_PORT=10080 go test -count=1 -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
 
 test-query-app:
 	 $(KIND_VARS) go test -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestQueryApp


### PR DESCRIPTION
I have a companion PR here https://github.com/ovrclk/kubespray/pull/3

When both of these are put together it does the following

1. Gives up the ability to provision a single master K8S cluster in Vagrant
2. Configures the cluster using our example
3. Gives us a way to automatically run the e2e tests against the K8S cluster

The K8S cluster is a single master with two other nodes. I'm running it in VirtualBox, you need about 6 GB of free memory for this to work. Theoretically we can point Vagrant at a VMWare cluster or AWS if we want to run e2e tests against a huge cluster for some reason.

The main drawback here is we can't run this automatically inside of Github CI.

Once this is merged we need to work on adding more e2e tests as there is substantially more we can cover in those tests.