### PR TITLE
feat(provider): Validate hostnames as part of a manifest before accepting it

### DIFF
--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -90,12 +90,17 @@ func queryAppWithRetries(t *testing.T, appURL string, appHost string, limit int)
 
 	return resp
 }
-
-// Assert provider launches app in kind cluster
 func queryApp(t *testing.T, appURL string, limit int) {
+	queryAppWithHostname(t, appURL, limit, "test.localhost")
+}
+
+
+func queryAppWithHostname(t *testing.T, appURL string, limit int, hostname string) {
+// Assert provider launches app in kind cluster
+
 	req, err := http.NewRequest("GET", appURL, nil)
 	require.NoError(t, err)
-	req.Host = "test.localhost" // NOTE: cannot be inserted as a req.Header element, that is overwritten by this req.Host field.
+	req.Host = hostname // NOTE: cannot be inserted as a req.Header element, that is overwritten by this req.Host field.
 	req.Header.Add("Cache-Control", "no-cache")
 	req.Header.Add("Connection", "keep-alive")
 	// Assert that the service is accessible. Unforetunately brittle single request.

--- a/provider/cluster/config.go
+++ b/provider/cluster/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	CPUCommitLevel                  float64
 	MemoryCommitLevel               float64
 	StorageCommitLevel              float64
+	BlockedHostnames                []string
 }
 
 func NewDefaultConfig() Config {

--- a/provider/cluster/hostname.go
+++ b/provider/cluster/hostname.go
@@ -1,0 +1,232 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	lifecycle "github.com/boz/go-lifecycle"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	"github.com/pkg/errors"
+	"strings"
+	"sync"
+)
+
+type reserveRequest struct {
+	hostnames []string
+	result    chan<- error
+	doReserve bool
+	dID       dtypes.DeploymentID
+}
+
+type HostnameServiceClient interface {
+	ReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error
+	ReleaseHostnames(hostnames []string)
+	CanReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error
+}
+
+type SimpleHostnames struct {
+	Hostnames map[string]dtypes.DeploymentID
+	lock      sync.Mutex
+} /* Used in test code */
+
+func (sh *SimpleHostnames) ReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error {
+	sh.lock.Lock()
+	defer sh.lock.Unlock()
+	ch := make(chan error, 1)
+	for _, hostname := range hostnames {
+		_, inUse := sh.Hostnames[hostname]
+		if inUse {
+			ch <- fmt.Errorf("%w: host %q in use", errHostnameNotAllowed, hostname)
+			return ch
+		}
+		sh.Hostnames[hostname] = did
+	}
+
+	ch <- nil
+	return ch
+}
+
+func (sh *SimpleHostnames) CanReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error {
+	sh.lock.Lock()
+	defer sh.lock.Unlock()
+	ch := make(chan error, 1)
+
+	for _, hostname := range hostnames {
+		usedByDid, inUse := sh.Hostnames[hostname]
+		if inUse && !usedByDid.Equals(did) {
+			ch <- fmt.Errorf("%w: host %q in use", errHostnameNotAllowed, hostname)
+			return ch
+		}
+	}
+
+	ch <- nil
+	return ch
+}
+
+func (sh *SimpleHostnames) ReleaseHostnames(hostnames []string) {
+	sh.lock.Lock()
+	defer sh.lock.Unlock()
+
+	for _, hostname := range hostnames {
+		delete(sh.Hostnames, hostname)
+	}
+}
+
+type hostnameService struct {
+	inUse map[string]dtypes.DeploymentID
+
+	requests chan reserveRequest
+	releases chan []string
+	lc       lifecycle.Lifecycle
+
+	blockedHostnames []string
+	blockedDomains   []string
+}
+
+const HostnameSeparator = '.'
+
+func newHostnameService(ctx context.Context, cfg Config) *hostnameService {
+
+	blockedHostnames := make([]string, 0)
+	blockedDomains := make([]string, 0)
+	for _, name := range cfg.BlockedHostnames {
+
+		if len(name) != 0 && name[0] == HostnameSeparator {
+			blockedDomains = append(blockedDomains, name)
+			blockedHostnames = append(blockedHostnames, name[1:])
+		} else {
+			blockedHostnames = append(blockedHostnames, name)
+		}
+	}
+
+	hs := &hostnameService{
+		inUse:            make(map[string]dtypes.DeploymentID),
+		blockedHostnames: blockedHostnames,
+		blockedDomains:   blockedDomains,
+		requests:         make(chan reserveRequest),
+		releases:         make(chan []string),
+		lc:               lifecycle.New(),
+	}
+
+	go hs.lc.WatchContext(ctx)
+	go hs.run()
+
+	return hs
+}
+
+func (hs *hostnameService) run() {
+	defer hs.lc.ShutdownCompleted()
+
+loop:
+	for {
+
+		// Wait for any service to finish
+		select {
+		case <-hs.lc.ShutdownRequest():
+			hs.lc.ShutdownInitiated(nil)
+			break loop
+		case rr := <-hs.requests:
+			hs.doRequest(rr)
+		case hostnames := <-hs.releases:
+			hs.doRelease(hostnames)
+		}
+	}
+
+}
+
+var errHostnameNotAllowed = errors.New("hostname not allowed")
+
+func (hs *hostnameService) isHostnameBlocked(hostname string) error {
+	for _, blockedHostname := range hs.blockedHostnames {
+		if blockedHostname == hostname {
+			return fmt.Errorf("%w: %q is blocked by this provider", errHostnameNotAllowed, hostname)
+		}
+	}
+
+	for _, blockedDomain := range hs.blockedDomains {
+		if strings.HasSuffix(hostname, blockedDomain) {
+			return fmt.Errorf("%w: domain %q is blocked by this provider", errHostnameNotAllowed, hostname)
+		}
+	}
+
+	return nil
+}
+
+func (hs *hostnameService) doRequest(rr reserveRequest) {
+	// check if hostname is blocked
+	for _, hostname := range rr.hostnames {
+		blockedErr := hs.isHostnameBlocked(hostname)
+		if blockedErr != nil {
+			rr.result <- blockedErr
+			return
+		}
+		takenBy, hostnameTaken := hs.inUse[hostname]
+		if hostnameTaken && !takenBy.Equals(rr.dID) {
+			rr.result <- fmt.Errorf("%w: %q already in use", errHostnameNotAllowed, hostname)
+			return
+		}
+	}
+
+	if rr.doReserve {
+		for _, hostname := range rr.hostnames {
+			hs.inUse[hostname] = rr.dID
+		}
+	}
+
+	rr.result <- nil // No error
+}
+
+func (hs *hostnameService) doRelease(hostnames []string) {
+	for _, hostname := range hostnames {
+		delete(hs.inUse, hostname)
+	}
+}
+
+func (hs *hostnameService) ReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error {
+	returnValue := make(chan error, 1) // Buffer of one so service does not block
+	lowercaseHostnames := make([]string, len(hostnames))
+	for i, hostname := range hostnames {
+		lowercaseHostnames[i] = strings.ToLower(hostname)
+	}
+	request := reserveRequest{
+		hostnames: lowercaseHostnames,
+		result:    returnValue,
+		doReserve: true, // reserve hostnames
+		dID:       did,
+	}
+
+	select {
+	case hs.requests <- request:
+
+	case <-hs.lc.ShuttingDown():
+		returnValue <- ErrNotRunning
+	}
+
+	return returnValue
+}
+
+func (hs *hostnameService) ReleaseHostnames(hostnames []string) {
+	hs.releases <- hostnames
+}
+
+func (hs *hostnameService) CanReserveHostnames(hostnames []string, did dtypes.DeploymentID) <-chan error {
+	returnValue := make(chan error, 1) // Buffer of one so service does not block
+	lowercaseHostnames := make([]string, len(hostnames))
+	for i, hostname := range hostnames {
+		lowercaseHostnames[i] = strings.ToLower(hostname)
+	}
+	request := reserveRequest{
+		hostnames: lowercaseHostnames,
+		result:    returnValue,
+		doReserve: false, // do not actually reserve hostnames
+		dID:       did,
+	}
+
+	select {
+	case hs.requests <- request:
+
+	case <-hs.lc.ShuttingDown():
+		returnValue <- ErrNotRunning
+	}
+
+	return returnValue
+}

