### PR TITLE
ci(setup-go): remove ^ to exact match go version

### DIFF
--- a/.github/workflows/k8s-integration.yaml
+++ b/.github/workflows/k8s-integration.yaml
@@ -23,7 +23,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v${{ env.KIND_VERSION }}"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -21,6 +21,6 @@ jobs:
           done < .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - run: make bins
       - run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: branch name
         id: branch_name
         run: |

--- a/.github/workflows/sims.yaml
+++ b/.github/workflows/sims.yaml
@@ -30,7 +30,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: test-sim-nondeterminism
         run: make test-sim-nondeterminism
 
@@ -43,7 +43,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: test-sim-import-export
         run: make test-sim-import-export
 
@@ -56,7 +56,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: test-sim-after-import
         run: make test-sim-after-import
 
@@ -69,6 +69,6 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: test-sim-fullapp
         run: make test-sim-fullapp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - run: make bins
       - run: make docker-image
 
@@ -34,7 +34,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - run: make test-full
 
   coverage:
@@ -46,7 +46,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - run: make test-coverage
       - uses: codecov/codecov-action@v1
 
@@ -59,7 +59,7 @@ jobs:
           env-file: .makerc
       - uses: actions/setup-go@v2
         with:
-          go-version: "^${{ env.GOLANG_VERSION }}"
+          go-version: "${{ env.GOLANG_VERSION }}"
       - run: make deps-tidy
       - run: make deps-vendor
       - run: make build


### PR DESCRIPTION
it turns out that `^` means `min version` not `exact version`