### PR TITLE
fix(provider): only bid on deployments that attributes have been audited

### DIFF
--- a/events/publish.go
+++ b/events/publish.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	atypes "github.com/ovrclk/akash/x/audit/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ovrclk/akash/pubsub"
@@ -108,6 +109,10 @@ func processEvent(bev abci.Event) (interface{}, bool) {
 	}
 
 	if mev, err := ptypes.ParseEvent(ev); err == nil {
+		return mev, true
+	}
+
+	if mev, err := atypes.ParseEvent(ev); err == nil {
 		return mev, true
 	}
 

--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -3,6 +3,7 @@ package bidengine
 import (
 	"context"
 	"fmt"
+	atypes "github.com/ovrclk/akash/x/audit/types"
 	"regexp"
 
 	lifecycle "github.com/boz/go-lifecycle"
@@ -30,14 +31,15 @@ type order struct {
 	sub                        pubsub.Subscriber
 	reservationFulfilledNotify chan<- int
 
-	log log.Logger
-	lc  lifecycle.Lifecycle
+	log  log.Logger
+	lc   lifecycle.Lifecycle
+	pass ProviderAttrSignatureService
 }
 
-func newOrder(svc *service, oid mtypes.OrderID, cfg Config, checkForExistingBid bool) (*order, error) {
-	return newOrderInternal(svc, oid, cfg, checkForExistingBid, nil)
+func newOrder(svc *service, oid mtypes.OrderID, cfg Config, pass ProviderAttrSignatureService, checkForExistingBid bool) (*order, error) {
+	return newOrderInternal(svc, oid, cfg, pass, checkForExistingBid, nil)
 }
-func newOrderInternal(svc *service, oid mtypes.OrderID, cfg Config, checkForExistingBid bool, reservationFulfilledNotify chan<- int) (*order, error) {
+func newOrderInternal(svc *service, oid mtypes.OrderID, cfg Config, pass ProviderAttrSignatureService, checkForExistingBid bool, reservationFulfilledNotify chan<- int) (*order, error) {
 	// Create a subscription that will see all events that have not been read from e.sub.Events()
 	sub, err := svc.sub.Clone()
 	if err != nil {
@@ -59,6 +61,7 @@ func newOrderInternal(svc *service, oid mtypes.OrderID, cfg Config, checkForExis
 		log:                        log,
 		lc:                         lifecycle.New(),
 		reservationFulfilledNotify: reservationFulfilledNotify, // Normally nil in production
+		pass:                       pass,
 	}
 
 	// Shut down when parent begins shutting down
@@ -90,6 +93,7 @@ func (o *order) run(checkForExistingBid bool) {
 		bidch         <-chan runner.Result
 		pricech       <-chan runner.Result
 		queryBidCh    <-chan runner.Result
+		shouldBidCh   <-chan runner.Result
 
 		group       *dtypes.Group
 		reservation ctypes.Reservation
@@ -198,7 +202,21 @@ loop:
 			res := result.Value().(dtypes.Group)
 			group = &res
 
-			if !o.shouldBid(group) {
+			shouldBidCh = runner.Do(func() runner.Result {
+				return runner.NewResult(o.shouldBid(group))
+			})
+
+		case result := <-shouldBidCh:
+			shouldBidCh = nil
+
+			if result.Error() != nil {
+				o.log.Error("failure during checking should bid", "err", result.Error())
+				break loop
+			}
+
+			shouldBid := result.Value().(bool)
+			if !shouldBid {
+				o.log.Debug("declined to bid")
 				break loop
 			}
 
@@ -316,20 +334,53 @@ loop:
 	}
 }
 
-func (o *order) shouldBid(group *dtypes.Group) bool {
+func (o *order) shouldBid(group *dtypes.Group) (bool, error) {
 
 	// does provider have required attributes?
-	// fixme - MatchAttributes does not check for signed attributes
-	// it is done during processing of MsgCreateBid
 	if !group.GroupSpec.MatchAttributes(o.session.Provider().Attributes) {
 		o.log.Debug("unable to fulfill: incompatible attributes")
-		return false
+		return false, nil
+	}
+
+	signatureRequirements := group.GroupSpec.Requirements.SignedBy
+	if signatureRequirements.Size() != 0 {
+		// Check that the signature requirements are met for each attribute
+		var provAttr []atypes.Provider
+		ownAttrs := atypes.Provider{
+			Owner:      o.session.Provider().Owner,
+			Auditor:    "",
+			Attributes: o.session.Provider().Attributes,
+		}
+		provAttr = append(provAttr, ownAttrs)
+		auditors := make([]string, 0)
+		auditors = append(auditors, group.GroupSpec.Requirements.SignedBy.AllOf...)
+		auditors = append(auditors, group.GroupSpec.Requirements.SignedBy.AnyOf...)
+
+		gotten := make(map[string]struct{})
+		for _, auditor := range auditors {
+			_, done := gotten[auditor]
+			if done {
+				continue
+			}
+			result, err := o.pass.GetAuditorAttributeSignatures(auditor)
+			if err != nil {
+				return false, err
+			}
+			provAttr = append(provAttr, result...)
+			gotten[auditor] = struct{}{}
+		}
+
+		ok := group.GroupSpec.MatchRequirements(provAttr)
+		if !ok {
+			o.log.Debug("attribute signature requirements not met")
+			return false, nil
+		}
 	}
 
 	if err := group.GroupSpec.ValidateBasic(); err != nil {
 		o.log.Error("unable to fulfill: group validation error",
 			"err", err)
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }

--- a/provider/bidengine/order_test.go
+++ b/provider/bidengine/order_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ovrclk/akash/pubsub"
 	"github.com/ovrclk/akash/testutil"
 	atypes "github.com/ovrclk/akash/types"
+	audittypes "github.com/ovrclk/akash/x/audit/types"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	mtypes "github.com/ovrclk/akash/x/market/types"
 	ptypes "github.com/ovrclk/akash/x/provider/types"
@@ -106,6 +107,12 @@ func makeMocks(s *orderTestScaffold) {
 
 }
 
+type nullProviderAttrSignatureService struct{}
+
+func (nullProviderAttrSignatureService) GetAuditorAttributeSignatures(auditor string) ([]audittypes.Provider, error) {
+	return nil, nil // Return no attributes & no error
+}
+
 func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricingStrategy) (*order, orderTestScaffold, <-chan int) {
 	if pricing == nil {
 		var err error
@@ -163,7 +170,7 @@ func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricing
 	}
 
 	reservationFulfilledNotify := make(chan int, 1)
-	order, err := newOrderInternal(serviceCast, scaffold.orderID, cfg, checkForExistingBid, reservationFulfilledNotify)
+	order, err := newOrderInternal(serviceCast, scaffold.orderID, cfg, nullProviderAttrSignatureService{}, checkForExistingBid, reservationFulfilledNotify)
 
 	require.NoError(t, err)
 	require.NotNil(t, order)

--- a/provider/bidengine/provider_attributes.go
+++ b/provider/bidengine/provider_attributes.go
@@ -1,0 +1,287 @@
+package bidengine
+
+import (
+	"context"
+	"errors"
+	"github.com/boz/go-lifecycle"
+	"github.com/ovrclk/akash/provider/session"
+	"github.com/ovrclk/akash/pubsub"
+	atypes "github.com/ovrclk/akash/x/audit/types"
+	"regexp"
+	"sync"
+	"time"
+)
+
+type ProviderAttrSignatureService interface {
+	GetAuditorAttributeSignatures(auditor string) ([]atypes.Provider, error)
+}
+
+type providerAttrSignatureService struct {
+	providerAddr string
+	lc           lifecycle.Lifecycle
+	requests     chan providerAttrRequest
+
+	session session.Session
+	fetchCh chan providerAttrResult
+
+	data       map[string]providerAttrEntry
+	inProgress map[string]struct{}
+	pending    map[string][]providerAttrRequest
+
+	wg sync.WaitGroup
+
+	sub pubsub.Subscriber
+
+	ttl time.Duration
+}
+
+func newProviderAttrSignatureService(s session.Session, bus pubsub.Bus) (*providerAttrSignatureService, error) {
+	return newProviderAttrSignatureServiceInternal(s, bus, 18*time.Hour)
+}
+
+func newProviderAttrSignatureServiceInternal(s session.Session, bus pubsub.Bus, ttl time.Duration) (*providerAttrSignatureService, error) {
+	subscriber, err := bus.Subscribe()
+	if err != nil {
+		return nil, err
+	}
+	retval := &providerAttrSignatureService{
+		providerAddr: s.Provider().Owner,
+		lc:           lifecycle.New(),
+		session:      s,
+		requests:     make(chan providerAttrRequest),
+		fetchCh:      make(chan providerAttrResult),
+		data:         make(map[string]providerAttrEntry),
+		pending:      make(map[string][]providerAttrRequest),
+		inProgress:   make(map[string]struct{}),
+		sub:          subscriber,
+		ttl:          ttl,
+	}
+
+	go retval.run()
+
+	return retval, nil
+}
+
+func (pass *providerAttrSignatureService) run() {
+	defer pass.sub.Close()
+	defer pass.lc.ShutdownCompleted()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+loop:
+	for {
+		select {
+		case ev := <-pass.sub.Events():
+			pass.handleEvent(ev)
+		case <-pass.lc.ShutdownRequest():
+			pass.lc.ShutdownInitiated(nil)
+			break loop
+		case request := <-pass.requests:
+			start := pass.addRequest(request)
+			if start {
+				pass.maybeStart(ctx, request.auditor)
+			}
+		case result := <-pass.fetchCh:
+			if result.err != nil {
+				pass.failAllPending(result.auditor, result.err)
+			} else {
+				pass.completeAllPending(result.auditor, result.providerAttr)
+			}
+			delete(pass.pending, result.auditor)
+		}
+	}
+
+	cancel()
+	pass.wg.Wait()
+}
+
+func (pass *providerAttrSignatureService) purgeAuditor(auditor string) {
+	delete(pass.data, auditor)
+}
+
+func (pass *providerAttrSignatureService) handleEvent(ev pubsub.Event) {
+	switch ev := ev.(type) {
+	case atypes.EventTrustedAuditorCreated:
+		if ev.Owner.String() == pass.providerAddr {
+			pass.purgeAuditor(ev.Auditor.String())
+		}
+	case atypes.EventTrustedAuditorDeleted:
+		if ev.Owner.String() == pass.providerAddr {
+			pass.purgeAuditor(ev.Auditor.String())
+		}
+	default:
+		// Ignore the event, we don't need it
+	}
+}
+
+func (pass *providerAttrSignatureService) failAllPending(auditor string, err error) {
+	pendingForAuditor := pass.pending[auditor]
+	for _, req := range pendingForAuditor {
+		req.errCh <- err
+	}
+	delete(pass.pending, auditor)
+}
+
+func (pass *providerAttrSignatureService) completeAllPending(auditor string, result []atypes.Provider) {
+	pendingForAuditor := pass.pending[auditor]
+	delete(pass.pending, auditor)
+
+	// Store in cache for later usage
+	pass.data[auditor] = providerAttrEntry{
+		providerAttr: result,
+		at:           time.Now(),
+	}
+
+	// Fill all requests
+	for _, req := range pendingForAuditor {
+		req.successCh <- result
+	}
+
+	pass.trimCache()
+}
+
+func providerAttrSize(entries []atypes.Provider) int {
+	size := 0
+	for _, x := range entries {
+		size += len(x.Attributes)
+	}
+	return size
+}
+
+func (pass *providerAttrSignatureService) trimCache() {
+	const maxEntries = 50000
+
+	toDelete := make([]string, 0, 4)
+	now := time.Now()
+	size := 0
+	for auditor, entry := range pass.data {
+		elapsed := now.Sub(entry.at)
+		expired := elapsed > pass.ttl
+		if expired {
+			toDelete = append(toDelete, auditor)
+		} else {
+			size += providerAttrSize(entry.providerAttr)
+		}
+	}
+
+	// Remove expired entries
+	for _, auditor := range toDelete {
+		delete(pass.data, auditor)
+	}
+	toDelete = nil
+
+	// Check if size is larger than what is wanted
+	if size > maxEntries {
+		pass.session.Log().Info("provider attr. cache size too large, pruning", "size", size)
+	} else {
+		return
+	}
+
+	// Remove approx. half of the stored values
+	const target = maxEntries / 2
+	size = 0
+	// Map iteration order in golang is random
+	for auditor, entry := range pass.data {
+		size += providerAttrSize(entry.providerAttr)
+		toDelete = append(toDelete, auditor)
+		if size >= target {
+			break
+		}
+	}
+
+	// Delete entries to get the size back down
+	for _, auditor := range toDelete {
+		delete(pass.data, auditor)
+	}
+}
+
+func (pass *providerAttrSignatureService) maybeStart(ctx context.Context, auditor string) {
+	// Check that request exists
+	if pendingForAuditor := pass.pending[auditor]; len(pendingForAuditor) == 0 {
+		return
+	}
+	// Check that request is not in flight
+	_, exists := pass.inProgress[auditor]
+	if exists {
+		return
+	}
+
+	pass.wg.Add(1)
+	go func() {
+		defer pass.wg.Done()
+		pass.fetchCh <- pass.fetch(ctx, auditor)
+	}()
+}
+
+var invalidProviderPattern = regexp.MustCompile("^.*invalid provider: address not found.*$")
+
+func (pass *providerAttrSignatureService) fetch(ctx context.Context, auditor string) providerAttrResult {
+	req := &atypes.QueryProviderAuditorRequest{
+		Owner:   pass.providerAddr,
+		Auditor: auditor,
+	}
+
+	pass.session.Log().Info("fetching provider auditor attributes", "auditor", req.Auditor, "provider", req.Owner)
+	result, err := pass.session.Client().Query().ProviderAuditorAttributes(ctx, req)
+	if err != nil {
+		// Error type is always "errors.fundamental" so use pattern matching here
+		if invalidProviderPattern.MatchString(err.Error()) {
+			return providerAttrResult{auditor: auditor} // No data
+		}
+		return providerAttrResult{auditor: auditor, err: err}
+	}
+
+	value := result.GetProviders()
+	pass.session.Log().Info("got auditor attributes", "auditor", auditor, "size", providerAttrSize(value))
+
+	return providerAttrResult{
+		auditor:      auditor,
+		providerAttr: value,
+	}
+}
+
+func (pass *providerAttrSignatureService) addRequest(request providerAttrRequest) bool {
+	entry, present := pass.data[request.auditor]
+
+	if present { // Cached value is present
+		elapsed := time.Since(entry.at) // Check if it is too old
+		if elapsed < pass.ttl {
+			request.successCh <- entry.providerAttr
+			pass.session.Log().Debug("reused auditor attributes", "auditor", request.auditor, "elapsed", elapsed)
+			return false
+		}
+	}
+
+	pendingList := pass.pending[request.auditor]
+	pendingList = append(pendingList, request)
+	pass.pending[request.auditor] = pendingList
+
+	return true
+}
+
+var errShuttingDown = errors.New("provider attribute signature service is shutting down")
+
+func (pass *providerAttrSignatureService) GetAuditorAttributeSignatures(auditor string) ([]atypes.Provider, error) {
+	successCh := make(chan []atypes.Provider, 1)
+	errCh := make(chan error, 1)
+	req := providerAttrRequest{
+		auditor:   auditor,
+		successCh: successCh,
+		errCh:     errCh,
+	}
+
+	select {
+	case pass.requests <- req:
+	case <-pass.lc.ShuttingDown():
+		return nil, errShuttingDown
+	}
+
+	select {
+	case <-pass.lc.ShuttingDown():
+		return nil, errShuttingDown
+	case err := <-errCh:
+		return nil, err
+	case result := <-successCh:
+		return result, nil
+	}
+}

--- a/provider/bidengine/provider_attributes_test.go
+++ b/provider/bidengine/provider_attributes_test.go
@@ -1,0 +1,296 @@
+package bidengine
+
+import (
+	"errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	clientmocks "github.com/ovrclk/akash/client/mocks"
+	"github.com/ovrclk/akash/provider/session"
+	"github.com/ovrclk/akash/pubsub"
+	"github.com/ovrclk/akash/testutil"
+	akashtypes "github.com/ovrclk/akash/types"
+	atypes "github.com/ovrclk/akash/x/audit/types"
+	ptypes "github.com/ovrclk/akash/x/provider/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+type providerAttributesTestScaffold struct {
+	service      *providerAttrSignatureService
+	provider     *ptypes.Provider
+	s            session.Session
+	bus          pubsub.Bus
+	client       *clientmocks.Client
+	queryClient  *clientmocks.QueryClient
+	auditorAddr  sdk.AccAddress
+	providerAddr sdk.AccAddress
+}
+
+func setupProviderAttributesTestScaffold(t *testing.T, ttl time.Duration, clientFactory func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient) *providerAttributesTestScaffold {
+	retval := &providerAttributesTestScaffold{
+		auditorAddr:  testutil.AccAddress(t),
+		providerAddr: testutil.AccAddress(t),
+	}
+	retval.provider = &ptypes.Provider{
+		Owner:      retval.providerAddr.String(),
+		HostURI:    "http://foo.localhost:8443",
+		Attributes: nil,
+		Info:       ptypes.ProviderInfo{},
+	}
+
+	retval.client = &clientmocks.Client{}
+
+	retval.queryClient = clientFactory(retval)
+	retval.client.On("Query").Return(retval.queryClient)
+	retval.s = session.New(testutil.Logger(t), retval.client, retval.provider)
+	retval.bus = pubsub.NewBus()
+	var err error
+	retval.service, err = newProviderAttrSignatureServiceInternal(retval.s, retval.bus, ttl)
+	require.NoError(t, err)
+
+	return retval
+}
+
+func (scaffold *providerAttributesTestScaffold) stop(t *testing.T) {
+	scaffold.service.lc.Shutdown(nil)
+
+	select {
+	case <-scaffold.service.lc.Done():
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for service to stop")
+	}
+	scaffold.bus.Close()
+}
+
+var errWithExpectedText = errors.New("invalid provider: address not found")
+
+func TestProvAttrCachesValue(t *testing.T) {
+	scaffold := setupProviderAttributesTestScaffold(t, 1*time.Hour, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		req := &atypes.QueryProviderAuditorRequest{
+			Owner:   scaffold.providerAddr.String(),
+			Auditor: scaffold.auditorAddr.String(),
+		}
+		queryClient := &clientmocks.QueryClient{}
+		response := &atypes.QueryProvidersResponse{
+			Providers: atypes.Providers{
+				atypes.Provider{
+					Owner: scaffold.providerAddr.String(),
+					Attributes: akashtypes.Attributes{
+						akashtypes.Attribute{
+							Key:   "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			Pagination: nil,
+		}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, req).Return(response, nil)
+
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	attrs, err = scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	scaffold.stop(t)
+
+	// Should have just 1 call
+	require.Len(t, scaffold.queryClient.Calls, 1)
+}
+
+func TestProvAttrReturnsEmpty(t *testing.T) {
+	scaffold := setupProviderAttributesTestScaffold(t, 1*time.Hour, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		req := &atypes.QueryProviderAuditorRequest{
+			Owner:   scaffold.providerAddr.String(),
+			Auditor: scaffold.auditorAddr.String(),
+		}
+		queryClient := &clientmocks.QueryClient{}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, req).Return(nil, errWithExpectedText)
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 0) // Nothing is returned
+
+	scaffold.stop(t)
+
+	// Should have just 1 call
+	require.Len(t, scaffold.queryClient.Calls, 1)
+}
+
+func TestProvAttrObeysTTL(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	scaffold := setupProviderAttributesTestScaffold(t, ttl, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		req := &atypes.QueryProviderAuditorRequest{
+			Owner:   scaffold.providerAddr.String(),
+			Auditor: scaffold.auditorAddr.String(),
+		}
+		queryClient := &clientmocks.QueryClient{}
+		response := &atypes.QueryProvidersResponse{
+			Providers: atypes.Providers{
+				atypes.Provider{
+					Owner: scaffold.providerAddr.String(),
+					Attributes: akashtypes.Attributes{
+						akashtypes.Attribute{
+							Key:   "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			Pagination: nil,
+		}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, req).Return(response, nil)
+
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	time.Sleep(2 * ttl)
+
+	attrs, err = scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	scaffold.stop(t)
+
+	// Should have just 1 call
+	require.Len(t, scaffold.queryClient.Calls, 2)
+}
+
+func TestProvAttrTrimsCache(t *testing.T) {
+	const ttl = 1 * time.Hour
+	scaffold := setupProviderAttributesTestScaffold(t, ttl, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		queryClient := &clientmocks.QueryClient{}
+		attrs := make([]akashtypes.Attribute, 1001)
+		for i := range attrs {
+			attrs[i] = akashtypes.Attribute{
+				Key:   "foo",
+				Value: "bar",
+			}
+		}
+		response := &atypes.QueryProvidersResponse{
+			Providers: atypes.Providers{
+				atypes.Provider{
+					Owner:      scaffold.providerAddr.String(),
+					Attributes: attrs,
+				},
+			},
+			Pagination: nil,
+		}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, mock.Anything).Return(response, nil)
+
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.NotNil(t, attrs)
+
+	addrs := make([]sdk.AccAddress, 1)
+	for i := 0; i != 51; i++ {
+		addr := testutil.AccAddress(t)
+		addrs = append(addrs, addr)
+		attrs, err := scaffold.service.GetAuditorAttributeSignatures(addr.String())
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+	}
+
+	for _, addr := range addrs {
+		attrs, err := scaffold.service.GetAuditorAttributeSignatures(addr.String())
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+	}
+
+	scaffold.stop(t)
+
+	// Should have more calls then addresses, since things get pushed out of the cache
+	require.Greater(t, len(scaffold.queryClient.Calls), len(addrs))
+}
+
+var errForTest = errors.New("an error used only for test")
+
+func TestProvAttrReturnsErrors(t *testing.T) {
+	const ttl = 1 * time.Hour
+	scaffold := setupProviderAttributesTestScaffold(t, ttl, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		queryClient := &clientmocks.QueryClient{}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, mock.Anything).Return(nil, errForTest)
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.ErrorIs(t, err, errForTest)
+	require.Nil(t, attrs)
+
+	scaffold.stop(t)
+}
+
+func TestProvAttrClearsCache(t *testing.T) {
+	const ttl = 1 * time.Hour
+	scaffold := setupProviderAttributesTestScaffold(t, ttl, func(scaffold *providerAttributesTestScaffold) *clientmocks.QueryClient {
+		req := &atypes.QueryProviderAuditorRequest{
+			Owner:   scaffold.providerAddr.String(),
+			Auditor: scaffold.auditorAddr.String(),
+		}
+		queryClient := &clientmocks.QueryClient{}
+		response := &atypes.QueryProvidersResponse{
+			Providers: atypes.Providers{
+				atypes.Provider{
+					Owner: scaffold.providerAddr.String(),
+					Attributes: akashtypes.Attributes{
+						akashtypes.Attribute{
+							Key:   "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			Pagination: nil,
+		}
+		queryClient.On("ProviderAuditorAttributes", mock.Anything, req).Return(response, nil)
+
+		return queryClient
+	})
+
+	attrs, err := scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	err = scaffold.bus.Publish(atypes.EventTrustedAuditorCreated{
+		Owner:   scaffold.providerAddr,
+		Auditor: scaffold.auditorAddr,
+	})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second) // Allow event to be received
+
+	attrs, err = scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	err = scaffold.bus.Publish(atypes.EventTrustedAuditorDeleted{
+		Owner:   scaffold.providerAddr,
+		Auditor: scaffold.auditorAddr,
+	})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second) // Allow event to be received
+
+	attrs, err = scaffold.service.GetAuditorAttributeSignatures(scaffold.auditorAddr.String())
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+
+	scaffold.stop(t)
+
+	// Should have 3 calls
+	require.Len(t, scaffold.queryClient.Calls, 3)
+}

--- a/x/audit/keeper/keeper.go
+++ b/x/audit/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	akashtypes "github.com/ovrclk/akash/types"
 	atypes "github.com/ovrclk/akash/types"
 	"github.com/ovrclk/akash/x/audit/types"
@@ -122,6 +121,11 @@ func (k Keeper) CreateOrUpdateProviderAttributes(ctx sdk.Context, id types.Provi
 	})
 
 	store.Set(key, k.cdc.MustMarshalBinaryBare(&prov))
+
+	ctx.EventManager().EmitEvent(
+		types.NewEventTrustedAuditorCreated(id.Owner, id.Auditor).ToSDKEvent(),
+	)
+
 	return nil
 }
 
@@ -183,6 +187,10 @@ func (k Keeper) DeleteProviderAttributes(ctx sdk.Context, id types.ProviderID, k
 			store.Set(key, k.cdc.MustMarshalBinaryBare(&prov))
 		}
 	}
+
+	ctx.EventManager().EmitEvent(
+		types.NewEventTrustedAuditorDeleted(id.Owner, id.Auditor).ToSDKEvent(),
+	)
 
 	return nil
 }

--- a/x/audit/types/event.go
+++ b/x/audit/types/event.go
@@ -8,22 +8,26 @@ import (
 
 const (
 	evActionTrustedAuditorCreated = "audit-trusted-auditor-created"
+	evActionTrustedAuditorDeleted = "audit-trusted-auditor-deleted"
 	evOwnerKey                    = "owner"
+	evAuditorKey                  = "auditor"
 )
 
 // EventTrustedAuditorCreated struct
 type EventTrustedAuditorCreated struct {
 	Context sdkutil.BaseModuleEvent `json:"context"`
-	Owner   sdk.AccAddress          `json:"owner"`
+	Owner   sdk.Address             `json:"owner"`
+	Auditor sdk.Address             `json:"auditor"`
 }
 
-func NewEventTrustedAuditorCreated(owner sdk.AccAddress) EventTrustedAuditorCreated {
+func NewEventTrustedAuditorCreated(owner sdk.Address, auditor sdk.Address) EventTrustedAuditorCreated {
 	return EventTrustedAuditorCreated{
 		Context: sdkutil.BaseModuleEvent{
 			Module: ModuleName,
 			Action: evActionTrustedAuditorCreated,
 		},
-		Owner: owner,
+		Owner:   owner,
+		Auditor: auditor,
 	}
 }
 
@@ -33,29 +37,61 @@ func (ev EventTrustedAuditorCreated) ToSDKEvent() sdk.Event {
 		append([]sdk.Attribute{
 			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeyAction, evActionTrustedAuditorCreated),
-		}, TrustedAuditorEVAttributes(ev.Owner)...)...,
+		}, TrustedAuditorEVAttributes(ev.Owner, ev.Auditor)...)...,
 	)
 }
 
 // TrustedAuditorEVAttributes returns event attributes for given Provider
-func TrustedAuditorEVAttributes(owner sdk.AccAddress) []sdk.Attribute {
+func TrustedAuditorEVAttributes(owner sdk.Address, auditor sdk.Address) []sdk.Attribute {
 	return []sdk.Attribute{
 		sdk.NewAttribute(evOwnerKey, owner.String()),
+		sdk.NewAttribute(evAuditorKey, auditor.String()),
 	}
 }
 
 // ParseEVTTrustedAuditor returns provider details for given event attributes
-func ParseEVTTrustedAuditor(attrs []sdk.Attribute) (sdk.AccAddress, error) {
+func ParseEVTTrustedAuditor(attrs []sdk.Attribute) (sdk.Address, sdk.Address, error) {
 	owner, err := sdkutil.GetAccAddress(attrs, evOwnerKey)
 	if err != nil {
-		return sdk.AccAddress{}, err
+		return nil, nil, err
 	}
 
-	return owner, nil
+	auditor, err := sdkutil.GetAccAddress(attrs, evAuditorKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return owner, auditor, nil
+}
+
+type EventTrustedAuditorDeleted struct {
+	Context sdkutil.BaseModuleEvent `json:"context"`
+	Owner   sdk.Address             `json:"owner"`
+	Auditor sdk.Address             `json:"auditor"`
+}
+
+func NewEventTrustedAuditorDeleted(owner sdk.Address, auditor sdk.Address) EventTrustedAuditorDeleted {
+	return EventTrustedAuditorDeleted{
+		Context: sdkutil.BaseModuleEvent{
+			Module: ModuleName,
+			Action: evActionTrustedAuditorDeleted,
+		},
+		Owner:   owner,
+		Auditor: auditor,
+	}
+}
+
+// ToSDKEvent method creates new sdk event for EventProviderCreated struct
+func (ev EventTrustedAuditorDeleted) ToSDKEvent() sdk.Event {
+	return sdk.NewEvent(sdkutil.EventTypeMessage,
+		append([]sdk.Attribute{
+			sdk.NewAttribute(sdk.AttributeKeyModule, ModuleName),
+			sdk.NewAttribute(sdk.AttributeKeyAction, evActionTrustedAuditorDeleted),
+		}, TrustedAuditorEVAttributes(ev.Owner, ev.Auditor)...)...,
+	)
 }
 
 // ParseEvent parses event and returns details of event and error if occurred
-// TODO: Enable returning actual events.
 func ParseEvent(ev sdkutil.Event) (sdkutil.ModuleEvent, error) {
 	if ev.Type != sdkutil.EventTypeMessage {
 		return nil, sdkutil.ErrUnknownType
@@ -65,11 +101,17 @@ func ParseEvent(ev sdkutil.Event) (sdkutil.ModuleEvent, error) {
 	}
 	switch ev.Action {
 	case evActionTrustedAuditorCreated:
-		owner, err := ParseEVTTrustedAuditor(ev.Attributes)
+		owner, auditor, err := ParseEVTTrustedAuditor(ev.Attributes)
 		if err != nil {
 			return nil, err
 		}
-		return NewEventTrustedAuditorCreated(owner), nil
+		return NewEventTrustedAuditorCreated(owner, auditor), nil
+	case evActionTrustedAuditorDeleted:
+		owner, auditor, err := ParseEVTTrustedAuditor(ev.Attributes)
+		if err != nil {
+			return nil, err
+		}
+		return NewEventTrustedAuditorDeleted(owner, auditor), nil
 	default:
 		return nil, sdkutil.ErrUnknownAction
 	}


### PR DESCRIPTION
I think I made this way more complex than it needed to be, but it seems that everything is working as it should now. The provider only bids on deployments if has those attributes & the correct signature  is on the blockchain.