### PR TITLE
fix(examples): The amount in gentx is no longer a command line switch

### DIFF
--- a/_run/common.mk
+++ b/_run/common.mk
@@ -62,7 +62,7 @@ node-init-genesis-account-%:
 .PHONY: node-init-gentx
 node-init-gentx:
 	$(AKASHD) $(KEY_OPTS) gentx validator \
-		--amount "$(CHAIN_MIN_DEPOSIT)$(CHAIN_TOKEN_DENOM)" \
+		"$(CHAIN_MIN_DEPOSIT)$(CHAIN_TOKEN_DENOM)" \
 		$(CHAIN_OPTS)
 
 .PHONY: node-init-finalize


### PR DESCRIPTION
The `_run/kube` examples and similar are broken.

It looks like the `gentx` command no longer actually wants the `--amount` flag, despite it being listed as a flag. When you specify it as a command line argument instead of a flag it works.