### PR TITLE
fix(provider): Update network policies for deployments

### DIFF
--- a/_docs/kustomize/networking/namespace.yaml
+++ b/_docs/kustomize/networking/namespace.yaml
@@ -4,5 +4,5 @@ metadata:
   name: akash-services
   labels:
     name: akash-services
-    akash.network: true
+    akash.network: "true"
     akash.network/name: akash-services

--- a/_docs/provider/kube/ns-network-policies.yaml
+++ b/_docs/provider/kube/ns-network-policies.yaml
@@ -1,0 +1,157 @@
+# Network Policies declared to control tenant traffic. This file is representative what the Providers apply to each tenant namespace via the k8s API.
+#
+# Unfortunately there's no clear way to generate this from the code itself to keep perfect parity. These rules were exported with `kubectl get...` and used to debug network issues on the edgenet provider nodes.
+#
+# To utilize, find-replace will need to update the Namespace identifier with the target namespace, then rules can be edited to test functionality.
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: default-deny-egress
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Egress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: default-deny-ingress
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: egress-allow-cidr
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    egress:
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+          - 10.0.0.0/8
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Egress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: egress-allow-internal
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Egress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: egress-allow-kube-dns
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    egress:
+    - ports:
+      - port: 53
+        protocol: UDP
+      to:
+      - ipBlock:
+          cidr: 10.0.0.0/8
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Egress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: ingress-allow-node-ports
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    ingress:
+    - from:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+          - 10.0.0.0/8
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: ingress-allow-controller
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: ingress-nginx
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      akash.network: "true"
+      akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    name: ingress-allow-internal
+    namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    podSelector:
+      matchLabels:
+        akash.network/namespace: jcdbq0ri93p2ej5p9k6bd59rl04o5nu9u7a1ottnvi81k
+    policyTypes:
+    - Ingress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -5,8 +5,16 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/server"
+	bankcli "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
+	ctypes "github.com/ovrclk/akash/provider/cluster/types"
+	"github.com/ovrclk/akash/x/provider/client/cli"
+	"github.com/ovrclk/akash/x/provider/types"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"os"
+
+	"net"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -19,11 +27,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	bankcli "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
-
 	providerCmd "github.com/ovrclk/akash/provider/cmd"
 	ptestutil "github.com/ovrclk/akash/provider/testutil"
 	"github.com/ovrclk/akash/sdl"
@@ -32,19 +37,27 @@ import (
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	mcli "github.com/ovrclk/akash/x/market/client/cli"
 	mtypes "github.com/ovrclk/akash/x/market/types"
-	"github.com/ovrclk/akash/x/provider/client/cli"
-	"github.com/ovrclk/akash/x/provider/types"
 )
 
 // IntegrationTestSuite wraps testing components
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cfg     network.Config
-	network *network.Network
+	cfg         network.Config
+	network     *network.Network
+	validator   *network.Validator
+	keyProvider keyring.Info
+	keyTenant   keyring.Info
+	prevLeases  mtypes.Leases
+
+	appHost string
+	appPort string
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
+	s.appHost, s.appPort = appEnv(s.T())
+
+	// Create a network for test
 	cfg := testutil.DefaultConfig()
 	cfg.NumValidators = 1
 	cfg.MinGasPrices = ""
@@ -57,69 +70,25 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	_, _, err = kb.NewMnemonic("keyFoo", keyring.English, sdk.FullFundraiserPath, hd.Secp256k1)
 	s.Require().NoError(err)
 
+	// Wait for the network to start
 	_, err = s.network.WaitForHeight(1)
 	s.Require().NoError(err)
-}
 
