### PR TITLE
ci(release): use GOLANG_VERSION to configure GOLANG_CROSS_VERSION

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ on:
       - v*
 
 env:
-  GOLANG_CROSS_VERSION: "v${{ secrets.GOLANG_VERSION }}"
+  GOLANG_VERSION: "v${{ secrets.GOLANG_VERSION }}"
 
 jobs:
   goreleaser:


### PR DESCRIPTION
GOLANG_CROSS_VERSION is immutable in makefile

Signed-off-by: Artur Troian <troian.ap@gmail.com>