### PR TITLE
Cancel bid if a manifest is not received

### DIFF
--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-
 	lifecycle "github.com/boz/go-lifecycle"
 	"github.com/pkg/errors"
 
@@ -75,8 +74,9 @@ func NewService(ctx context.Context, session session.Session, bus pubsub.Bus, cl
 		statusch:  make(chan chan<- *ctypes.Status),
 		managers:  make(map[string]*deploymentManager),
 		managerch: make(chan *deploymentManager),
-		log:       log,
-		lc:        lc,
+
+		log: log,
+		lc:  lc,
 	}
 
 	go s.lc.WatchContext(ctx)
@@ -94,8 +94,9 @@ type service struct {
 	inventory *inventoryService
 	hostnames *hostnameService
 
-	statusch  chan chan<- *ctypes.Status
-	managers  map[string]*deploymentManager
+	statusch chan chan<- *ctypes.Status
+	managers map[string]*deploymentManager
+
 	managerch chan *deploymentManager
 
 	log log.Logger
@@ -190,7 +191,6 @@ loop:
 				}
 
 				key := mquery.LeasePath(ev.LeaseID)
-
 				if manager := s.managers[key]; manager != nil {
 					if err := manager.update(mgroup); err != nil {
 						s.log.Error("updating deployment", "err", err, "lease", ev.LeaseID, "group-name", mgroup.Name)
@@ -203,6 +203,7 @@ loop:
 
 			case mtypes.EventLeaseClosed:
 				s.teardownLease(ev.ID)
+
 			}
 
 		case ch := <-s.statusch:
@@ -221,6 +222,7 @@ loop:
 			}
 
 			delete(s.managers, mquery.LeasePath(dm.lease))
