### PR TITLE
feat(provider): Add basic resource overcommit in the kubernetes cluster

### DIFF
--- a/provider/cluster/config.go
+++ b/provider/cluster/config.go
@@ -6,6 +6,9 @@ type Config struct {
 	InventoryResourcePollPeriod     time.Duration
 	InventoryResourceDebugFrequency uint
 	InventoryExternalPortQuantity   uint
+	CPUCommitLevel                  float64
+	MemoryCommitLevel               float64
+	StorageCommitLevel              float64
 }
 
 func NewDefaultConfig() Config {

--- a/provider/cluster/kube/client_test.go
+++ b/provider/cluster/kube/client_test.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"context"
+	"errors"
 	"github.com/ovrclk/akash/testutil"
 	kubernetes_mocks "github.com/ovrclk/akash/testutil/kubernetes_mock"
 	appsv1_mocks "github.com/ovrclk/akash/testutil/kubernetes_mock/typed/apps/v1"
@@ -12,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"testing"
@@ -238,5 +240,267 @@ func TestLeaseStatusWithForwardedPortOnly(t *testing.T) {
 	ports := status.ForwardedPorts["myservice"]
 	require.Len(t, ports, 1)
 	require.Equal(t, int(ports[0].ExternalPort), expectedExternalPort)
+}
 
+type inventoryScaffold struct {
+	kmock             *kubernetes_mocks.Interface
+	corev1Mock        *corev1_mocks.CoreV1Interface
+	nodeInterfaceMock *corev1_mocks.NodeInterface
+	podInterfaceMock  *corev1_mocks.PodInterface
+}
+
+func makeInventoryScaffold() *inventoryScaffold {
+	s := &inventoryScaffold{
+		kmock:             &kubernetes_mocks.Interface{},
+		corev1Mock:        &corev1_mocks.CoreV1Interface{},
+		nodeInterfaceMock: &corev1_mocks.NodeInterface{},
+		podInterfaceMock:  &corev1_mocks.PodInterface{},
+	}
+
+	s.kmock.On("CoreV1").Return(s.corev1Mock)
+	s.corev1Mock.On("Nodes").Return(s.nodeInterfaceMock, nil)
+	s.corev1Mock.On("Pods", "" /* all namespaces */).Return(s.podInterfaceMock, nil)
+
+	return s
+}
+
+func TestInventoryZero(t *testing.T) {
+	s := makeInventoryScaffold()
+
+	nodeList := &v1.NodeList{}
+	listOptions := metav1.ListOptions{}
+	s.nodeInterfaceMock.On("List", mock.Anything, listOptions).Return(nodeList, nil)
+
+	podList := &v1.PodList{}
+	s.podInterfaceMock.On("List", mock.Anything, mock.Anything).Return(podList, nil)
+
+	clientInterface := clientForTest(t, s.kmock)
+	inventory, err := clientInterface.Inventory(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, inventory)
+
+	// The inventory was called and the kubernetes client says there are no nodes & no pods. Inventory
+	// should be zero
+	require.Len(t, inventory, 0)
+
+	podListOptionsInCall := s.podInterfaceMock.Calls[0].Arguments[1].(metav1.ListOptions)
+	require.Equal(t, "status.phase!=Failed,status.phase!=Succeeded", podListOptionsInCall.FieldSelector)
+}
+
+func TestInventorySingleNodeNoPods(t *testing.T) {
+	s := makeInventoryScaffold()
+
+	nodeList := &v1.NodeList{}
+	nodeList.Items = make([]v1.Node, 1)
+
+	nodeResourceList := make(v1.ResourceList)
+	const expectedCPU = 13
+	cpuQuantity := resource.NewQuantity(expectedCPU, "m")
+	nodeResourceList[v1.ResourceCPU] = *cpuQuantity
+
+	const expectedMemory = 14
+	memoryQuantity := resource.NewQuantity(expectedMemory, "M")
+	nodeResourceList[v1.ResourceMemory] = *memoryQuantity
+
+	const expectedStorage = 15
+	ephemeralStorageQuantity := resource.NewQuantity(expectedStorage, "M")
+	nodeResourceList[v1.ResourceEphemeralStorage] = *ephemeralStorageQuantity
+
+	nodeConditions := make([]v1.NodeCondition, 1)
+	nodeConditions[0] = v1.NodeCondition{
+		Type:   v1.NodeReady,
+		Status: v1.ConditionTrue,
+	}
+
+	nodeList.Items[0] = v1.Node{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			Allocatable: nodeResourceList,
+			Conditions:  nodeConditions,
+		},
+	}
+
+	listOptions := metav1.ListOptions{}
+	s.nodeInterfaceMock.On("List", mock.Anything, listOptions).Return(nodeList, nil)
+
+	podList := &v1.PodList{}
+	s.podInterfaceMock.On("List", mock.Anything, mock.Anything).Return(podList, nil)
+
+	clientInterface := clientForTest(t, s.kmock)
+	inventory, err := clientInterface.Inventory(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, inventory)
+
+	require.Len(t, inventory, 1)
+
+	node := inventory[0]
+	availableResources := node.Available()
+	// Multiply expected value by 1000 since millicpu is used
+	require.Equal(t, uint64(expectedCPU*1000), availableResources.CPU.Units.Value())
+	require.Equal(t, uint64(expectedMemory), availableResources.Memory.Quantity.Value())
+	require.Equal(t, uint64(expectedStorage), availableResources.Storage.Quantity.Value())
+}
+
+func TestInventorySingleNodeWithPods(t *testing.T) {
+	s := makeInventoryScaffold()
+
+	nodeList := &v1.NodeList{}
+	nodeList.Items = make([]v1.Node, 1)
+
+	nodeResourceList := make(v1.ResourceList)
+	const expectedCPU = 13
+	cpuQuantity := resource.NewQuantity(expectedCPU, "m")
+	nodeResourceList[v1.ResourceCPU] = *cpuQuantity
+
+	const expectedMemory = 2048
+	memoryQuantity := resource.NewQuantity(expectedMemory, "M")
+	nodeResourceList[v1.ResourceMemory] = *memoryQuantity
+
+	const expectedStorage = 4096
+	ephemeralStorageQuantity := resource.NewQuantity(expectedStorage, "M")
+	nodeResourceList[v1.ResourceEphemeralStorage] = *ephemeralStorageQuantity
+
+	nodeConditions := make([]v1.NodeCondition, 1)
+	nodeConditions[0] = v1.NodeCondition{
+		Type:   v1.NodeReady,
+		Status: v1.ConditionTrue,
+	}
+
+	nodeList.Items[0] = v1.Node{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			Allocatable: nodeResourceList,
+			Conditions:  nodeConditions,
+		},
+	}
+
+	listOptions := metav1.ListOptions{}
+	s.nodeInterfaceMock.On("List", mock.Anything, listOptions).Return(nodeList, nil)
+
+	const cpuPerContainer = 1
+	const memoryPerContainer = 3
+	const storagePerContainer = 17
+	// Define two pods
+	pods := make([]v1.Pod, 2)
+	// First pod has 1 container
+	podContainers := make([]v1.Container, 1)
+	containerRequests := make(v1.ResourceList)
+	cpuQuantity.SetMilli(cpuPerContainer)
+	containerRequests[v1.ResourceCPU] = *cpuQuantity
+
+	memoryQuantity = resource.NewQuantity(memoryPerContainer, "M")
+	containerRequests[v1.ResourceMemory] = *memoryQuantity
+
+	ephemeralStorageQuantity = resource.NewQuantity(storagePerContainer, "M")
+	containerRequests[v1.ResourceEphemeralStorage] = *ephemeralStorageQuantity
+
+	podContainers[0] = v1.Container{
+		Resources: v1.ResourceRequirements{
+			Limits:   nil,
+			Requests: containerRequests,
+		},
+	}
+	pods[0] = v1.Pod{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.PodSpec{
+			Containers: podContainers,
+		},
+		Status: v1.PodStatus{},
+	}
+
+	// Define 2nd pod with multiple containers
+	podContainers = make([]v1.Container, 2)
+	for i := range podContainers {
+		containerRequests := make(v1.ResourceList)
+		cpuQuantity.SetMilli(cpuPerContainer)
+		containerRequests[v1.ResourceCPU] = *cpuQuantity
+
+		memoryQuantity = resource.NewQuantity(memoryPerContainer, "M")
+		containerRequests[v1.ResourceMemory] = *memoryQuantity
+
+		ephemeralStorageQuantity = resource.NewQuantity(storagePerContainer, "M")
+		containerRequests[v1.ResourceEphemeralStorage] = *ephemeralStorageQuantity
+
+		// Container limits are enforced by kubernetes as absolute limits, but not
+		// used when considering inventory since overcommit is possible in a kubernetes cluster
+		// Set limits to any value larger than requests in this test since it should not change
+		// the value returned  by the code
+		containerLimits := make(v1.ResourceList)
+
+		for k, v := range containerRequests {
+			replacementV := resource.NewQuantity(0, "")
+			replacementV.Set(v.Value() * int64(testutil.RandRangeInt(2, 100)))
+			containerLimits[k] = *replacementV
+		}
+
+		podContainers[i] = v1.Container{
+			Resources: v1.ResourceRequirements{
+				Limits:   containerLimits,
+				Requests: containerRequests,
+			},
+		}
+	}
+	pods[1] = v1.Pod{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.PodSpec{
+			Containers: podContainers,
+		},
+		Status: v1.PodStatus{},
+	}
+
+	podList := &v1.PodList{
+		Items: pods,
+	}
+
+	s.podInterfaceMock.On("List", mock.Anything, mock.Anything).Return(podList, nil)
+
+	clientInterface := clientForTest(t, s.kmock)
+	inventory, err := clientInterface.Inventory(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, inventory)
+
+	require.Len(t, inventory, 1)
+
+	node := inventory[0]
+	availableResources := node.Available()
+	// Multiply expected value by 1000 since millicpu is used
+	require.Equal(t, uint64(expectedCPU*1000)-3*cpuPerContainer, availableResources.CPU.Units.Value())
+	require.Equal(t, uint64(expectedMemory)-3*memoryPerContainer, availableResources.Memory.Quantity.Value())
+	require.Equal(t, uint64(expectedStorage)-3*storagePerContainer, availableResources.Storage.Quantity.Value())
+}
+
+var errForTest = errors.New("error in test")
+
+func TestInventoryWithNodeError(t *testing.T) {
+	s := makeInventoryScaffold()
+
+	listOptions := metav1.ListOptions{}
+	s.nodeInterfaceMock.On("List", mock.Anything, listOptions).Return(nil, errForTest)
+
+	clientInterface := clientForTest(t, s.kmock)
+	inventory, err := clientInterface.Inventory(context.Background())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errForTest))
+	require.Nil(t, inventory)
+}
+
+func TestInventoryWithPodsError(t *testing.T) {
+	s := makeInventoryScaffold()
+
+	listOptions := metav1.ListOptions{}
+	nodeList := &v1.NodeList{}
+	s.nodeInterfaceMock.On("List", mock.Anything, listOptions).Return(nodeList, nil)
+	s.podInterfaceMock.On("List", mock.Anything, mock.Anything).Return(nil, errForTest)
+
+	clientInterface := clientForTest(t, s.kmock)
+	inventory, err := clientInterface.Inventory(context.Background())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errForTest))
+	require.Nil(t, inventory)
 }

