### PR TITLE
fix(provider): query provider if flag is not supplied for send-manifest

### DIFF
--- a/provider/cmd/leaseLogs.go
+++ b/provider/cmd/leaseLogs.go
@@ -29,7 +29,7 @@ func leaseLogsCmd() *cobra.Command {
 
 	cmd.Flags().BoolP("follow", "f", false, "Specify if the logs should be streamed. Defaults to false")
 	cmd.Flags().Int64P("tail", "t", -1, "The number of lines from the end of the logs to show. Defaults to -1")
-	cmd.Flags().String("format", "text", "Output format text|json. Defaults to text")
+	cmd.Flags().String("format", outputText, "Output format text|json. Defaults to text")
 
 	return cmd
 }
@@ -60,7 +60,7 @@ func doServiceLogs(cmd *cobra.Command) error {
 		return err
 	}
 
-	if outputFormat != "text" && outputFormat != "json" {
+	if outputFormat != outputText && outputFormat != outputJSON {
 		return errors.Errorf("invalid output format %s. expected text|json", outputFormat)
 	}
 

--- a/provider/cmd/manifest.go
+++ b/provider/cmd/manifest.go
@@ -1,16 +1,27 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"fmt"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	akashclient "github.com/ovrclk/akash/client"
 	gwrest "github.com/ovrclk/akash/provider/gateway/rest"
 	"github.com/ovrclk/akash/sdl"
 	cutils "github.com/ovrclk/akash/x/cert/utils"
+)
+
+var (
+	errSubmitManifestFailed = errors.New("submit manifest to some providers has been failed")
 )
 
 // SendManifestCmd looks up the Providers blockchain information,
@@ -26,7 +37,9 @@ func SendManifestCmd() *cobra.Command {
 		},
 	}
 
-	addCmdFlags(cmd)
+	addManifestFlags(cmd)
+
+	cmd.Flags().StringP("output", "o", outputText, "output format text|json|yaml. default text")
 
 	return cmd
 }
@@ -47,7 +60,7 @@ func doSendManifest(cmd *cobra.Command, sdlpath string) error {
 		return err
 	}
 
-	prov, err := providerFromFlags(cmd.Flags())
+	cert, err := cutils.LoadAndQueryCertificateForAccount(cmd.Context(), cctx, cctx.Keyring)
 	if err != nil {
 		return err
 	}
@@ -57,15 +70,75 @@ func doSendManifest(cmd *cobra.Command, sdlpath string) error {
 		return err
 	}
 
-	cert, err := cutils.LoadAndQueryCertificateForAccount(cmd.Context(), cctx, cctx.Keyring)
+	// owner address in FlagFrom has already been validated thus save to just pull its value as string
+	providers, err := providersForDeployment(cmd.Context(), cctx, cmd.Flags(), dtypes.DeploymentID{
+		Owner: cctx.GetFromAddress().String(),
+		DSeq:  dseq,
+	})
 	if err != nil {
 		return err
 	}
 
-	gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
+	type result struct {
+		Provider sdk.Address `json:"provider" yaml:"provider"`
+		Status   string      `json:"status" yaml:"status"`
+		Error    error       `json:"error,omitempty" yaml:"error,omitempty"`
+	}
+
+	results := make([]result, len(providers))
+
+	submitFailed := false
+
+	for i, provider := range providers {
+		gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), provider, []tls.Certificate{cert})
+		if err != nil {
+			return err
+		}
+
+		err = gclient.SubmitManifest(context.Background(), dseq, mani)
+		res := result{
+			Provider: provider,
+			Status:   "PASS",
+			Error:    err,
+		}
+
+		if err != nil {
+			res.Status = "FAIL"
+			submitFailed = true
+		}
+
+		results[i] = res
+	}
+
+	buf := &bytes.Buffer{}
+
+	switch cmd.Flag("output").Value.String() {
+	case outputText:
+		for _, res := range results {
+			_, _ = fmt.Fprintf(buf, "provider: %s\n\tstatus: %s\n", res.Provider, res.Status)
+			if res.Error != nil {
+				_, _ = fmt.Fprintf(buf, "\terror: %v\n", res.Error)
+			}
+		}
+	case outputJSON:
+		err = json.NewEncoder(buf).Encode(results)
+	case outputYAML:
+		err = yaml.NewEncoder(buf).Encode(results)
+	}
+
 	if err != nil {
 		return err
 	}
 
-	return showErrorToUser(gclient.SubmitManifest(context.Background(), dseq, mani))
+	_, err = fmt.Fprint(cmd.OutOrStdout(), buf.String())
+
+	if err != nil {
+		return err
+	}
+
+	if submitFailed {
+		return errSubmitManifestFailed
+	}
+
+	return nil
 }

--- a/provider/cmd/serviceStatus.go
+++ b/provider/cmd/serviceStatus.go
@@ -13,12 +13,6 @@ import (
 	mcli "github.com/ovrclk/akash/x/market/client/cli"
 )
 
-const (
-	FlagService  = "service"
-	FlagProvider = "provider"
-	FlagDSeq     = "dseq"
-)
-
 func serviceStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "service-status",


### PR DESCRIPTION
fixes #1177

output examples
**text**
```text
provider: akash1f6gmtjpx4r8qda9nxjwq26fp5mcjyqmaq5m6j7
    status: PASS
provider: akash10cl5rm0cqnpj45knzakpa4cnvn5amzwp4lhcal
    status: PASS
```

**yaml**
```yaml
- provider: akash1f6gmtjpx4r8qda9nxjwq26fp5mcjyqmaq5m6j7
  status: PASS
- provider: akash10cl5rm0cqnpj45knzakpa4cnvn5amzwp4lhcal
  status: PASS
```

**json**
```json
[{
	"provider": "akash1f6gmtjpx4r8qda9nxjwq26fp5mcjyqmaq5m6j7",
	"status": "PASS"
}, {
	"provider": "akash10cl5rm0cqnpj45knzakpa4cnvn5amzwp4lhcal",
	"status": "PASS"
}]
```