-func (s *IntegrationTestSuite) TearDownSuite() {
-	val := s.network.Validators[0]
-	keyTenant, err := val.ClientCtx.Keyring.Key("keyBar")
-	s.Require().NoError(err)
-	resp, err := deploycli.QueryDeploymentsExec(val.ClientCtx.WithOutputFormat("json"))
-	s.Require().NoError(err)
-
-	deployResp := &dtypes.QueryDeploymentsResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
-	s.Require().NoError(err)
-	s.Require().Len(deployResp.Deployments, 1, "Deployment Create Failed")
-	deployments := deployResp.Deployments
-
-	// get queried deployment
-	createdDep := deployments[0]
-	// teardown lease
-	_, err = deploycli.TxCloseDeploymentExec(
-		val.ClientCtx,
-		keyTenant.GetAddress(),
-		fmt.Sprintf("--owner=%s", createdDep.Groups[0].GroupID.Owner),
-		fmt.Sprintf("--dseq=%v", createdDep.Deployment.DeploymentID.DSeq),
-		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
-		fmt.Sprintf("--gas=%d", flags.DefaultGasLimit),
-	)
-	s.Require().NoError(err)
-	s.Require().NoError(s.waitForBlocksCommitted(3))
-
-	// test query deployments with state filter closed
-	resp, err = deploycli.QueryDeploymentsExec(
-		val.ClientCtx.WithOutputFormat("json"),
-		"--state=closed",
-	)
-	s.Require().NoError(err)
-
-	qResp := &dtypes.QueryDeploymentsResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), qResp)
-	s.Require().NoError(err)
-	s.Require().Len(qResp.Deployments, 1, "Deployment Close Failed")
-
-	s.network.Cleanup()
-}
-
-func (s *IntegrationTestSuite) TestE2EApp() {
-	val := s.network.Validators[0]
+	//
+	s.validator = s.network.Validators[0]
 
 	// Send coins value
-	sendTokens := sdk.NewInt64Coin(s.cfg.BondDenom, 1000)
+	sendTokens := sdk.NewInt64Coin(s.cfg.BondDenom, 9999999)
 
 	// Setup a Provider key
-	keyProvider, err := val.ClientCtx.Keyring.Key("keyFoo")
+	s.keyProvider, err = s.validator.ClientCtx.Keyring.Key("keyFoo")
 	s.Require().NoError(err)
 
 	// give provider some coins
 	_, err = bankcli.MsgSendExec(
-		val.ClientCtx,
-		val.Address,
-		keyProvider.GetAddress(),
+		s.validator.ClientCtx,
+		s.validator.Address,
+		s.keyProvider.GetAddress(),
 		sdk.NewCoins(sendTokens),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
@@ -130,14 +99,14 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	// Set up second tenant key
-	keyTenant, err := val.ClientCtx.Keyring.Key("keyBar")
+	s.keyTenant, err = s.validator.ClientCtx.Keyring.Key("keyBar")
 	s.Require().NoError(err)
 
 	// give tenant some coins too
 	_, err = bankcli.MsgSendExec(
-		val.ClientCtx,
-		val.Address,
-		keyTenant.GetAddress(),
+		s.validator.ClientCtx,
+		s.validator.Address,
+		s.keyTenant.GetAddress(),
 		sdk.NewCoins(sendTokens),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
@@ -172,8 +141,8 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 
 	// create Provider blockchain declaration
 	_, err = cli.TxCreateProviderExec(
-		val.ClientCtx,
-		keyProvider.GetAddress(),
+		s.validator.ClientCtx,
+		s.keyProvider.GetAddress(),
 		fmt.Sprintf("%s/%s", s.network.BaseDir, fstat.Name()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
@@ -184,17 +153,17 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 
 	s.Require().NoError(s.network.WaitForNextBlock())
 
-	localCtx := val.ClientCtx.WithOutputFormat("json")
+	localCtx := s.validator.ClientCtx.WithOutputFormat("json")
 	// test query providers
 	resp, err := cli.QueryProvidersExec(localCtx)
 	s.Require().NoError(err)
 
 	out := &types.QueryProvidersResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), out)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), out)
 	s.Require().NoError(err)
 	s.Require().Len(out.Providers, 1, "Provider Creation Failed")
 	providers := out.Providers
-	s.Require().Equal(keyProvider.GetAddress().String(), providers[0].Owner)
+	s.Require().Equal(s.keyProvider.GetAddress().String(), providers[0].Owner)
 
 	// test query provider
 	createdProvider := providers[0]
@@ -202,21 +171,21 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	s.Require().NoError(err)
 
 	var provider types.Provider
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), &provider)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), &provider)
 	s.Require().NoError(err)
 	s.Require().Equal(createdProvider, provider)
 
 	// Run Provider service
-	keyName := keyProvider.GetName()
+	keyName := s.keyProvider.GetName()
 
 	// Change the akash home directory for CLI to access the test keyring