--- a/provider/cluster/kube/settings.go
+++ b/provider/cluster/kube/settings.go
@@ -29,6 +29,10 @@ type Settings struct {
 
 	// NetworkPoliciesEnabled determines if NetworkPolicies should be installed.
 	NetworkPoliciesEnabled bool
+
+	CPUCommitLevel     float64
+	MemoryCommitLevel  float64
+	StorageCommitLevel float64
 }
 
 var errSettingsValidation = errors.New("settings validation")

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -3,14 +3,13 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"sync"
-
 	lifecycle "github.com/boz/go-lifecycle"
 	"github.com/ovrclk/akash/manifest"
 	"github.com/ovrclk/akash/provider/session"
 	"github.com/ovrclk/akash/pubsub"
 	mtypes "github.com/ovrclk/akash/x/market/types"
 	"github.com/tendermint/tendermint/libs/log"
+	"sync"
 )
 
 type deploymentState string
@@ -126,10 +125,16 @@ loop:
 			}
 			switch dm.state {
 			case dsDeployActive:
+				if result != nil {
+					break loop
+				}
 				dm.log.Debug("deploy complete")
 				dm.state = dsDeployComplete
 				dm.startMonitor()
 			case dsDeployPending:
+				if result != nil {
+					break loop
+				}
 				// start update
 				runch = dm.startDeploy()
 			case dsDeployComplete:

--- a/provider/cluster/monitor.go
+++ b/provider/cluster/monitor.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	monitorMaxRetries        = 20
-	monitorRetryPeriodMin    = time.Second * 2
-	monitorRetryPeriodJitter = time.Second * 5
+	monitorMaxRetries        = 40
+	monitorRetryPeriodMin    = time.Second * 4
+	monitorRetryPeriodJitter = time.Second * 15
 
 	monitorHealthcheckPeriodMin    = time.Second * 10
 	monitorHealthcheckPeriodJitter = time.Second * 5

--- a/provider/cluster/util/util.go
+++ b/provider/cluster/util/util.go
@@ -1,6 +1,11 @@
 package util
 
-import "github.com/ovrclk/akash/manifest"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ovrclk/akash/manifest"
+	atypes "github.com/ovrclk/akash/types"
+	"math"
+)
 
 func ShouldBeIngress(expose manifest.ServiceExpose) bool {
 	return expose.Proto == manifest.TCP && expose.Global && 80 == ExposeExternalPort(expose)
@@ -11,4 +16,26 @@ func ExposeExternalPort(expose manifest.ServiceExpose) int32 {
 		return int32(expose.Port)
 	}
 	return int32(expose.ExternalPort)
+}
+
+func ComputeCommittedResources(factor float64, rv atypes.ResourceValue) atypes.ResourceValue {
+	// If the value is less than 1, commit the original value. There is no concept of undercommit
+	if factor <= 1.0 {
+		return rv
+	}
+
+	v := rv.Val.Uint64()
+	fraction := 1.0 / factor
+	commitedValue := math.Round(float64(v) * fraction)
+
+	// Don't return a value of zero, since this is used as a resource request
+	if commitedValue <= 0 {
+		commitedValue = 1
+	}
+
+	result := atypes.ResourceValue{
+		Val: sdk.NewInt(int64(commitedValue)),
+	}
+
+	return result
 }

