### PR TITLE
ci(go): remove v prefix from go version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ on:
       - v*
 
 env:
-  GOLANG_VERSION: "v${{ secrets.GOLANG_VERSION }}"
+  GOLANG_VERSION: "${{ secrets.GOLANG_VERSION }}"
 
 jobs:
   goreleaser:


### PR DESCRIPTION
Signed-off-by: Artur Troian <troian.ap@gmail.com>
