### PR TITLE
feat(sdkutil): retry in broadcast-mode block

### DIFF
--- a/sdkutil/broadcast.go
+++ b/sdkutil/broadcast.go
@@ -1,0 +1,177 @@
+package sdkutil
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/input"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
+	"github.com/spf13/pflag"
+	ttypes "github.com/tendermint/tendermint/types"
+)
+
+const (
+	broadcastBlockRetryTimeout = 30 * time.Second
+	broadcastBlockRetryPeriod  = time.Second
+
+	// sadface.
+
+	// Only way to detect the timeout error.
+	// https://github.com/tendermint/tendermint/blob/46e06c97320bc61c4d98d3018f59d47ec69863c9/rpc/core/mempool.go#L124
+	timeoutErrorMessage = "timed out waiting for tx to be included in a block"
+
+	// Only way to check for tx not found error.
+	// https://github.com/tendermint/tendermint/blob/46e06c97320bc61c4d98d3018f59d47ec69863c9/rpc/core/tx.go#L31-L33
+	notFoundErrorMessageSuffix = ") not found"
+)
+
+func BroadcastTX(ctx client.Context, flags *pflag.FlagSet, msgs ...sdk.Msg) error {
+
+	// rewrite of https://github.com/cosmos/cosmos-sdk/blob/ca98fda6eae597b1e7d468f96d030b6d905748d7/client/tx/tx.go#L29
+	// to add continuing retries if broadcast-mode=block fails with a timeout.
+
+	txf := tx.NewFactoryCLI(ctx, flags)
+
+	if ctx.GenerateOnly {
+		return tx.GenerateTx(ctx, txf, msgs...)
+	}
+
+	txf, err := tx.PrepareFactory(ctx, txf)
+	if err != nil {
+		return err
+	}
+
+	txf, err = adjustGas(ctx, txf, msgs...)
+	if err != nil {
+		return err
+	}
+	if ctx.Simulate {
+		return nil
+	}
+
+	txb, err := tx.BuildUnsignedTx(txf, msgs...)
+	if err != nil {
+		return err
+	}
+
+	ok, err := confirmTx(ctx, txb)
+	if !ok || err != nil {
+		return err
+	}
+
+	err = tx.Sign(txf, ctx.GetFromName(), txb, true)
+	if err != nil {
+		return err
+	}
+
+	txBytes, err := ctx.TxConfig.TxEncoder()(txb.GetTx())
+	if err != nil {
+		return err
+	}
+
+	res, err := doBroadcast(ctx, broadcastBlockRetryTimeout, txBytes)
+	if err != nil {
+		return err
+	}
+
+	return ctx.PrintProto(res)
+
+}
+
+func doBroadcast(ctx client.Context, timeout time.Duration, txb ttypes.Tx) (*sdk.TxResponse, error) {
+	switch ctx.BroadcastMode {
+	case flags.BroadcastSync:
+		return ctx.BroadcastTxSync(txb)
+	case flags.BroadcastAsync:
+		return ctx.BroadcastTxAsync(txb)
+	}
+
+	// broadcast-mode=block
+
+	// submit with mode commit/block
+	cres, err := ctx.BroadcastTxCommit(txb)
+
+	switch {
+	case err == nil:
+		// no error, return
+		return cres, err
+	case err.Error() != timeoutErrorMessage:
+		// other error, return
+		return cres, err
+	default:
+		// timeout error, continue on to retry
+	}
+
+	// loop
+	lctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for lctx.Err() == nil {
+
+		// wait up to one second
+		select {
+		case <-lctx.Done():
+			return cres, err
+		case <-time.After(broadcastBlockRetryPeriod):
+		}
+
+		// check transaction
+		res, err := authclient.QueryTx(ctx, cres.TxHash)
+		if err == nil {
+			return res, nil
+		}
+
+		// if it's not a "not found" error, return
+		if !strings.HasSuffix(err.Error(), notFoundErrorMessageSuffix) {
+			return res, err
+		}
+	}
+
+	return cres, lctx.Err()
+}
+
+func confirmTx(ctx client.Context, txb client.TxBuilder) (bool, error) {
+	if ctx.SkipConfirm {
+		return true, nil
+	}
+
+	out, err := ctx.TxConfig.TxJSONEncoder()(txb.GetTx())
+	if err != nil {
+		return false, err
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "%s\n\n", out)
+
+	buf := bufio.NewReader(os.Stdin)
+	ok, err := input.GetConfirmation("confirm transaction before signing and broadcasting", buf, os.Stderr)
+
+	if err != nil || !ok {
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", "cancelled transaction")
+		return false, err
+	}
+
+	return true, nil
+}
+
+func adjustGas(ctx client.Context, txf tx.Factory, msgs ...sdk.Msg) (tx.Factory, error) {
+	if !ctx.Simulate && !txf.SimulateAndExecute() {
+		return txf, nil
+	}
+	_, adjusted, err := tx.CalculateGas(ctx.QueryWithData, txf, msgs...)
+	if err != nil {
+		return txf, err
+	}
+
+	txf = txf.WithGas(adjusted)
+	_, _ = fmt.Fprintf(os.Stderr, "%s\n", tx.GasEstimateResponse{GasEstimate: txf.Gas()})
+
+	return txf, nil
+}