--- a/provider/cluster/util/util_test.go
+++ b/provider/cluster/util/util_test.go
@@ -3,6 +3,7 @@ package util_test
 import (
 	"github.com/ovrclk/akash/manifest"
 	"github.com/ovrclk/akash/provider/cluster/util"
+	atypes "github.com/ovrclk/akash/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -35,4 +36,24 @@ func TestShouldBeIngress(t *testing.T) {
 		Proto:  manifest.UDP,
 		Port:   80,
 	}))
+}
+
+func TestComputeCommittedResources(t *testing.T) {
+
+	rv := atypes.NewResourceValue(100)
+	// Negative factor returns original value
+	require.Equal(t, uint64(100), util.ComputeCommittedResources(-1.0, rv).Val.Uint64())
+
+	// Zero factor returns original value
+	require.Equal(t, uint64(100), util.ComputeCommittedResources(0.0, rv).Val.Uint64())
+
+	// Factor of one returns the original value
+	require.Equal(t, uint64(100), util.ComputeCommittedResources(1.0, rv).Val.Uint64())
+
+	require.Equal(t, uint64(50), util.ComputeCommittedResources(2.0, rv).Val.Uint64())
+
+	require.Equal(t, uint64(33), util.ComputeCommittedResources(3.0, rv).Val.Uint64())
+
+	// Even for huge overcommit values, zero is not returned
+	require.Equal(t, uint64(1), util.ComputeCommittedResources(10000.0, rv).Val.Uint64())
 }