-	cliHome := strings.Replace(val.ClientCtx.HomeDir, "simd", "simcli", 1)
+	cliHome := strings.Replace(s.validator.ClientCtx.HomeDir, "simd", "simcli", 1)
 
-	cctx := val.ClientCtx
+	cctx := s.validator.ClientCtx
 	go func() {
 		_, err := ptestutil.RunLocalProvider(cctx,
 			cctx.ChainID,
-			val.RPCAddress,
+			s.validator.RPCAddress,
 			cliHome,
 			keyName,
 			provURL.Host,
@@ -226,16 +195,232 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	}()
 
 	s.Require().NoError(s.network.WaitForNextBlock())
+}
 
+func (s *IntegrationTestSuite) TearDownSuite() {
+
+	keyTenant, err := s.validator.ClientCtx.Keyring.Key("keyBar")
+	s.Require().NoError(err)
+	resp, err := deploycli.QueryDeploymentsExec(s.validator.ClientCtx.WithOutputFormat("json"))
+	s.Require().NoError(err)
+
+	deployResp := &dtypes.QueryDeploymentsResponse{}
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
+	s.Require().NoError(err)
+	s.Require().False(0 == len(deployResp.Deployments), "no deployments created")
+
+	deployments := deployResp.Deployments
+
+	for _, createdDep := range deployments {
+		// teardown lease
+		_, err = deploycli.TxCloseDeploymentExec(
+			s.validator.ClientCtx,
+			keyTenant.GetAddress(),
+			fmt.Sprintf("--owner=%s", createdDep.Groups[0].GroupID.Owner),
+			fmt.Sprintf("--dseq=%v", createdDep.Deployment.DeploymentID.DSeq),
+			fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+			fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+			fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+			fmt.Sprintf("--gas=%d", flags.DefaultGasLimit),
+		)
+		s.Require().NoError(err)
+		s.Require().NoError(s.waitForBlocksCommitted(1))
+	}
+
+	s.Require().NoError(s.waitForBlocksCommitted(3))
+	// test query deployments with state filter closed
+	resp, err = deploycli.QueryDeploymentsExec(
+		s.validator.ClientCtx.WithOutputFormat("json"),
+		"--state=closed",
+	)
+	s.Require().NoError(err)
+
+	qResp := &dtypes.QueryDeploymentsResponse{}
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), qResp)
+	s.Require().NoError(err)
+	s.Require().True(len(qResp.Deployments) == len(deployResp.Deployments), "Deployment Close Failed")
+
+	s.network.Cleanup()
+}
+
+func newestLease(leases mtypes.Leases) mtypes.Lease {
+	result := mtypes.Lease{}
+	assigned := false
+
+	for _, lease := range leases {
+		if !assigned {
+			result = lease
+			assigned = true
+		} else if result.GetLeaseID().DSeq < lease.GetLeaseID().DSeq {
+			result = lease
+		}
+	}
+
+	return result
+}
+
+func getKubernetesIP() string {
+	return os.Getenv("KUBE_NODE_IP")
+}
+
+func (s *IntegrationTestSuite) TestE2EContainerToContainer() {
+	// create a deployment
+	deploymentPath, err := filepath.Abs("../x/deployment/testdata/deployment-v2-c2c.yaml")
+	s.Require().NoError(err)
+
+	// Create Deployments
+	_, err = deploycli.TxCreateDeploymentExec(
+		s.validator.ClientCtx,
+		s.keyTenant.GetAddress(),
+		deploymentPath,
+		fmt.Sprintf("--%s", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20))).String()),
+		fmt.Sprintf("--gas=%d", flags.DefaultGasLimit),
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(7))
+
+	// Assert provider made bid and created lease; test query leases ---------
+	resp, err := mcli.QueryLeasesExec(s.validator.ClientCtx.WithOutputFormat("json"))
+	s.Require().NoError(err)
+
+	leaseRes := &mtypes.QueryLeasesResponse{}
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), leaseRes)
+	s.Require().NoError(err)
+
+	s.Require().Len(leaseRes.Leases, len(s.prevLeases)+1)
+	s.prevLeases = leaseRes.Leases
+
+	lease := newestLease(leaseRes.Leases)
+	lid := lease.LeaseID
+	s.Require().Equal(s.keyProvider.GetAddress().String(), lid.Provider)
+
+	// Send Manifest to Provider ----------------------------------------------
+	_, err = ptestutil.TestSendManifest(s.validator.ClientCtx.WithOutputFormat("json"), lid.BidID(), deploymentPath)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+
+	// Hit the endpoint to set a key in redis, foo = bar
+	appURL := fmt.Sprintf("http://%s:%s/SET/foo/bar", s.appHost, s.appPort)
+
+	const testHost = "webdistest.localhost"
+	const attempts = 120
+	httpResp := queryAppWithRetries(s.T(), appURL, testHost, attempts)
+	bodyData, err := ioutil.ReadAll(httpResp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(`{"SET":[true,"OK"]}`, string(bodyData))
+
+	// Hit the endpoint to read a key in redis, foo
+	appURL = fmt.Sprintf("http://%s:%s/GET/foo", s.appHost, s.appPort)
+	httpResp = queryAppWithRetries(s.T(), appURL, testHost, attempts)
+	bodyData, err = ioutil.ReadAll(httpResp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(`{"GET":"bar"}`, string(bodyData)) // Check that the value is bar
+}
+
+func (s *IntegrationTestSuite) TestE2EAppNodePort() {
+	// create a deployment
+	deploymentPath, err := filepath.Abs("../x/deployment/testdata/deployment-v2-nodeport.yaml")
+	s.Require().NoError(err)
+
+	// Create Deployments
+	_, err = deploycli.TxCreateDeploymentExec(
+		s.validator.ClientCtx,
+		s.keyTenant.GetAddress(),
+		deploymentPath,
+		fmt.Sprintf("--%s", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(20))).String()),
+		fmt.Sprintf("--gas=%d", flags.DefaultGasLimit),
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(7))
+
+	// Assert provider made bid and created lease; test query leases ---------
+	resp, err := mcli.QueryLeasesExec(s.validator.ClientCtx.WithOutputFormat("json"))
+	s.Require().NoError(err)
+
+	leaseRes := &mtypes.QueryLeasesResponse{}
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), leaseRes)
+	s.Require().NoError(err)
+
+	s.Require().Len(leaseRes.Leases, len(s.prevLeases)+1)
+	s.prevLeases = leaseRes.Leases
+
+	lease := newestLease(leaseRes.Leases)
+	lid := lease.LeaseID
+	s.Require().Equal(s.keyProvider.GetAddress().String(), lid.Provider)
+
+	// Send Manifest to Provider ----------------------------------------------
+	_, err = ptestutil.TestSendManifest(s.validator.ClientCtx.WithOutputFormat("json"), lid.BidID(), deploymentPath)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+
+	// Get the lease status
+	cmdResult, err := providerCmd.ProviderLeaseStatusExec(
+		s.validator.ClientCtx,
+		fmt.Sprintf("--%s=%v", "dseq", lid.DSeq),
+		fmt.Sprintf("--%s=%v", "gseq", lid.GSeq),
+		fmt.Sprintf("--%s=%v", "oseq", lid.OSeq),
+		fmt.Sprintf("--%s=%v", "owner", lid.Owner),
+		fmt.Sprintf("--%s=%v", "provider", lid.Provider))
+	assert.NoError(s.T(), err)
+	data := ctypes.LeaseStatus{}
+	err = json.Unmarshal(cmdResult.Bytes(), &data)
+	assert.NoError(s.T(), err)
+
+	forwardedPort := uint16(0)
+portLoop:
+	for _, entry := range data.ForwardedPorts {
+		for _, port := range entry {
+			forwardedPort = port.ExternalPort
+			break portLoop
+		}
+	}
+	s.Require().NotEqual(uint16(0), forwardedPort)
+
+	const maxAttempts = 60
+	var recvData []byte
+	var connErr error
+	var conn net.Conn
+
+	kubernetesIP := getKubernetesIP()
+	if len(kubernetesIP) != 0 {
+		for attempts := 0; attempts != maxAttempts; attempts++ {
+			// Connect with a timeout so the test doesn't get stuck here
+			conn, connErr = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", kubernetesIP, forwardedPort), 2*time.Second)
+			// If an error, just wait and try again
+			if connErr != nil {
+				time.Sleep(time.Duration(500) * time.Millisecond)
+				continue
+			}
+			break
+		}
+
+		// check that a connection was created without any error
+		s.Require().NoError(connErr)
+		// Read everything with a timeout
+		err = conn.SetReadDeadline(time.Now().Add(time.Duration(10) * time.Second))
+		s.Require().NoError(err)
+		recvData, err = ioutil.ReadAll(conn)
+		s.Require().NoError(err)
+		s.Require().NoError(conn.Close())
+
+		s.Require().Regexp("^.*hello world(?s:.)*$", string(recvData))
+	}
+}
+
+func (s *IntegrationTestSuite) TestE2EApp() {
 	// create a deployment
 	deploymentPath, err := filepath.Abs("../x/deployment/testdata/deployment-v2.yaml")
 	s.Require().NoError(err)
 
 	// Create Deployments and assert query to assert
-	tenantAddr := keyTenant.GetAddress().String()
+	tenantAddr := s.keyTenant.GetAddress().String()
 	_, err = deploycli.TxCreateDeploymentExec(
-		val.ClientCtx,
-		keyTenant.GetAddress(),
+		s.validator.ClientCtx,
+		s.keyTenant.GetAddress(),
 		deploymentPath,
 		fmt.Sprintf("--%s", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
@@ -246,11 +431,11 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	// Test query deployments ---------------------------------------------
-	resp, err = deploycli.QueryDeploymentsExec(val.ClientCtx.WithOutputFormat("json"))
+	resp, err := deploycli.QueryDeploymentsExec(s.validator.ClientCtx.WithOutputFormat("json"))
 	s.Require().NoError(err)
 
 	deployResp := &dtypes.QueryDeploymentsResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
 	s.Require().NoError(err)
 	s.Require().Len(deployResp.Deployments, 1, "Deployment Create Failed")
 	deployments := deployResp.Deployments
@@ -258,35 +443,35 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 
 	// test query deployment
 	createdDep := deployments[0]
-	resp, err = deploycli.QueryDeploymentExec(val.ClientCtx.WithOutputFormat("json"), createdDep.Deployment.DeploymentID)
+	resp, err = deploycli.QueryDeploymentExec(s.validator.ClientCtx.WithOutputFormat("json"), createdDep.Deployment.DeploymentID)
 	s.Require().NoError(err)
 
 	deploymentResp := dtypes.DeploymentResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), &deploymentResp)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), &deploymentResp)
 	s.Require().NoError(err)
 	s.Require().Equal(createdDep, deploymentResp)
 	s.Require().NotEmpty(deploymentResp.Deployment.Version)
 
 	// test query deployments with filters -----------------------------------
 	resp, err = deploycli.QueryDeploymentsExec(
-		val.ClientCtx.WithOutputFormat("json"),
+		s.validator.ClientCtx.WithOutputFormat("json"),
 		fmt.Sprintf("--owner=%s", tenantAddr),
 		fmt.Sprintf("--dseq=%v", createdDep.Deployment.DeploymentID.DSeq),
 	)
 	s.Require().NoError(err, "Error when fetching deployments with owner filter")
 
 	deployResp = &dtypes.QueryDeploymentsResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), deployResp)
 	s.Require().NoError(err)
 	s.Require().Len(deployResp.Deployments, 1)
 
 	// Assert orders created by provider
 	// test query orders
