### PR TITLE
fix(provider): not showing all events

### DIFF
--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -241,7 +241,7 @@ func newEventsFeedWatch(ctx context.Context, events watch.Interface) ctypes.Even
 	wtch := ctypes.NewEventsFeed(ctx)
 
 	go func() {
-		func() {
+		defer func() {
 			events.Stop()
 			wtch.Shutdown()
 		}()

--- a/provider/cluster/types/types.go
+++ b/provider/cluster/types/types.go
@@ -88,6 +88,7 @@ type LeaseEvent struct {
 	ReportingInstance   string           `json:"reportingInstance,omitempty" yaml:"reportingInstance"`
 	Time                time.Time        `json:"time" yaml:"time"`
 	Reason              string           `json:"reason" yaml:"reason"`
+	Note                string           `json:"note" yaml:"note"`
 	Object              LeaseEventObject `json:"object" yaml:"object"`
 }
 


### PR DESCRIPTION
fixes #1124

add missed defer statement
add Note field describing event details

Signed-off-by: Artur Troian <troian.ap@gmail.com>

**tested with SDL**
```yaml
---
version: "2.0"

services:
  web:
    image: polinux/stress
    command:
      - "stress"
    args:
      - "--vm"
      - "1"
      - "--vm-bytes"
      - "250M"
      - "--vm-hang"
      - "1"
    expose:
      - port: 80
        as: 80
        accept:
          - hello.localhost
        to:
          - global: true

profiles:
  compute:
    web:
      resources:
        cpu:
          units: 0.1
        memory:
          size: 100Mi
        storage:
          size: 128Mi
  placement:
    westcoast:
      attributes:
        region: us-west
      pricing:
        web:
          denom: uakt
          amount: 1000

deployment:
  web:
    westcoast:
      profile: web
      count: 1
```

**output example**
```json
{
  "type": "Warning",
  "time": "0001-01-01T00:00:00Z",
  "reason": "Failed",
  "note": "Error: failed to create containerd task: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: \"--vm\": executable file not found in $PATH: unknown",
  "object": {
    "kind": "Pod",
    "namespace": "2es4iipof1s9s35h3civuou110db77kqjhj6n01gll7qm",
    "name": "web-7946fd4df-d69q2"
  }
}
```