--- a/provider/config.go
+++ b/provider/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	InventoryResourcePollPeriod     time.Duration
 	InventoryResourceDebugFrequency uint
 	BPS                             bidengine.BidPricingStrategy
+	CPUCommitLevel                  float64
+	MemoryCommitLevel               float64
+	StorageCommitLevel              float64
 }
 
 func NewDefaultConfig() Config {

--- a/provider/service.go
+++ b/provider/service.go
@@ -50,6 +50,9 @@ func NewService(ctx context.Context, session session.Session, bus pubsub.Bus, cc
 	clusterConfig.InventoryResourcePollPeriod = cfg.InventoryResourcePollPeriod
 	clusterConfig.InventoryResourceDebugFrequency = cfg.InventoryResourceDebugFrequency
 	clusterConfig.InventoryExternalPortQuantity = cfg.ClusterExternalPortQuantity
+	clusterConfig.CPUCommitLevel = cfg.CPUCommitLevel
+	clusterConfig.MemoryCommitLevel = cfg.MemoryCommitLevel
+	clusterConfig.StorageCommitLevel = cfg.StorageCommitLevel
 
 	cluster, err := cluster.NewService(ctx, session, bus, cclient, clusterConfig)
 	if err != nil {

--- a/script/setup-kind.sh
+++ b/script/setup-kind.sh
@@ -31,13 +31,7 @@ install_metrics() {
     --selector=k8s-app=metrics-server \
     --timeout=90s
 
-  count=1
-  while ! kubectl top nodes; do
-    echo "[$((count++))] waiting for metrics..."
-    sleep 1
-  done
-
-  echo "metrics available"
+  echo "metrics initialized"
 }
 
 usage() {


### PR DESCRIPTION
The main issue I found while testing things using my local kubernetes cluster is that the provider continues to bid on things even after the available resources are consumed in the cluster. The provider was setting a limit only in the container pods (which also becomes the request in that case). Kubernetes enforces this, refusing to spinup new pods if available resources aren't there. The provider was continuing to bid because the "inventory" was determined by getting values from the metrics server. For almost all deployment, utilized CPU is less than the CPU limit enforced in the kubernetes pod. It's been changed to just measure the commit CPU by going through all the pods in the cluster.

After this changes, the provider just stops bidding once the available CPU is no longer enough to meet the requested amount. 

The tests in this wound up being a bit verbose, due to the way the kubernetes API works.

This makes the following changes

1. Measure requested resources in the kubernetes cluster for inventory, not the values reported by the metrics server
2. Specify requests & limits when creating a kubernetes pod. By default requests == limits. When overcommit is enabled, requests is less than limits
3. Add overcommit percentage options to the provider. By default overcommit is zero for all resources. Specifying an overcommit of 50 would result in 150% of available CPU in the cluster being requested by the pods
4. If a deployment fails, stop the associated manager immediately
5. If a deployment fails to be cleaned up, retry it with delay between retries up to 5 times. This should help avoid leaking resources (although I don't think that was a problem in testnet).