### PR TITLE
feat(provider): Run containers in deployments with a pod security policy

### DIFF
--- a/_run/kube/deployment.yaml
+++ b/_run/kube/deployment.yaml
@@ -6,7 +6,6 @@ services:
     image: quay.io/ovrclk/demo-app
     expose:
       - port: 80
-        as: 80
         accept:
           - hello.localhost
         to:

--- a/_run/single/deployment.yaml
+++ b/_run/single/deployment.yaml
@@ -6,7 +6,6 @@ services:
     image: quay.io/ovrclk/demo-app
     expose:
       - port: 80
-        as: 80
         accept:
           - hello.localhost
         to:

--- a/provider/cluster/kube/apply.go
+++ b/provider/cluster/kube/apply.go
@@ -57,23 +57,22 @@ func applyNetPolicies(ctx context.Context, kc kubernetes.Interface, b *netPolBui
 	return err
 }
 
-// TODO: re-enable.  see #946
-// func applyRestrictivePodSecPoliciesToNS(ctx context.Context, kc kubernetes.Interface, p *pspRestrictedBuilder) error {
-// 	obj, err := kc.PolicyV1beta1().PodSecurityPolicies().Get(ctx, p.name(), metav1.GetOptions{})
-// 	switch {
-// 	case err == nil:
-// 		obj, err = p.update(obj)
-// 		if err == nil {
-// 			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Update(ctx, obj, metav1.UpdateOptions{})
-// 		}
-// 	case errors.IsNotFound(err):
-// 		obj, err = p.create()
-// 		if err == nil {
-// 			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Create(ctx, obj, metav1.CreateOptions{})
-// 		}
-// 	}
-// 	return err
-// }
+func applyRestrictivePodSecPoliciesToNS(ctx context.Context, kc kubernetes.Interface, p *pspRestrictedBuilder) error {
+	obj, err := kc.PolicyV1beta1().PodSecurityPolicies().Get(ctx, p.name(), metav1.GetOptions{})
+	switch {
+	case err == nil && obj != nil:
+		obj, err = p.update(obj)
+		if err == nil {
+			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Update(ctx, obj, metav1.UpdateOptions{})
+		}
+	case errors.IsNotFound(err):
+		obj, err = p.create()
+		if err == nil {
+			_, err = kc.PolicyV1beta1().PodSecurityPolicies().Create(ctx, obj, metav1.CreateOptions{})
+		}
+	}
+	return err
+}
 
 func applyDeployment(ctx context.Context, kc kubernetes.Interface, b *deploymentBuilder) error {
 	obj, err := kc.AppsV1().Deployments(b.ns()).Get(ctx, b.name(), metav1.GetOptions{})

--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -138,11 +138,10 @@ func (c *client) Deploy(ctx context.Context, lid mtypes.LeaseID, group *manifest
 		return err
 	}
 
-	// TODO: re-enable.  see #946
-	// if err := applyRestrictivePodSecPoliciesToNS(ctx, c.kc, newPspBuilder(c.settings, lid, group)); err != nil {
-	// 	c.log.Error("applying pod security policies", "err", err, "lease", lid)
-	// 	return err
-	// }
+	if err := applyRestrictivePodSecPoliciesToNS(ctx, c.kc, newPspBuilder(c.settings, lid, group)); err != nil {
+		c.log.Error("applying pod security policies", "err", err, "lease", lid)
+		return err
+	}
 
 	if err := applyNetPolicies(ctx, c.kc, newNetPolBuilder(c.settings, lid, group)); err != nil {
 		c.log.Error("applying namespace network policies", "err", err, "lease", lid)

--- a/provider/cluster/kube/settings.go
+++ b/provider/cluster/kube/settings.go
@@ -28,7 +28,8 @@ type Settings struct {
 	ClusterPublicHostname string
 
 	// NetworkPoliciesEnabled determines if NetworkPolicies should be installed.
-	NetworkPoliciesEnabled bool
+	NetworkPoliciesEnabled     bool
+	PodSecurityPoliciesEnabled bool
 
 	CPUCommitLevel     float64
 	MemoryCommitLevel  float64


### PR DESCRIPTION
This set of changes is based off the work Josh did, but only contains the following restrictions

1. Disallow access to kubernetes persistent volumes (we have no support of this at present)
2. Disallow direct access to host network adapter 
3. Disallow host IPC communication
4. Disallow host PID usage
5. Disallow access to any devices on the host