--- a/x/audit/client/cli/tx.go
+++ b/x/audit/client/cli/tx.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/ovrclk/akash/sdkutil"
 	akashtypes "github.com/ovrclk/akash/types"
 	atypes "github.com/ovrclk/akash/types"
 	"github.com/ovrclk/akash/x/audit/types"
@@ -85,7 +85,7 @@ func cmdCreateProviderAttributes() *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -125,7 +125,7 @@ func cmdDeleteProviderAttributes() *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/cert/client/cli/tx.go
+++ b/x/cert/client/cli/tx.go
@@ -21,7 +21,6 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	cinpuit "github.com/cosmos/cosmos-sdk/client/input"
-	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
@@ -30,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/ovrclk/akash/sdkutil"
 	"github.com/ovrclk/akash/x/cert/types"
 	cutils "github.com/ovrclk/akash/x/cert/utils"
 )
@@ -158,7 +158,7 @@ func handleCreate(cctx sdkclient.Context, cmd *cobra.Command, pemFile string, do
 	}
 
 	if !toGenesis {
-		return tx.GenerateOrBroadcastTxCLI(cctx, cmd.Flags(), msg)
+		return sdkutil.BroadcastTX(cctx, cmd.Flags(), msg)
 	}
 
 	return addCertToGenesis(cmd, types.GenesisCertificate{
@@ -258,7 +258,7 @@ func doCreateCmd(cmd *cobra.Command, domains []string) error {
 						return err
 					}
 
-					return tx.GenerateOrBroadcastTxCLI(cctx, cmd.Flags(), msg)
+					return sdkutil.BroadcastTX(cctx, cmd.Flags(), msg)
 				}
 			}
 		} else {
@@ -517,7 +517,7 @@ func doRevoke(cctx sdkclient.Context, flags *pflag.FlagSet, serial string) error
 		},
 	}
 
-	return tx.GenerateOrBroadcastTxCLI(cctx, flags, msg)
+	return sdkutil.BroadcastTX(cctx, flags, msg)
 }
 
 func getConfirmation(cmd *cobra.Command, prompt string) (bool, error) {

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/pkg/errors"
 
 	"github.com/ovrclk/akash/cmd/common"
+	"github.com/ovrclk/akash/sdkutil"
 	"github.com/ovrclk/akash/sdl"
 	cutils "github.com/ovrclk/akash/x/cert/utils"
 	"github.com/ovrclk/akash/x/deployment/types"
@@ -104,7 +104,7 @@ func cmdCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -141,7 +141,7 @@ func cmdDeposit(key string) *cobra.Command {
 				Amount: deposit,
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -169,7 +169,7 @@ func cmdClose(key string) *cobra.Command {
 
 			msg := &types.MsgCloseDeployment{ID: id}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -218,7 +218,7 @@ func cmdUpdate(key string) *cobra.Command {
 				msg.Groups = append(msg.Groups, *group)
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -268,7 +268,7 @@ func cmdGroupClose(_ string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -304,7 +304,7 @@ func cmdGroupPause(_ string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -340,7 +340,7 @@ func cmdGroupStart(_ string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ovrclk/akash/cmd/common"
+	"github.com/ovrclk/akash/sdkutil"
 	"github.com/ovrclk/akash/x/market/types"
 	"github.com/spf13/cobra"
 )
@@ -83,7 +83,7 @@ func cmdBidCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -119,7 +119,7 @@ func cmdBidClose(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -168,7 +168,7 @@ func cmdLeaseCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -203,7 +203,7 @@ func cmdLeaseWithdraw(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -238,7 +238,7 @@ func cmdLeaseClose(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/provider/client/cli/tx.go
+++ b/x/provider/client/cli/tx.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/ovrclk/akash/sdkutil"
 	"github.com/ovrclk/akash/x/provider/config"
 	"github.com/ovrclk/akash/x/provider/types"
 	"github.com/pkg/errors"
@@ -55,7 +55,7 @@ func cmdCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -90,7 +90,7 @@ func cmdUpdate(key string) *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
 		},
 	}
 


### PR DESCRIPTION
Rewrite of https://github.com/cosmos/cosmos-sdk/blob/ca98fda6eae597b1e7d468f96d030b6d905748d7/client/tx/tx.go#L29
with a different method for broadcast-mode=block:

1. use BroadcastSync
2. query for the tx until timeout or the tx is found in a block.