### PR TITLE
fix(provider): Reject SDL describing invalid env. var. names

### DIFF
--- a/validation/manifest.go
+++ b/validation/manifest.go
@@ -64,6 +64,7 @@ func validateManifestGroup(group manifest.Group, helper *validateManifestGroupsH
 }
 
 var serviceNameValidationRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+var envVarValidatorRegex = regexp.MustCompile(`^[-._a-zA-Z][-._a-zA-Z0-9]*$`)
 
 func validateManifestService(service manifest.Service, helper *validateManifestGroupsHelper) error {
 	if len(service.Name) == 0 {
@@ -84,6 +85,19 @@ func validateManifestService(service manifest.Service, helper *validateManifestG
 		if idx == 0 {
 			return fmt.Errorf("%w: service %q defines an env. var. with an empty name", ErrInvalidManifest, service.Name)
 		}
+
+		var envVarName string
+		if idx > 0 {
+			envVarName = envVar[0:idx]
+		} else {
+			envVarName = envVar
+		}
+
+		matches := envVarValidatorRegex.MatchString(envVarName)
+		if !matches {
+			return fmt.Errorf("%w: service %q defines an env. var. with an invalid name %q", ErrInvalidManifest, service.Name, envVarName)
+		}
+
 	}
 
 	for _, serviceExpose := range service.Expose {

--- a/validation/manifest_test.go
+++ b/validation/manifest_test.go
@@ -411,7 +411,7 @@ func TestManifestWithEmptyImageNameInvalid(t *testing.T) {
 
 func TestManifestWithEmptyEnvValueIsValid(t *testing.T) {
 	m := simpleManifest()
-	envVars := make([]string, 2)
+	envVars := make([]string, 1)
 	envVars[0] = "FOO=" // sets FOO to empty string
 	m[0].Services[0].Env = envVars
 	err := validation.ValidateManifest(m)
@@ -420,12 +420,22 @@ func TestManifestWithEmptyEnvValueIsValid(t *testing.T) {
 
 func TestManifestWithEmptyEnvNameIsInvalid(t *testing.T) {
 	m := simpleManifest()
-	envVars := make([]string, 2)
+	envVars := make([]string, 1)
 	envVars[0] = "=FOO" // invalid
 	m[0].Services[0].Env = envVars
 	err := validation.ValidateManifest(m)
 	require.Error(t, err)
 	require.Regexp(t, `^.*var\. with an empty name.*$`, err)
+}
+
+func TestManifestWithBadEnvNameIsInvalid(t *testing.T) {
+	m := simpleManifest()
+	envVars := make([]string, 1)
+	envVars[0] = "9VAR=FOO" // invalid because it starts with a digit
+	m[0].Services[0].Env = envVars
+	err := validation.ValidateManifest(m)
+	require.Error(t, err)
+	require.Regexp(t, `^.*var\. with an invalid name.*$`, err)
 }
 
 func TestManifestServiceUnknownProtocolIsInvalid(t *testing.T) {


### PR DESCRIPTION
If an environmental variable name is invalid, this code change causes the SDL to fail validation.