### PR TITLE
fix(deploy tool): Do not crash on unknown events

### DIFF
--- a/deploy/cmd/event-handlers.go
+++ b/deploy/cmd/event-handlers.go
@@ -170,9 +170,10 @@ func DeploymentDataUpdateHandler(dd *DeploymentData, bids chan<- mtypes.EventBid
 			}
 			return
 
-		// In any other case we should exit with error
+		// Ignore any other event
 		default:
-			return fmt.Errorf("%w: %T", errUnexpectedEvent, ev)
+			log.Debug("Ignoring event")
+			return
 		}
 	}
 }


### PR DESCRIPTION
Just skip an unknown event, it should be no problem at all.