### PR TITLE
ci(proto): setup go environment for proto

### DIFF
--- a/.github/workflows/proto.yaml
+++ b/.github/workflows/proto.yaml
@@ -24,6 +24,12 @@ jobs:
         run: git checkout master
       - name: checkout back to GITHUB_SHA
         run: git checkout $GITHUB_SHA
+      - uses: c-py/action-dotenv-to-setenv@v3
+        with:
+          env-file: .makerc
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ env.GOLANG_VERSION }}"
       - name: go mod vendor
         run: make modvendor
       - name: check-breakage


### PR DESCRIPTION
required by make modvendor target

Signed-off-by: Artur Troian <troian.ap@gmail.com>