-	resp, err = mcli.QueryOrdersExec(val.ClientCtx.WithOutputFormat("json"))
+	resp, err = mcli.QueryOrdersExec(s.validator.ClientCtx.WithOutputFormat("json"))
 	s.Require().NoError(err)
 
 	result := &mtypes.QueryOrdersResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), result)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), result)
 	s.Require().NoError(err)
 	s.Require().Len(result.Orders, 1)
 	orders := result.Orders
@@ -296,37 +481,28 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	s.Require().NoError(s.waitForBlocksCommitted(6))
 
 	// Assert provider made bid and created lease; test query leases ---------
-	resp, err = mcli.QueryLeasesExec(val.ClientCtx.WithOutputFormat("json"))
+	resp, err = mcli.QueryLeasesExec(s.validator.ClientCtx.WithOutputFormat("json"))
 	s.Require().NoError(err)
 
 	leaseRes := &mtypes.QueryLeasesResponse{}
-	err = val.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), leaseRes)
+	err = s.validator.ClientCtx.JSONMarshaler.UnmarshalJSON(resp.Bytes(), leaseRes)
 	s.Require().NoError(err)
-	s.Require().Len(leaseRes.Leases, 1)
-	lease := leaseRes.Leases[0]
+	s.Require().Len(leaseRes.Leases, len(s.prevLeases)+1)
+	s.prevLeases = leaseRes.Leases
+	lease := newestLease(leaseRes.Leases)
 	lid := lease.LeaseID