--- a/provider/cluster/hostname_test.go
+++ b/provider/cluster/hostname_test.go
@@ -1,0 +1,139 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"github.com/ovrclk/akash/testutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+type scaffold struct {
+	service *hostnameService
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+func makeHostnameScaffold(blockedHostnames []string) *scaffold {
+	ctx, cancel := context.WithCancel(context.Background())
+	v := &scaffold{
+		service: newHostnameService(ctx, Config{BlockedHostnames: blockedHostnames}),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	return v
+}
+
+const testWait = time.Second * time.Duration(5)
+
+func TestBlockedHostname(t *testing.T) {
+	s := makeHostnameScaffold([]string{"foobar.com", "bobsdefi.com"})
+
+	did := testutil.DeploymentID(t)
+	responseCh := s.service.CanReserveHostnames([]string{"foobar.com", "other.org"}, did)
+	select {
+	case err := <-responseCh:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errHostnameNotAllowed))
+		require.Regexp(t, "^.*blocked by this provider.*$", err.Error())
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+	s.cancel()
+
+	select {
+	case <-s.service.lc.Done():
+
+	case <-time.After(testWait):
+		t.Fatal("timed out waiting for service shutdown")
+	}
+}
+
+func TestBlockedDomain(t *testing.T) {
+	s := makeHostnameScaffold([]string{"foobar.com", ".bobsdefi.com"})
+
+	did := testutil.DeploymentID(t)
+	responseCh := s.service.CanReserveHostnames([]string{"accounts.bobsdefi.com"}, did)
+	select {
+	case err := <-responseCh:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errHostnameNotAllowed))
+		require.Regexp(t, "^.*blocked by this provider.*$", err.Error())
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+	s.cancel()
+
+	select {
+	case <-s.service.lc.Done():
+
+	case <-time.After(testWait):
+		t.Fatal("timed out waiting for service shutdown")
+	}
+}
+
+func TestReserveMoreHostnamesSameDeployment(t *testing.T) {
+	s := makeHostnameScaffold([]string{"foobar.com", ".bobsdefi.com"})
+
+	did := testutil.DeploymentID(t)
+	responseCh := s.service.ReserveHostnames([]string{"meow.com", "kittens.com"}, did)
+	select {
+	case err := <-responseCh:
+		require.NoError(t, err)
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+
+	responseCh = s.service.ReserveHostnames([]string{"kittens.com", "meow.com", "cats.com"}, did)
+	select {
+	case err := <-responseCh:
+		require.NoError(t, err)
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+
+}
+
+func TestReserveAndReleaseDomain(t *testing.T) {
+	s := makeHostnameScaffold([]string{"foobar.com", ".bobsdefi.com"})
+
+	did := testutil.DeploymentID(t)
+	responseCh := s.service.ReserveHostnames([]string{"meow.com", "kittens.com"}, did)
+	select {
+	case err := <-responseCh:
+		require.NoError(t, err)
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+
+	secondDid := testutil.DeploymentID(t)
+	responseCh = s.service.ReserveHostnames([]string{"KITTENS.com"}, secondDid)
+	select {
+	case err := <-responseCh:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errHostnameNotAllowed))
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+
+	s.service.ReleaseHostnames([]string{"meow.com", "kittens.com"})
+
+	responseCh = s.service.ReserveHostnames([]string{"kittens.com"}, secondDid)
+	select {
+	case err := <-responseCh:
+		require.NoError(t, err)
+	case <-time.After(testWait):
+		t.Fatal("test timed out waiting on response from service")
+	}
+
+	s.cancel()
+
+	select {
+	case <-s.service.lc.Done():
+
+	case <-time.After(testWait):
+		t.Fatal("timed out waiting for service shutdown")
+	}
+}

--- a/provider/cluster/util/util.go
+++ b/provider/cluster/util/util.go
@@ -39,3 +39,14 @@ func ComputeCommittedResources(factor float64, rv atypes.ResourceValue) atypes.R
 
 	return result
 }
+
+func AllHostnamesOfManifestGroup(mgroup manifest.Group) []string {
+	allHostnames := make([]string, 0)
+	for _, service := range mgroup.Services {
+		for _, expose := range service.Expose {
+			allHostnames = append(allHostnames, expose.Hosts...)
+		}
+	}
+
+	return allHostnames
+}

--- a/provider/config.go
+++ b/provider/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	CPUCommitLevel                  float64
 	MemoryCommitLevel               float64
 	StorageCommitLevel              float64
+	BlockedHostnames                []string
+	DeploymentIngressStaticHosts    bool
 }
 
 func NewDefaultConfig() Config {

--- a/provider/manifest/config.go
+++ b/provider/manifest/config.go
@@ -1,7 +1,5 @@
 package manifest
 
-import "time"
-
-type config struct {
-	ManifestLingerDuration time.Duration `env:"AKASH_MANIFEST_LINGER_DURATION" envDefault:"5m"`
+type ServiceConfig struct {
+	HTTPServicesRequireAtLeastOneHost bool
 }

--- a/provider/service.go
+++ b/provider/service.go
@@ -53,6 +53,7 @@ func NewService(ctx context.Context, session session.Session, bus pubsub.Bus, cc
 	clusterConfig.CPUCommitLevel = cfg.CPUCommitLevel
 	clusterConfig.MemoryCommitLevel = cfg.MemoryCommitLevel
 	clusterConfig.StorageCommitLevel = cfg.StorageCommitLevel
+	clusterConfig.BlockedHostnames = cfg.BlockedHostnames
 
 	cluster, err := cluster.NewService(ctx, session, bus, cclient, clusterConfig)
 	if err != nil {
@@ -78,7 +79,11 @@ func NewService(ctx context.Context, session session.Session, bus pubsub.Bus, cc
 		return nil, errors.Wrap(err, errmsg)
 	}
 
-	manifest, err := manifest.NewService(ctx, session, bus)
+	manifestConfig := manifest.ServiceConfig{
+		HTTPServicesRequireAtLeastOneHost: cfg.DeploymentIngressStaticHosts,
+	}
+
+	manifest, err := manifest.NewService(ctx, session, bus, cluster.HostnameService(), manifestConfig)
 	if err != nil {
 		session.Log().Error("creating manifest handler", "err", err)
 		cancel()

--- a/x/deployment/testdata/deployment-v2-newcontainer.yaml
+++ b/x/deployment/testdata/deployment-v2-newcontainer.yaml
@@ -1,0 +1,36 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app-2
+    expose:
+      - port: 80
+        to:
+          - global: true
+        accept:
+          - test.localhost
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "512Mi"
+
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1

--- a/x/deployment/testdata/deployment-v2-nohost.yaml
+++ b/x/deployment/testdata/deployment-v2-nohost.yaml
@@ -1,0 +1,34 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app
+    expose:
+      - port: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "512Mi"
+
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1

--- a/x/deployment/testdata/deployment-v2-updateA.yaml
+++ b/x/deployment/testdata/deployment-v2-updateA.yaml
@@ -1,0 +1,36 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app
+    expose:
+      - port: 80
+        to:
+          - global: true
+        accept:
+          - testupdatea.localhost
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "512Mi"
+
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1

--- a/x/deployment/testdata/deployment-v2-updateB.yaml
+++ b/x/deployment/testdata/deployment-v2-updateB.yaml
@@ -1,0 +1,37 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app
+    expose:
+      - port: 80
+        to:
+          - global: true
+        accept:
+          - testupdatea.localhost
+          - testupdateb.localhost
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "512Mi"
+
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1


### PR DESCRIPTION
In this pull request I did the following

1. If "DeploymentIngressStaticHosts" is set, we require all deployment groups to have at least on hostname specified
if they are going to be used for HTTP via a Kubernetes Ingress. No restrictions are added to node port stuff.
2. Checked to see if hostnames are in use before accepting a manifest. If it is in use, reject the manifest
3. Add an option to block a hostname or domains. Hostnames can be specified by using a string like "bobsdefi.com". An entire
domain can be blocked by using a string like ".bobsdefi.com". This is specified a string slice in the code, and the command line option
can be given multiple times to add multiple entries.

Implementation notes:

1. I added something as part of `provider/cluster` that I am calling the hostname service. The inventory service is used when
determining to bid on a lease, so I opted not to make this part of the inventory service. This new services just tracks
the hostnames in use, as well as checking to see if a hostname is blocked by the provider. When a hostname is "in use" it is associated with a given deployment ID. This means that later deployment updates can expand the use of hostnames without having to pick an entirely new set.
2. The deployment manager reserves & releases hostnames whenever it starts up and stops a deployment.
3. The manifest service checks hostnames availability before accepting a manifest.
4. I had to add a list of known leases & group names to the manifest service, so it can check the correct deployment groups hostnames.
5. The manifest service is responsible for determining if we should accept or reject a manifest. As a result I did some strange
stuff to avoid it blocking on a single manifest while validating the hostnames are available. It's spinning up a new goroutine
to wait on an answer from the hostname service.
6. I nuked some lingering usage of `env.Parse` for configuration, I don't think we were setting that environment variable anyways

On point #5, if we push out the responsiblity of accepting or rejecting a manifest into the manifest manager it might make
some of the code simpler. But at present we onlt start the manifest manager if the manifest is valid. I didn't want to change that at this time.

Test notes:
 I added and E2E test that updates an existing deployment with additional hostnames.