### PR TITLE
fix: parse CLI flags for all commands

### DIFF
--- a/x/audit/client/cli/query.go
+++ b/x/audit/client/cli/query.go
@@ -15,7 +15,6 @@ func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Audit query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/audit/client/cli/tx.go
+++ b/x/audit/client/cli/tx.go
@@ -20,7 +20,6 @@ func GetTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Audit transaction subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/cert/client/cli/query.go
+++ b/x/cert/client/cli/query.go
@@ -17,7 +17,6 @@ func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Certificate query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/cert/client/cli/tx.go
+++ b/x/cert/client/cli/tx.go
@@ -48,7 +48,6 @@ func GetTxCmd() *cobra.Command {
 		Use:                        types.ModuleName,
 		Short:                      "Certificates transaction subcommands",
 		SuggestionsMinimumDistance: 2,
-		DisableFlagParsing:         true,
 		RunE:                       sdkclient.ValidateCmd,
 	}
 
@@ -65,7 +64,6 @@ func cmdCreate() *cobra.Command {
 		Use:                        "create",
 		Short:                      "create/update api certificates",
 		SuggestionsMinimumDistance: 2,
-		DisableFlagParsing:         true,
 		RunE:                       sdkclient.ValidateCmd,
 	}
 

--- a/x/deployment/client/cli/query.go
+++ b/x/deployment/client/cli/query.go
@@ -15,7 +15,6 @@ func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Deployment query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -111,7 +110,6 @@ func getGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "group",
 		Short:                      "Deployment group query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -23,7 +23,6 @@ func GetTxCmd(key string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Deployment transaction subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/market/client/cli/query.go
+++ b/x/market/client/cli/query.go
@@ -12,7 +12,6 @@ func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Market query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -30,7 +29,6 @@ func getOrderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "order",
 		Short:                      "Order query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -47,7 +45,6 @@ func getBidCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "bid",
 		Short:                      "Bid query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -64,7 +61,6 @@ func getLeaseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "lease",
 		Short:                      "Lease query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -17,7 +17,6 @@ func GetTxCmd(key string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Transaction subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -32,7 +31,6 @@ func cmdBid(key string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "bid",
 		Short:                      "Bid subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -135,7 +133,6 @@ func cmdLease(key string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "lease",
 		Short:                      "Lease subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/provider/client/cli/query.go
+++ b/x/provider/client/cli/query.go
@@ -15,7 +15,6 @@ func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Provider query commands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/provider/client/cli/tx.go
+++ b/x/provider/client/cli/tx.go
@@ -17,7 +17,6 @@ func GetTxCmd(key string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Provider transaction subcommands",
-		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}


### PR DESCRIPTION
I don't know why we had this turned off, but I did a smoke test and it fixed the issue for me where it was trying to parse the home directory that is stored at `~/.akash`. I don't see any reason to have this disabled.