-	s.Require().Equal(keyProvider.GetAddress().String(), lid.Provider)
+	s.Require().Equal(s.keyProvider.GetAddress().String(), lid.Provider)
 
 	// Send Manifest to Provider ----------------------------------------------
-	bID := mtypes.BidID{
-		Provider: lid.Provider,
-		Owner:    lid.Owner,
-		DSeq:     lid.DSeq,
-		GSeq:     lid.GSeq,
-		OSeq:     lid.OSeq,
-	}
-
-	_, err = ptestutil.TestSendManifest(val.ClientCtx.WithOutputFormat("json"), bID, deploymentPath)
+	_, err = ptestutil.TestSendManifest(s.validator.ClientCtx.WithOutputFormat("json"), lid.BidID(), deploymentPath)
 	s.Require().NoError(err)
-
 	s.Require().NoError(s.waitForBlocksCommitted(20))
 
-	host, appPort := appEnv(s.T())
-	appURL := fmt.Sprintf("http://%s:%s/", host, appPort)
+	appURL := fmt.Sprintf("http://%s:%s/", s.appHost, s.appPort)
 	queryApp(s.T(), appURL, 50)
 
 	cmdResult, err := providerCmd.ProviderStatusExec(
-		val.ClientCtx,
+		s.validator.ClientCtx,
 		fmt.Sprintf("--%s=%v", "provider", lid.Provider))
 	assert.NoError(s.T(), err)
 	data := make(map[string]interface{})
