### PR TITLE
feat(docs): Add executable for generating Markdown documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # binaries
 /akash
+/akash_docgen
 
 # dev artifacts
 /devdata

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINS                  := akash
+BINS                  := akash akash_docgen
 APP_DIR               := ./app
 
 GO                    := GO111MODULE=on go

--- a/docgen/main.go
+++ b/docgen/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	root "github.com/ovrclk/akash/cmd/akash/cmd"
+	"github.com/spf13/cobra/doc"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprint(os.Stderr, "Usage is:\n\takash_docgen <output path>\n")
+		os.Exit(1)
+	}
+	outputPath := os.Args[1]
+	cmd, _ := root.NewRootCmd()
+	err := doc.GenMarkdownTree(cmd, outputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed generating markdown into %q:%v\n", outputPath, err)
+		os.Exit(1)
+	}
+}

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -11,6 +11,10 @@ build:
 akash:
 	$(GO) build $(BUILD_FLAGS) ./cmd/akash
 
+.PHONY: akash_docgen
+akash_docgen:
+	$(GO) build -o akash_docgen $(BUILD_FLAGS) ./docgen
+
 .PHONY: install
 install:
 	$(GO) install $(BUILD_FLAGS) ./cmd/akash


### PR DESCRIPTION
This adds an executable that dumps the markdown documentation for the `akash` command into whatever destination pass on the command line.