### PR TITLE
fix(sdl): Reject decimal coin values

### DIFF
--- a/sdl/coin_test.go
+++ b/sdl/coin_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestPricing(t *testing.T) {
-	t.Skip("https://github.com/ovrclk/akash/issues/1027")
 	tests := []struct {
 		text  string
 		value sdk.Coin
@@ -18,6 +17,7 @@ func TestPricing(t *testing.T) {
 		{"amount: 1\ndenom: uakt", sdk.NewCoin("uakt", sdk.NewInt(1)), false},
 		{"amount: -1\ndenom: uakt", sdk.NewCoin("uakt", sdk.NewInt(1)), true},
 		{"amount: 0.7\ndenom: uakt", sdk.NewCoin("uakt", sdk.NewInt(0)), true},
+		{"amount: -0.7\ndenom: uakt", sdk.NewCoin("uakt", sdk.NewInt(0)), true},
 	}
 
 	for idx, test := range tests {


### PR DESCRIPTION
Apparently all the Cosmos coin parsing code just truncates any decimal values.

I just changed our parsing code to check for a fractional value beforehand and reject it at that point.