### PR TITLE
fix(provider): Correct bugs around inventory management

### DIFF
--- a/types/resource.go
+++ b/types/resource.go
@@ -75,7 +75,18 @@ func (m ResourceUnits) Sub(rhs ResourceUnits) (ResourceUnits, error) {
 		return ResourceUnits{}, errCannotSub
 	}
 
-	res := m
+	// Make a deep copy
+	res := ResourceUnits{
+		CPU:       &CPU{},
+		Memory:    &Memory{},
+		Storage:   &Storage{},
+		Endpoints: nil,
+	}
+	*res.CPU = *m.CPU
+	*res.Memory = *m.Memory
+	*res.Storage = *m.Storage
+	res.Endpoints = make([]Endpoint, len(m.Endpoints))
+	copy(res.Endpoints, m.Endpoints)
 
 	if res.CPU != nil {
 		if err := res.CPU.sub(rhs.CPU); err != nil {

--- a/types/resource_test.go
+++ b/types/resource_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"github.com/ovrclk/akash/types/unit"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceUnitsSubIsIdempotent(t *testing.T) {
+	ru := ResourceUnits{
+		CPU:     &CPU{Units: NewResourceValue(1000)},
+		Memory:  &Memory{Quantity: NewResourceValue(10 * unit.Gi)},
+		Storage: &Storage{Quantity: NewResourceValue(10 * unit.Gi)},
+	}
+	cpuAsString := ru.CPU.String()
+	newRu, err := ru.Sub(
+		ResourceUnits{
+			CPU:     &CPU{Units: NewResourceValue(1)},
+			Memory:  &Memory{Quantity: NewResourceValue(0 * unit.Gi)},
+			Storage: &Storage{Quantity: NewResourceValue(0 * unit.Gi)},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, newRu)
+
+	cpuAsStringAfter := ru.CPU.String()
+	require.Equal(t, cpuAsString, cpuAsStringAfter)
+
+	require.Equal(t, newRu.CPU.GetUnits().Value(), uint64(999))
+}

--- a/types/resourcevalue.go
+++ b/types/resourcevalue.go
@@ -6,8 +6,9 @@ import (
 )
 
 var (
-	errOverflow  = errors.Errorf("resource value overflow")
-	errCannotSub = errors.Errorf("cannot sub resources when lhs does not have same units as rhs")
+	errOverflow       = errors.Errorf("resource value overflow")
+	errCannotSub      = errors.Errorf("cannot subtract resources when lhs does not have same units as rhs")
+	errNegativeResult = errors.Errorf("result of subtraction is negative")
 )
 
 /*
@@ -72,7 +73,7 @@ func (m ResourceValue) sub(rhs ResourceValue) (ResourceValue, error) {
 	res = res.Sub(rhs.Val)
 
 	if res.Sign() == -1 {
-		return ResourceValue{}, errCannotSub
+		return ResourceValue{}, errNegativeResult
 	}
 
 	return ResourceValue{res}, nil

--- a/types/resourcevalue_test.go
+++ b/types/resourcevalue_test.go
@@ -22,3 +22,34 @@ func TestSubToNegative(t *testing.T) {
 	_, err := val1.sub(val2)
 	require.Error(t, err)
 }
+
+func TestResourceValueSubIsIdempotent(t *testing.T) {
+	val1 := NewResourceValue(100)
+	before := val1.String()
+	val2 := NewResourceValue(1)
+
+	_, err := val1.sub(val2)
+	require.NoError(t, err)
+	after := val1.String()
+
+	require.Equal(t, before, after)
+}
+
+func TestCPUSubIsNotIdempotent(t *testing.T) {
+	val1 := &CPU{
+		Units:      NewResourceValue(100),
+		Attributes: nil,
+	}
+
+	before := val1.String()
+	val2 := &CPU{
+		Units:      NewResourceValue(1),
+		Attributes: nil,
+	}
+
+	err := val1.sub(val2)
+	require.NoError(t, err)
+	after := val1.String()
+
+	require.NotEqual(t, before, after)
+}


### PR DESCRIPTION
So we had two issues

1. Calling `.Sub()` on `ResourceUnits` was not idempotent. It mutated the receiver. This is wrong.
2. We had a race where we marked a deployment as allocated, so we consider it to be already in the resource counts from kube. But we don't fetch a new inventory data from kube, so this leads to reservations being made that should not be.

I wrote more tests around the provider's inventory code. All I really did here was

1. Correct a copy of a pointer to be a copy of a value
2. Don't process reservations after a deployment is marked `allocated` until we get a new update of the inventory from kubernetes
3. Update some tests that are failing as a result of this fix.