### PR TITLE
fix(provider): Don't log errors for inventory not found

### DIFF
--- a/provider/cluster/inventory.go
+++ b/provider/cluster/inventory.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// errNotFound is the new error with message "not found"
-	errNotFound = errors.New("not found")
+	errReservationNotFound = errors.New("reservation not found")
 	// ErrInsufficientCapacity is the new error when capacity is insufficient
 	ErrInsufficientCapacity = errors.New("insufficient capacity")
 )
@@ -390,7 +390,7 @@ loop:
 			}
 
 			inventoryRequestsCounter.WithLabelValues("lookup", "not-found").Inc()
-			req.ch <- inventoryResponse{err: errNotFound}
+			req.ch <- inventoryResponse{err: errReservationNotFound}
 
 		case req := <-is.unreservech:
 			is.log.Debug("unreserving capacity", "order", req.order)
@@ -414,7 +414,7 @@ loop:
 			}
 
 			inventoryRequestsCounter.WithLabelValues("unreserve", "not-found").Inc()
-			req.ch <- inventoryResponse{err: errNotFound}
+			req.ch <- inventoryResponse{err: errReservationNotFound}
 
 		case responseCh := <-is.statusch:
 			responseCh <- is.getStatus(inventory, reservations)

--- a/provider/cluster/service.go
+++ b/provider/cluster/service.go
@@ -268,7 +268,7 @@ func (s *service) teardownLease(lid mtypes.LeaseID) {
 	if lid.Provider == s.session.Provider().Owner {
 		s.log.Info("unreserving unmanaged order", "lease", lid)
 		err := s.inventory.unreserve(lid.OrderID())
-		if err != nil {
+		if err != nil && !errors.Is(errReservationNotFound, err) {
 			s.log.Error("unreserve failed", "lease", lid, "err", err)
 		}
 	}


### PR DESCRIPTION
We have some fail-safe code to clean up reservations. It's not a big deal. This error gets logged quite a bit in production however after EventLeaseClosed shows up, so I think we should just stop logging it