### PR TITLE
fix(lint): Disable network when running the linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ GRPC_GATEWAY                   := $(CACHE_BIN)/protoc-gen-grpc-gateway
 DOCKER_RUN            := docker run --rm -v $(shell pwd):/workspace -w /workspace
 DOCKER_BUF            := $(DOCKER_RUN) bufbuild/buf:$(BUF_VERSION)
 DOCKER_CLANG          := $(DOCKER_RUN) tendermintdev/docker-build-proto
-GOLANGCI_LINT          = $(DOCKER_RUN) golangci/golangci-lint:$(GOLANGCI_LINT_VERSION)-alpine golangci-lint run
+GOLANGCI_LINT          = $(DOCKER_RUN) --network none golangci/golangci-lint:$(GOLANGCI_LINT_VERSION)-alpine golangci-lint run
 LINT                   = $(GOLANGCI_LINT) ./... --disable-all --deadline=5m --enable
 TEST_DOCKER_REPO      := jackzampolin/akashtest
 


### PR DESCRIPTION
For some reason when running commands like `make test-sublinters` it is equivalent to unplugging & plugging in the network cable on the host each time docker is run.

This disables the network access for the linters run in docker, which don't need it anyways.