### PR TITLE
Add prometheus metrics to provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.0.3-0.20190619091711-d94255cb3dfc // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.8.0
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/cors v1.7.1-0.20191011001009-dcbccb712443 // indirect
 	github.com/rs/zerolog v1.20.0

--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	atypes "github.com/ovrclk/akash/x/audit/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"regexp"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/ovrclk/akash/provider/event"
 	"github.com/ovrclk/akash/provider/session"
 	"github.com/ovrclk/akash/pubsub"
+	metricsutils "github.com/ovrclk/akash/util/metrics"
 	"github.com/ovrclk/akash/util/runner"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	mtypes "github.com/ovrclk/akash/x/market/types"
@@ -36,6 +39,42 @@ type order struct {
 	lc   lifecycle.Lifecycle
 	pass ProviderAttrSignatureService
 }
+
+var (
+	pricingDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:        "provider_bid_pricing_duration",
+		Help:        "",
+		ConstLabels: nil,
+		Buckets:     prometheus.ExponentialBuckets(150000.0, 2.0, 10.0),
+	})
+
+	bidCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "provider_bid",
+		Help: "The total number of bids created",
+	}, []string{"action", "result"})
+
+	reservationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:        "provider_reservation_duration",
+		Help:        "",
+		ConstLabels: nil,
+		Buckets:     prometheus.ExponentialBuckets(150000.0, 2.0, 10.0),
+	})
+
+	reservationCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "provider_reservation",
+		Help: "",
+	}, []string{"action", "result"})
+
+	shouldBidCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "provider_should_bid",
+		Help: "",
+	}, []string{"result"})
+
+	orderCompleteCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "provider_order_complete",
+		Help: "",
+	}, []string{"result"})
+)
 
 func newOrder(svc *service, oid mtypes.OrderID, cfg Config, pass ProviderAttrSignatureService, checkForExistingBid bool) (*order, error) {
 	return newOrderInternal(svc, oid, cfg, pass, checkForExistingBid, nil)
@@ -161,9 +200,11 @@ loop:
 
 				// check winning provider
 				if ev.ID.Provider != o.session.Provider().Address().String() {
+					orderCompleteCounter.WithLabelValues("lease-lost").Inc()
 					o.log.Info("lease lost", "lease", ev.ID)
 					break loop
 				}
+				orderCompleteCounter.WithLabelValues("lease-won").Inc()
 
 				// TODO: sanity check (price, state, etc...)
 				o.log.Info("lease won", "lease", ev.ID)
@@ -187,6 +228,7 @@ loop:
 				}
 
 				o.log.Info("order closed")
+				orderCompleteCounter.WithLabelValues("order-closed").Inc()
 				break loop
 			}
 
@@ -212,30 +254,36 @@ loop:
 			shouldBidCh = nil
 
 			if result.Error() != nil {
+				shouldBidCounter.WithLabelValues(metricsutils.FailLabel).Inc()
 				o.log.Error("failure during checking should bid", "err", result.Error())
 				break loop
 			}
 
 			shouldBid := result.Value().(bool)
 			if !shouldBid {
+				shouldBidCounter.WithLabelValues("decline").Inc()
 				o.log.Debug("declined to bid")
 				break loop
 			}
 
+			shouldBidCounter.WithLabelValues("accept").Inc()
 			o.log.Info("requesting reservation")
 			// Begin reserving resources from cluster.
-			clusterch = runner.Do(func() runner.Result {
+			clusterch = runner.Do(metricsutils.ObserveRunner(func() runner.Result {
 				v := runner.NewResult(o.cluster.Reserve(o.orderID, group))
 				return v
-			})
+			}, reservationDuration))
 
 		case result := <-clusterch:
 			clusterch = nil
 
 			if result.Error() != nil {
+				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel)
 				o.log.Error("reserving resources", "err", result.Error())
 				break loop
 			}
+
+			reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel)
 
 			o.log.Info("Reservation fulfilled")
 
@@ -254,18 +302,17 @@ loop:
 				// fulfillment already created (state recovered via queryExistingOrders)
 				break
 			}
-
-			pricech = runner.Do(func() runner.Result {
+			pricech = runner.Do(metricsutils.ObserveRunner(func() runner.Result {
 				// Calculate price & bid
 				return runner.NewResult(o.cfg.PricingStrategy.CalculatePrice(ctx, group.GroupID.Owner, &group.GroupSpec))
-
-			})
+			}, pricingDuration))
 		case result := <-pricech:
 			pricech = nil
 			if result.Error() != nil {
 				o.log.Error("error calculating price", "err", result.Error())
 				break loop
 			}
+
 			price := result.Value().(sdk.Coin)
 			maxPrice := group.GroupSpec.Price()
 
@@ -287,9 +334,11 @@ loop:
 			o.log.Info("bid complete")
 
 			if result.Error() != nil {
+				bidCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel).Inc()
 				o.log.Error("submitting fulfillment", "err", result.Error())
 				break loop
 			}
+			bidCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel).Inc()
 
 			// Fulfillment placed.
 			o.bidPlaced = true
@@ -300,6 +349,7 @@ loop:
 
 		case <-bidTimeout:
 			o.log.Info("bid timeout, closing bid")