@@ -343,7 +519,7 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	require.NoError(s.T(), err)
 
 	cmdResult, err = providerCmd.ProviderLeaseStatusExec(
-		val.ClientCtx,
+		s.validator.ClientCtx,
 		fmt.Sprintf("--%s=%v", "dseq", lid.DSeq),
 		fmt.Sprintf("--%s=%v", "gseq", lid.GSeq),
 		fmt.Sprintf("--%s=%v", "oseq", lid.OSeq),
@@ -363,7 +539,7 @@ func (s *IntegrationTestSuite) TestE2EApp() {
 	for _, group := range mani.GetGroups() {
 		for _, service := range group.Services {
 			cmdResult, err = providerCmd.ProviderServiceStatusExec(
-				val.ClientCtx,
+				s.validator.ClientCtx,
 				fmt.Sprintf("--%s=%v", "dseq", lid.DSeq),
 				fmt.Sprintf("--%s=%v", "gseq", lid.GSeq),
 				fmt.Sprintf("--%s=%v", "oseq", lid.OSeq),

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -1,4 +1,6 @@
 COVER_PACKAGES = $(shell go list ./... | grep -v mock)
+# This is statically specified in the vagrant configuration
+KUBE_NODE_IP ?= 172.18.8.101
 ###############################################################################
 ###                           Integration                                   ###
 ###############################################################################
@@ -8,7 +10,7 @@ test-e2e-integration:
 	$(KIND_VARS) go test -count=1 -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
 
 test-e2e-integration-k8s:
-	KUBE_INGRESS_IP=127.0.0.1 KUBE_INGRESS_PORT=10080 go test -count=1 -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
+	KUBE_NODE_IP="$(KUBE_NODE_IP)" KUBE_INGRESS_IP=127.0.0.1 KUBE_INGRESS_PORT=10080 go test -count=1 -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestIntegrationTestSuite
 
 test-query-app:
 	 $(KIND_VARS) go test -mod=readonly -p 4 -tags "e2e integration $(BUILD_MAINNET)" -v ./integration/... -run TestQueryApp

--- a/provider/cluster/kube/builder_test.go
+++ b/provider/cluster/kube/builder_test.go
@@ -18,14 +18,22 @@ func TestLidNsSanity(t *testing.T) {
 	leaseID := testutil.LeaseID(t)
 
 	ns := lidNS(leaseID)
-
 	assert.NotEmpty(t, ns)
 
 	// namespaces must be no more than 63 characters.
 	assert.Less(t, len(ns), int(64))
-
+	settings := NewDefaultSettings()
 	g := &manifest.Group{}
-	mb := newManifestBuilder(log, NewDefaultSettings(), ns, leaseID, g)
+
+	b := builder{
+		log:      log,
+		settings: settings,
+		lid:      leaseID,
+		group:    g,
+	}
+
+	mb := newManifestBuilder(log, settings, ns, leaseID, g)
+	assert.Equal(t, b.ns(), mb.ns())
 
 	m, err := mb.create()
 	assert.NoError(t, err)
@@ -51,10 +59,10 @@ func TestNetworkPolicies(t *testing.T) {
 	np = newNetPolBuilder(settings, leaseID, g)
 	netPolicies, err = np.create()
 	assert.NoError(t, err)
-	assert.Len(t, netPolicies, 7)
+	assert.Len(t, netPolicies, 1)
 
 	pol0 := netPolicies[0]
-	assert.Equal(t, pol0.Name, "default-deny-ingress")
+	assert.Equal(t, pol0.Name, "akash-deployment-restrictions")
 
 	// Change the DSeq ID
 	np.lid.DSeq = uint64(100)

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -184,7 +184,7 @@ func RunCmd() *cobra.Command {
 		return nil
 	}
 
-	cmd.Flags().Bool(FlagDeploymentNetworkPoliciesEnabled, false, "Enable network policies")
+	cmd.Flags().Bool(FlagDeploymentNetworkPoliciesEnabled, true, "Enable network policies")
 	if err := viper.BindPFlag(FlagDeploymentNetworkPoliciesEnabled, cmd.Flags().Lookup(FlagDeploymentNetworkPoliciesEnabled)); err != nil {
 		return nil
 	}

--- a/x/deployment/testdata/deployment-v2-c2c.yaml
+++ b/x/deployment/testdata/deployment-v2-c2c.yaml
@@ -1,0 +1,58 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: anapsix/webdis
+    env:
+      - REDIS_HOST=redis-server
+    expose:
+      - port: 7379
+        as: 80
+        to:
+          - global: true
+        accept:
+          - webdistest.localhost
+
+  redis-server:
+    image: redis:rc-alpine3.12
+    expose:
+      - port: 6379
+      
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 16Mi
+        storage:
+          size: 128Mi
+    redis-server:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 64Mi
+        storage:
+          size: 128Mi
+  placement:
+    global:
+      pricing:
+        web: 
+          denom: uakt
+          amount: 9000
+        redis-server:
+          denom: uakt
+          amount: 9000
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1
+  redis-server:
+    global:
+      profile: redis-server
+      count: 1

--- a/x/deployment/testdata/deployment-v2-nodeport.yaml
+++ b/x/deployment/testdata/deployment-v2-nodeport.yaml
@@ -1,0 +1,39 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: hydrogen18/hello_world:20201209
+    expose:
+      - port: 10000
+        as: 10000
+        to:
+          - global: true
+      - port: 10000
+        as: 10000
+        proto: UDP
+        to: 
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 16Mi
+        storage:
+          size: 128Mi
+  placement:
+    global:
+      pricing:
+        web: 
+          denom: uakt
+          amount: 9000
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1


### PR DESCRIPTION
This should have the following changes

1. Create a default network policy **within each deployment namespace**, that applies to all pods
2. Enable access from Ingress controller to pod containers by default
3. Enable DNS access from pod containers by default
4. Allow public IPV4 addresses to be accesed from pod containers, but deny private IPV4 addresses
5. Explicitly allow connections between pods within the same namespace
6. For each service with a nodeport, add a policy **selecting just that pod** to open the appropriate port & protocol

The following tests are added

1. End to end test of NodePort connectivity - possible when you're testing against K8S in Vagrant
2. End to end test of container to container communication in the same deployment. I'm using Redis & webdis for this.

These end to end tests should cover the expected modes of communication that a deployment cn have 

Before I made these changes, I could get a shell into a pod container and access basically anything (including other deployments). After these changes I tested manually using a shell from within a container

1. That I can't connect to other pods in other deployments
2. That I can't access stuff on my local home network
3. That I can access the internet (I can use apk in containers for example to install new packages)

There is still the issue that apparently Kubernetes has a 100 pod per node limitation, but I'm going to address that in a separate PR.

This is a pretty big set of changes and I may have missed something, it's based off just my idea of the network security should work.