### PR TITLE
fix(cli): set out/err streams to be stdout/stderr respectively

### DIFF
--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -138,6 +138,9 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		debug.Cmd(),
 	)
 
+	rootCmd.SetOut(rootCmd.OutOrStdout())
+	rootCmd.SetErr(rootCmd.ErrOrStderr())
+
 	server.AddCommands(rootCmd, app.DefaultHome, newApp, createAppAndExport, addModuleInitFlags)
 }
 


### PR DESCRIPTION
fixes #1150
fixing issue when status command prints output to stderr

Signed-off-by: Artur Troian <troian.ap@gmail.com>