+
 		}
 	}
 

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -76,6 +76,7 @@ const (
 	FlagKubeConfig                       = "kubeconfig"
 	FlagDeploymentRuntimeClass           = "deployment-runtime-class"
 	FlagBidTimeout                       = "bid-timeout"
+	FlagManifestTimeout                  = "manifest-timeout"
 )
 
 var (
@@ -245,6 +246,12 @@ func RunCmd() *cobra.Command {
 	if err := viper.BindPFlag(FlagBidTimeout, cmd.Flags().Lookup(FlagBidTimeout)); err != nil {
 		return nil
 	}
+
+	cmd.Flags().Duration(FlagManifestTimeout, 5*time.Minute, "time after which bids are cancelled if no manifest is received")
+	if err := viper.BindPFlag(FlagManifestTimeout, cmd.Flags().Lookup(FlagManifestTimeout)); err != nil {
+		return nil
+	}
+
 	return cmd
 }
 
@@ -335,6 +342,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	kubeConfig := viper.GetString(FlagKubeConfig)
 	deploymentRuntimeClass := viper.GetString(FlagDeploymentRuntimeClass)
 	bidTimeout := viper.GetDuration(FlagBidTimeout)
+	manifestTimeout := viper.GetDuration(FlagManifestTimeout)
 
 	if err != nil {
 		return err
@@ -469,6 +477,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.BlockedHostnames = blockedHostnames
 	config.DeploymentIngressStaticHosts = deploymentIngressStaticHosts
 	config.BidTimeout = bidTimeout
+	config.ManifestTimeout = manifestTimeout
 
 	config.BidPricingStrategy = pricing
 	service, err := provider.NewService(ctx, cctx, info.GetAddress(), session, bus, cclient, config)

--- a/provider/config.go
+++ b/provider/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	BlockedHostnames                []string
 	DeploymentIngressStaticHosts    bool
 	BidTimeout                      time.Duration
+	ManifestTimeout                 time.Duration
 }
 
 func NewDefaultConfig() Config {

--- a/provider/manifest/config.go
+++ b/provider/manifest/config.go
@@ -1,5 +1,8 @@
 package manifest
 
+import "time"
+
 type ServiceConfig struct {
 	HTTPServicesRequireAtLeastOneHost bool
+	ManifestTimeout                   time.Duration
 }

--- a/provider/manifest/watchdog.go
+++ b/provider/manifest/watchdog.go
@@ -1,0 +1,71 @@
+package manifest
+
+import (
+	"context"
+	"github.com/boz/go-lifecycle"
+	"github.com/ovrclk/akash/provider/session"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	"github.com/ovrclk/akash/x/market/types"
+	"github.com/tendermint/tendermint/libs/log"
+	"time"
+)
+
+type watchdog struct {
+	leaseID types.LeaseID
+	timeout time.Duration
+	lc      lifecycle.Lifecycle
+	sess    session.Session
+	ctx     context.Context
+	log     log.Logger
+}
+
+func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID types.LeaseID, timeout time.Duration) *watchdog {
+	ctx, cancel := context.WithCancel(context.Background())
+	result := &watchdog{
+		leaseID: leaseID,
+		timeout: timeout,
+		lc:      lifecycle.New(),
+		sess:    sess,
+		ctx:     ctx,
+		log:     sess.Log().With("leaseID", leaseID),
+	}
+
+	go func() {
+		result.lc.WatchChannel(parent)
+		cancel()
+	}()
+
+	go func() {
+		<-result.lc.Done()
+		done <- leaseID.DeploymentID()
+	}()
+
+	go result.run()
+
+	return result
+}
+
+func (wd *watchdog) stop() {
+	wd.lc.ShutdownAsync(nil)
+}
+
+func (wd *watchdog) run() {
+	defer wd.lc.ShutdownCompleted()
+
+	wd.log.Debug("watchdog start")
+	select {
+	case <-time.After(wd.timeout):
+		// Close the bid, since if this point is reached then a manifest has not been received
+	case err := <-wd.lc.ShutdownRequest():
+		wd.lc.ShutdownInitiated(err)
+		return // Nothing to do
+	}
+
+	wd.log.Info("watchdog closing bid")
+	err := wd.sess.Client().Tx().Broadcast(wd.ctx, &types.MsgCloseBid{
+		BidID: types.MakeBidID(wd.leaseID.OrderID(), wd.sess.Provider().Address()),
+	})
+	if err != nil {
+		wd.log.Error("failed closing bid", "err", err)
+	}
+}

--- a/provider/manifest/watchdog_test.go
+++ b/provider/manifest/watchdog_test.go
@@ -1,0 +1,113 @@
+package manifest
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	broadcastmocks "github.com/ovrclk/akash/client/broadcaster/mocks"
+	clientmocks "github.com/ovrclk/akash/client/mocks"
+	"github.com/ovrclk/akash/provider/session"
+	"github.com/ovrclk/akash/testutil"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	"github.com/ovrclk/akash/x/market/types"
+	ptypes "github.com/ovrclk/akash/x/provider/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+type watchdogTestScaffold struct {
+	client     *clientmocks.Client
+	parentCh   chan struct{}
+	doneCh     chan dtypes.DeploymentID
+	broadcasts chan sdk.Msg
+	leaseID    types.LeaseID
+	provider   ptypes.Provider
+}
+
+func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *watchdogTestScaffold) {
+	scaffold := &watchdogTestScaffold{}
+	scaffold.parentCh = make(chan struct{})
+	scaffold.doneCh = make(chan dtypes.DeploymentID, 1)
+	scaffold.broadcasts = make(chan sdk.Msg)
+	scaffold.provider = testutil.Provider(t)
+	scaffold.leaseID = testutil.LeaseID(t)
+	scaffold.leaseID.Provider = scaffold.provider.Owner
+	scaffold.broadcasts = make(chan sdk.Msg, 1)
+
+	txClientMock := &broadcastmocks.Client{}
+	txClientMock.On("Broadcast", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		scaffold.broadcasts <- args.Get(1).(sdk.Msg)
+	}).Return(nil)
+
+	scaffold.client = &clientmocks.Client{}
+	scaffold.client.On("Tx").Return(txClientMock)
+	sess := session.New(testutil.Logger(t), scaffold.client, &scaffold.provider)
+	require.NotNil(t, sess.Client())
+
+	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout)
+
+	return wd, scaffold
+}
+
+func TestWatchdogTimesout(t *testing.T) {
+	wd, scaffold := makeWatchdogTestScaffold(t, 3*time.Second)
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting on watchdog to stop")
+	}
+
+	// Check that close bid was sent
+	msg := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	closeBid, ok := msg.(*types.MsgCloseBid)
+	require.True(t, ok)
+	require.Equal(t, closeBid.BidID.LeaseID(), scaffold.leaseID)
+
+	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
+	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}
+
+func TestWatchdogStops(t *testing.T) {
+	wd, scaffold := makeWatchdogTestScaffold(t, 1*time.Minute)
+
+	wd.stop() // ask it to stop immediately
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting on watchdog to stop")
+	}
+
+	// Check that close bid was not sent
+	select {
+	case <-scaffold.broadcasts:
+		t.Fatal("should no have broadcast any message")
+	default:
+	}
+
+	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
+	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}
+
+func TestWatchdogStopsOnParent(t *testing.T) {
+	wd, scaffold := makeWatchdogTestScaffold(t, 1*time.Minute)
+
+	close(scaffold.parentCh) // ask it to stop immediately
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting on watchdog to stop")
+	}
+
+	// Check that close bid was not sent
+	select {
+	case <-scaffold.broadcasts:
+		t.Fatal("should no have broadcast any message")
+	default:
+	}
+
+	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
+	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}

--- a/provider/service.go
+++ b/provider/service.go
@@ -96,6 +96,7 @@ func NewService(ctx context.Context, cctx client.Context, accAddr sdk.AccAddress
 
 	manifestConfig := manifest.ServiceConfig{
 		HTTPServicesRequireAtLeastOneHost: !cfg.DeploymentIngressStaticHosts,
+		ManifestTimeout:                   cfg.ManifestTimeout,
 	}
 
 	manifest, err := manifest.NewService(ctx, session, bus, cluster.HostnameService(), manifestConfig)


### PR DESCRIPTION
This starts a watchdog per deployment ID that either is:

1. Cancelled when a manifest arrives 
2. Closes the bid when a timeout is reached

This should save AKT of folks who for someone can't send a valid manifest to the provider