### PR TITLE
refactor(provider/cli): show logs/events for all leases by default

### DIFF
--- a/_run/kube/README.md
+++ b/_run/kube/README.md
@@ -223,14 +223,14 @@ Get service status
 
 __t1 service status__
 ```sh
-make provider-service-status
+make provider-lease-status
 ```
 
 Fetch logs from deployed service (all pods)
 
 __t1 service logs__
 ```sh
-make provider-service-logs
+make provider-lease-logs
 ```
 
 If you chose to use port 80 when setting up kind, you can browse to your

--- a/provider/cmd/helpers.go
+++ b/provider/cmd/helpers.go
@@ -22,6 +22,9 @@ const (
 	FlagDSeq     = "dseq"
 	FlagGSeq     = "gseq"
 	FlagOSeq     = "oseq"
+	flagOutput   = "output"
+	flagFollow   = "follow"
+	flagTail     = "tail"
 )
 
 const (
@@ -49,8 +52,8 @@ func addCmdFlags(cmd *cobra.Command) {
 func addManifestFlags(cmd *cobra.Command) {
 	addCmdFlags(cmd)
 
-	cmd.Flags().Uint32("gseq", 1, "group sequence")
-	cmd.Flags().Uint32("oseq", 1, "order sequence")
+	cmd.Flags().Uint32(FlagGSeq, 1, "group sequence")
+	cmd.Flags().Uint32(FlagOSeq, 1, "order sequence")
 }
 
 func addLeaseFlags(cmd *cobra.Command) {
@@ -84,7 +87,7 @@ func providerFromFlags(flags *pflag.FlagSet) (sdk.Address, error) {
 	return addr, nil
 }
 
-func providersForDeployment(ctx context.Context, cctx client.Context, flags *pflag.FlagSet, did dtypes.DeploymentID) ([]sdk.Address, error) {
+func leasesForDeployment(ctx context.Context, cctx client.Context, flags *pflag.FlagSet, did dtypes.DeploymentID) ([]mtypes.LeaseID, error) {
 	filter := mtypes.LeaseFilters{
 		Owner: did.Owner,
 		DSeq:  did.DSeq,
@@ -120,16 +123,11 @@ func providersForDeployment(ctx context.Context, cctx client.Context, flags *pfl
 		return nil, errors.Errorf("no active leases found for dseq=%v", did.DSeq)
 	}
 
-	addrs := make([]sdk.Address, 0, len(resp.Leases))
+	leases := make([]mtypes.LeaseID, 0, len(resp.Leases))
 
 	for _, lease := range resp.Leases {
-		addr, err := sdk.AccAddressFromBech32(lease.Lease.LeaseID.Provider)
-		if err != nil {
-			return nil, err
-		}
-
-		addrs = append(addrs, addr)
+		leases = append(leases, lease.Lease.LeaseID)
 	}
 
-	return addrs, nil
+	return leases, nil
 }

--- a/provider/cmd/leaseEvents.go
+++ b/provider/cmd/leaseEvents.go
@@ -2,15 +2,19 @@ package cmd
 
 import (
 	"crypto/tls"
+	"sync"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cmdcommon "github.com/ovrclk/akash/cmd/common"
+	cltypes "github.com/ovrclk/akash/provider/cluster/types"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
 	"github.com/spf13/cobra"
 
 	akashclient "github.com/ovrclk/akash/client"
-	cmdcommon "github.com/ovrclk/akash/cmd/common"
 	gwrest "github.com/ovrclk/akash/provider/gateway/rest"
 	cutils "github.com/ovrclk/akash/x/cert/utils"
-	mcli "github.com/ovrclk/akash/x/market/client/cli"
 )
 
 func leaseEventsCmd() *cobra.Command {
@@ -36,12 +40,20 @@ func doLeaseEvents(cmd *cobra.Command) error {
 		return err
 	}
 
-	prov, err := providerFromFlags(cmd.Flags())
+	cert, err := cutils.LoadAndQueryCertificateForAccount(cmd.Context(), cctx, cctx.Keyring)
 	if err != nil {
 		return err
 	}
 
-	bid, err := mcli.BidIDFromFlagsForOwner(cmd.Flags(), cctx.FromAddress)
+	dseq, err := dseqFromFlags(cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	leases, err := leasesForDeployment(cmd.Context(), cctx, cmd.Flags(), dtypes.DeploymentID{
+		Owner: cctx.GetFromAddress().String(),
+		DSeq:  dseq,
+	})
 	if err != nil {
 		return err
 	}
@@ -51,39 +63,69 @@ func doLeaseEvents(cmd *cobra.Command) error {
 		return err
 	}
 
-	follow, err := cmd.Flags().GetBool("follow")
+	follow, err := cmd.Flags().GetBool(flagFollow)
 	if err != nil {
 		return err
 	}
 
-	cert, err := cutils.LoadAndQueryCertificateForAccount(cmd.Context(), cctx, cctx.Keyring)
-	if err != nil {
-		return err
+	ctx := cmd.Context()
+
+	type result struct {
+		lid      mtypes.LeaseID
+		provider sdk.Address
+		error    error
+		stream   *gwrest.LeaseKubeEvents
 	}
 
-	gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
-	if err != nil {
-		return err
-	}
+	streams := make([]result, 0, len(leases))
 
-	result, err := gclient.LeaseEvents(cmd.Context(), bid.LeaseID(), svcs, follow)
-	if err != nil {
-		return showErrorToUser(err)
-	}
-
-	for res := range result.Stream {
-		if err = cmdcommon.PrintJSON(cctx, res); err != nil {
-			break
+	for _, lid := range leases {
+		stream := result{lid: lid}
+		prov, _ := sdk.AccAddressFromBech32(lid.Provider)
+		gclient, err := gwrest.NewClient(akashclient.NewQueryClientFromCtx(cctx), prov, []tls.Certificate{cert})
+		if err == nil {
+			stream.stream, stream.error = gclient.LeaseEvents(ctx, lid, svcs, follow)
+		} else {
+			stream.error = err
 		}
+
+		streams = append(streams, stream)
 	}
 
-	select {
-	case msg, ok := <-result.OnClose:
-		if ok && msg != "" {
-			_ = cctx.PrintString(msg + "\n")
-		}
-	default:
+	var wgStreams sync.WaitGroup
+	type logEntry struct {
+		cltypes.LeaseEvent `json:",inline"`
+		Lid                mtypes.LeaseID `json:"lease_id"`
 	}
+
+	outch := make(chan logEntry)
+
+	go func() {
+		for evt := range outch {
+			_ = cmdcommon.PrintJSON(cctx, evt)
+		}
+	}()
+
+	for _, stream := range streams {
+		if stream.error != nil {
+			continue
+		}
+
+		wgStreams.Add(1)
+		go func(stream result) {
+			defer wgStreams.Done()
+
+			for res := range stream.stream.Stream {
+				outch <- logEntry{
+					LeaseEvent: res,
+					Lid:        stream.lid,
+				}
+			}
+		}(stream)
+	}
+
+	wgStreams.Wait()
+	close(outch)
 
 	return nil
 }


### PR DESCRIPTION
fixes #1250

lease events example
```json
{
  "type": "Warning",
  "time": "0001-01-01T00:00:00Z",
  "reason": "Failed",
  "note": "Error: ImagePullBackOff",
  "object": {
    "kind": "Pod",
    "namespace": "4a7d0egn6o6n277feui0o8457nvr4gt6k3qjvjm0qsdi0",
    "name": "web-7654dc49f7-5mhv6"
  },
  "lease_id": {
    "owner": "akash1zlqr03j0mk04guz9k9t8p0w4tvdqxyzkz2d0pw",
    "dseq": 1,
    "gseq": 1,
    "oseq": 1,
    "provider": "akash1lxl3a62vn0rkzxacyz4zky679jmcwl3n2eqgcw"
  }
}
```

log output as json
```json
{
  "name": "web-68d66d985b-k426m",
  "message": "2021-05-13T07:00:59+0000 ERROR An error is usually an exception that has been caught and not handled.",
  "lease_id": {
    "owner": "akash1zlqr03j0mk04guz9k9t8p0w4tvdqxyzkz2d0pw",
    "dseq": 2,
    "gseq": 1,
    "oseq": 1,
    "provider": "akash1lxl3a62vn0rkzxacyz4zky679jmcwl3n2eqgcw"
  }
}
```

log output as text
```
[akash1zlqr03j0mk04guz9k9t8p0w4tvdqxyzkz2d0pw/2/1/1/akash1lxl3a62vn0rkzxacyz4zky679jmcwl3n2eqgcw][web-68d66d985b-k426m] 2021-05-13T07:00:15+0000 INFO This is less important than debug log and is often used to provide context in the current task.
```

Signed-off-by: Artur Troian <troian.ap@gmail.com>