### PR TITLE
fix(provider): eliminate resource leaks causing OOM

### DIFF
--- a/provider/bidengine/service.go
+++ b/provider/bidengine/service.go
@@ -52,17 +52,17 @@ type Service interface {
 func NewService(ctx context.Context, session session.Session, cluster cluster.Cluster, bus pubsub.Bus, cfg Config) (Service, error) {
 	session = session.ForModule("bidengine-service")
 
+	existingOrders, err := queryExistingOrders(ctx, session)
+	if err != nil {
+		session.Log().Error("finding existing orders", "err", err)
+		return nil, err
+	}
+
 	sub, err := bus.Subscribe()
 	if err != nil {
 		return nil, err
 	}
 
-	existingOrders, err := queryExistingOrders(ctx, session)
-	if err != nil {
-		session.Log().Error("finding existing orders", "err", err)
-		sub.Close()
-		return nil, err
-	}
 	session.Log().Info("found orders", "count", len(existingOrders))
 
 	providerAttrService, err := newProviderAttrSignatureService(session, bus)

--- a/provider/cluster/lease_withdraw.go
+++ b/provider/cluster/lease_withdraw.go
@@ -67,6 +67,7 @@ func (dw *deploymentWithdrawal) run() {
 	if err != nil {
 		dw.log.Error("Could not subscribe to events", "err", err)
 	}
+	defer events.Close()
 
 	const withdrawalPeriod = 24 * time.Hour
 	ticker := time.NewTicker(withdrawalPeriod)

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -116,6 +116,7 @@ func (dm *deploymentManager) run() {
 
 	var runch <-chan error
 
+	var shutdownErr error
 loop:
 	for {
 		select {
@@ -130,8 +131,7 @@ loop:
 			defer dm.hostnameService.ReleaseHostnames(allHostnames)
 			runch = dm.startDeploy()
 
-		case err := <-dm.lc.ShutdownRequest():
-			dm.lc.ShutdownInitiated(err)
+		case shutdownErr = <-dm.lc.ShutdownRequest():
 			break loop
 
 		case mgroup := <-dm.updatech:
@@ -199,6 +199,7 @@ loop:
 			}
 		}
 	}
+	dm.lc.ShutdownInitiated(shutdownErr)
 
 	if runch != nil {
 		<-runch

--- a/provider/manifest/manager.go
+++ b/provider/manifest/manager.go
@@ -35,19 +35,13 @@ var (
 	ErrNoLeaseForDeployment    = errors.New("no lease for deployment")
 )
 
-func newManager(h *service, daddr dtypes.DeploymentID) (*manager, error) {
+func newManager(h *service, daddr dtypes.DeploymentID) *manager {
 	session := h.session.ForModule("manifest-manager")
-
-	sub, err := h.sub.Clone()
-	if err != nil {
-		return nil, err
-	}
 
 	m := &manager{
 		daddr:           daddr,
 		session:         session,
 		bus:             h.bus,
-		sub:             sub,
 		leasech:         make(chan event.LeaseWon),
 		rmleasech:       make(chan mtypes.LeaseID),
 		manifestch:      make(chan manifestRequest),
@@ -61,7 +55,7 @@ func newManager(h *service, daddr dtypes.DeploymentID) (*manager, error) {
 	go m.lc.WatchChannel(h.lc.ShuttingDown())
 	go m.run(h.managerch)
 
-	return m, nil
+	return m
 }
 
 // 'manager' facilitates operations around a configured Deployment.
@@ -70,7 +64,6 @@ type manager struct {
 	daddr   dtypes.DeploymentID
 	session session.Session
 	bus     pubsub.Bus
-	sub     pubsub.Subscriber
 
 	leasech    chan event.LeaseWon
 	rmleasech  chan mtypes.LeaseID


### PR DESCRIPTION
We were running out of memory in prod.

Using the pprof package I could see the number of goroutines in pubsub code kept going up. Also a bunch of them sitting on `WatchChannel` in the `go-lifecycle` package

I changed the following.

1. Make sure we call `.Close()` on all pubsub subscribers
2. Remove a pubsub subscriber we aren't using
3. Move call to `.ShutdownInitiated` to outside of a loop, so that the `WatchChannel` always has the opportunity to terminate