### PR TITLE
feat(provider): cancel bids if no lease is created

### DIFF
--- a/provider/bidengine/config.go
+++ b/provider/bidengine/config.go
@@ -1,8 +1,12 @@
 package bidengine
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"time"
+)
 
 type Config struct {
 	PricingStrategy BidPricingStrategy
 	Deposit         sdk.Coin
+	BidTimeout      time.Duration
 }

--- a/provider/bidengine/order_test.go
+++ b/provider/bidengine/order_test.go
@@ -113,7 +113,7 @@ func (nullProviderAttrSignatureService) GetAuditorAttributeSignatures(auditor st
 	return nil, nil // Return no attributes & no error
 }
 
-func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricingStrategy) (*order, orderTestScaffold, <-chan int) {
+func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricingStrategy, callerConfig *Config) (*order, orderTestScaffold, <-chan int) {
 	if pricing == nil {
 		var err error
 		pricing, err = MakeRandomRangePricing()
@@ -142,10 +142,13 @@ func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricing
 	mySession := session.New(myLog, scaffold.client, myProvider)
 
 	scaffold.testBus = pubsub.NewBus()
-	cfg := Config{
-		PricingStrategy: pricing,
-		Deposit:         mtypes.DefaultBidMinDeposit,
+	var cfg Config
+	if callerConfig != nil {
+		cfg = *callerConfig // Copy values from caller
 	}
+	// Overwrite some with stuff built in this function
+	cfg.PricingStrategy = pricing
+	cfg.Deposit = mtypes.DefaultBidMinDeposit
 
 	myService, err := NewService(context.Background(), mySession, scaffold.cluster, scaffold.testBus, cfg)
 	require.NoError(t, err)
@@ -179,7 +182,7 @@ func makeOrderForTest(t *testing.T, checkForExistingBid bool, pricing BidPricing
 }
 
 func Test_BidOrderAndUnreserve(t *testing.T) {
-	order, scaffold, _ := makeOrderForTest(t, false, nil)
+	order, scaffold, _ := makeOrderForTest(t, false, nil, nil)
 
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 	// Should have called reserve once
@@ -205,9 +208,49 @@ func Test_BidOrderAndUnreserve(t *testing.T) {
 	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
 }
 
+func Test_BidOrderAndUnreserveOnTimeout(t *testing.T) {
+	order, scaffold, _ := makeOrderForTest(t, false, nil, &Config{
+		BidTimeout: 5 * time.Second,
+	})
+
+	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	// Should have called reserve once
+	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+
+	createBidMsg, ok := broadcast.(*mtypes.MsgCreateBid)
+	require.True(t, ok)
+
+	require.Equal(t, createBidMsg.Order, scaffold.orderID)
+
+	priceDenom := createBidMsg.Price.Denom
+	require.Equal(t, testutil.CoinDenom, priceDenom)
+	priceAmount := createBidMsg.Price.Amount.Int64()
+
+	require.GreaterOrEqual(t, priceAmount, int64(1))
+	require.Less(t, priceAmount, int64(100))
+
+	// After the broadcast call the timeout should take effect
+	// and then close the bid, unreserving capacity in the process
+	broadcast = testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	_, ok = broadcast.(*mtypes.MsgCloseBid)
+	require.True(t, ok)
+
+	// After the broadcast call shut down happens automatically
+	order.lc.Shutdown(nil)
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting on shutdown")
+	case <-order.lc.Done():
+		break
+	}
+
+	// Should have called unreserve once
+	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+}
+
 func Test_BidOrderPriceTooHigh(t *testing.T) {
 	pricing := testBidPricingStrategy(9999999999)
-	order, scaffold, _ := makeOrderForTest(t, false, pricing)
+	order, scaffold, _ := makeOrderForTest(t, false, pricing, nil)
 
 	select {
 	case <-order.lc.Done(): // Should stop on its own
@@ -230,7 +273,7 @@ func Test_BidOrderPriceTooHigh(t *testing.T) {
 }
 
 func Test_BidOrderAndThenClosedUnreserve(t *testing.T) {
-	order, scaffold, _ := makeOrderForTest(t, false, nil)
+	order, scaffold, _ := makeOrderForTest(t, false, nil, nil)
 
 	testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 	// Should have called reserve once at this point
@@ -252,7 +295,7 @@ func Test_BidOrderAndThenClosedUnreserve(t *testing.T) {
 }
 
 func Test_BidOrderAndThenLeaseCreated(t *testing.T) {
-	order, scaffold, _ := makeOrderForTest(t, false, nil)
+	order, scaffold, _ := makeOrderForTest(t, false, nil, nil)
 
 	// Wait for first broadcast
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
@@ -293,7 +336,7 @@ func Test_BidOrderAndThenLeaseCreated(t *testing.T) {
 
 func Test_BidOrderAndThenLeaseCreatedForDifferentDeployment(t *testing.T) {
 
-	order, scaffold, _ := makeOrderForTest(t, false, nil)
+	order, scaffold, _ := makeOrderForTest(t, false, nil, nil)
 
 	// Wait for first broadcast
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
@@ -347,7 +390,7 @@ func Test_BidOrderAndThenLeaseCreatedForDifferentDeployment(t *testing.T) {
 
 func Test_ShouldNotBidWhenAlreadySet(t *testing.T) {
 
-	order, scaffold, reservationFulfilledNotify := makeOrderForTest(t, true, nil)
+	order, scaffold, reservationFulfilledNotify := makeOrderForTest(t, true, nil, nil)
 
 	// Wait for a reserve call
 	testutil.ChannelWaitForValue(t, scaffold.reserveCallNotify)
@@ -403,7 +446,7 @@ func Test_ShouldNotBidWhenAlreadySet(t *testing.T) {
 }
 
 func Test_ShouldRecognizeLeaseCreatedIfBiddingIsSkipped(t *testing.T) {
-	order, scaffold, _ := makeOrderForTest(t, true, nil)
+	order, scaffold, _ := makeOrderForTest(t, true, nil, nil)
 
 	// Wait for a reserve call
 	testutil.ChannelWaitForValue(t, scaffold.reserveCallNotify)
@@ -451,7 +494,7 @@ func Test_BidOrderUsesBidPricingStrategy(t *testing.T) {
 	expectedBid := int64(37)
 	// Create a test strategy that gives a fixed price
 	pricing := testBidPricingStrategy(expectedBid)
-	order, scaffold, _ := makeOrderForTest(t, false, pricing)
+	order, scaffold, _ := makeOrderForTest(t, false, pricing, nil)
 
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 
@@ -486,7 +529,7 @@ var errBidPricingAlwaysFails = errors.New("bid pricing fail in test")
 func Test_BidOrderFailsAndAborts(t *testing.T) {
 	// Create a test strategy that gives a fixed price
 	pricing := alwaysFailsBidPricingStrategy{failure: errBidPricingAlwaysFails}
-	order, scaffold, _ := makeOrderForTest(t, false, pricing)
+	order, scaffold, _ := makeOrderForTest(t, false, pricing, nil)
 
 	<-order.lc.Done() // Stops whenever the bid pricing is called and returns an errro
 

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -75,6 +75,7 @@ const (
 	FlagAuthPem                          = "auth-pem"
 	FlagKubeConfig                       = "kubeconfig"
 	FlagDeploymentRuntimeClass           = "deployment-runtime-class"
+	FlagBidTimeout                       = "bid-timeout"
 )
 
 var (
@@ -239,6 +240,11 @@ func RunCmd() *cobra.Command {
 	if err := viper.BindPFlag(FlagDeploymentRuntimeClass, cmd.Flags().Lookup(FlagDeploymentRuntimeClass)); err != nil {
 		return nil
 	}
+
+	cmd.Flags().Duration(FlagBidTimeout, 20*time.Minute, "time after which bids are cancelled if no lease is created")
+	if err := viper.BindPFlag(FlagBidTimeout, cmd.Flags().Lookup(FlagBidTimeout)); err != nil {
+		return nil
+	}
 	return cmd
 }
 
@@ -328,6 +334,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	blockedHostnames := viper.GetStringSlice(FlagDeploymentBlockedHostnames)
 	kubeConfig := viper.GetString(FlagKubeConfig)
 	deploymentRuntimeClass := viper.GetString(FlagDeploymentRuntimeClass)
+	bidTimeout := viper.GetDuration(FlagBidTimeout)
 
 	if err != nil {
 		return err
@@ -461,6 +468,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.StorageCommitLevel = overcommitPercentStorage
 	config.BlockedHostnames = blockedHostnames
 	config.DeploymentIngressStaticHosts = deploymentIngressStaticHosts
+	config.BidTimeout = bidTimeout
 
 	config.BidPricingStrategy = pricing
 	service, err := provider.NewService(ctx, cctx, info.GetAddress(), session, bus, cclient, config)

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -241,7 +241,7 @@ func RunCmd() *cobra.Command {
 		return nil
 	}
 
-	cmd.Flags().Duration(FlagBidTimeout, 20*time.Minute, "time after which bids are cancelled if no lease is created")
+	cmd.Flags().Duration(FlagBidTimeout, 5*time.Minute, "time after which bids are cancelled if no lease is created")
 	if err := viper.BindPFlag(FlagBidTimeout, cmd.Flags().Lookup(FlagBidTimeout)); err != nil {
 		return nil
 	}

--- a/provider/config.go
+++ b/provider/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	StorageCommitLevel              float64
 	BlockedHostnames                []string
 	DeploymentIngressStaticHosts    bool
+	BidTimeout                      time.Duration
 }
 
 func NewDefaultConfig() Config {

--- a/provider/service.go
+++ b/provider/service.go
@@ -84,6 +84,7 @@ func NewService(ctx context.Context, cctx client.Context, accAddr sdk.AccAddress
 	bidengine, err := bidengine.NewService(ctx, session, cluster, bus, bidengine.Config{
 		PricingStrategy: cfg.BidPricingStrategy,
 		Deposit:         cfg.BidDeposit,
+		BidTimeout:      cfg.BidTimeout,
 	})
 	if err != nil {
 		errmsg := "creating bidengine service"


### PR DESCRIPTION
After a bid is created, just start a timer. If the timer is reached, cancel the bid and unreserve capacity.

This prevents a bunch of bids from taking up all capacity without any actual use of it.