+			orderCompleteCounter.WithLabelValues("bid-timeout").Inc()
 			break loop
 		}
 	}
@@ -315,6 +365,9 @@ loop:
 			o.log.Debug("unreserving reservation")
 			if err := o.cluster.Unreserve(reservation.OrderID()); err != nil {
 				o.log.Error("error unreserving reservation", "err", err)
+				reservationCounter.WithLabelValues("close", metricsutils.FailLabel)
+			} else {
+				reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel)
 			}
 		}
 
@@ -325,6 +378,9 @@ loop:
 			})
 			if err != nil {
 				o.log.Error("closing bid", "err", err)
+				bidCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
+			} else {
+				bidCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
 			}
 		}
 	}

--- a/provider/cluster/client.go
+++ b/provider/cluster/client.go
@@ -38,13 +38,14 @@ type Client interface {
 }
 
 type node struct {
-	id                 string
-	availableResources atypes.ResourceUnits
+	id                    string
+	availableResources    atypes.ResourceUnits
+	allocateableResources atypes.ResourceUnits
 }
 
 // NewNode returns new Node instance with provided details
-func NewNode(id string, available atypes.ResourceUnits) ctypes.Node {
-	return &node{id: id, availableResources: available}
+func NewNode(id string, allocateable atypes.ResourceUnits, available atypes.ResourceUnits) ctypes.Node {
+	return &node{id: id, allocateableResources: allocateable, availableResources: available}
 }
 
 // ID returns id of node
@@ -59,6 +60,10 @@ func (n *node) Reserve(atypes.ResourceUnits) error {
 // Available returns available units of node
 func (n *node) Available() atypes.ResourceUnits {
 	return n.availableResources
+}
+
+func (n *node) Allocateable() atypes.ResourceUnits {
+	return n.allocateableResources
 }
 
 const (
@@ -229,6 +234,17 @@ func (c *nullClient) Inventory(context.Context) ([]ctypes.Node, error) {
 			Storage: &atypes.Storage{
 				Quantity: atypes.NewResourceValue(nullClientStorage),
 			},
-		}),
+		},
+			atypes.ResourceUnits{
+				CPU: &atypes.CPU{
+					Units: atypes.NewResourceValue(nullClientCPU),
+				},
+				Memory: &atypes.Memory{
+					Quantity: atypes.NewResourceValue(nullClientMemory),
+				},
+				Storage: &atypes.Storage{
+					Quantity: atypes.NewResourceValue(nullClientStorage),
+				},
+			}),
 	}, nil
 }

--- a/provider/cluster/inventory_test.go
+++ b/provider/cluster/inventory_test.go
@@ -56,8 +56,8 @@ func TestInventory_reservationAllocateable(t *testing.T) {
 	}
 
 	inventory := []ctypes.Node{
-		NewNode("a", newResourceUnits()),
-		NewNode("b", newResourceUnits()),
+		NewNode("a", newResourceUnits(), newResourceUnits()),
+		NewNode("b", newResourceUnits(), newResourceUnits()),
 	}
 
 	reservations := []*reservation{

--- a/provider/cluster/types/types.go
+++ b/provider/cluster/types/types.go
@@ -60,6 +60,7 @@ type LeaseStatus struct {
 type Node interface {
 	ID() string
 	Available() atypes.ResourceUnits
+	Allocateable() atypes.ResourceUnits
 	Reserve(atypes.ResourceUnits) error
 }
 

--- a/provider/cmd/metrics.go
+++ b/provider/cmd/metrics.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func makeMetricsRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			// Opt into OpenMetrics to support exemplars.
+			EnableOpenMetrics: true,
+		},
+	))
+
+	return router
+}

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"github.com/ovrclk/akash/util/runner"
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+const SuccessLabel = "success"
+const FailLabel = "fail"
+const OpenLabel = "open"
+
+func IncCounterVecWithLabelValues(counter *prometheus.CounterVec, name string, err error) {
+	label := SuccessLabel
+	if err != nil {
+		label = FailLabel
+	}
+	counter.WithLabelValues(name, label).Inc()
+}
+
+func IncCounterVecWithLabelValuesFiltered(counter *prometheus.CounterVec, name string, err error, filters ...func(error) bool) {
+	label := SuccessLabel
+	if err != nil {
+		flipLabel := true
+		for _, filter := range filters {
+			if filter(err) {
+				flipLabel = false
+				break
+			}
+		}
+		if flipLabel {
+			label = FailLabel
+		}
+	}
+	counter.WithLabelValues(name, label).Inc()
+}
+
+func ObserveRunner(f func() runner.Result, observer prometheus.Histogram) func() runner.Result {
+	return func() runner.Result {
+		startAt := time.Now()
+		result := f()
+		elapsed := time.Since(startAt)
+		observer.Observe(float64(elapsed.Microseconds()))
+		return result
+	}
+}


### PR DESCRIPTION
This adds a bunch of metrics around critical stuff. To enable it on the provider you just pass a command like arg like `--metrics-listener 0.0.0.0:3331` and it starts. If not specified, it doesn't start the metrics listener