### PR TITLE
WIP: Transfer ingress domain from one deployment to the next

### DIFF
--- a/provider/cluster/client.go
+++ b/provider/cluster/client.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"io"
 	"math/rand"
 	"sync"
@@ -31,6 +30,7 @@ type ReadClient interface {
 	LeaseEvents(context.Context, mtypes.LeaseID, string, bool) (ctypes.EventsWatcher, error)
 	LeaseLogs(context.Context, mtypes.LeaseID, string, bool, *int64) ([]*ctypes.ServiceLog, error)
 	ServiceStatus(context.Context, mtypes.LeaseID, string) (*ctypes.ServiceStatus, error)
+	LeaseHostnames(context.Context, mtypes.LeaseID) ([]string, error)
 }
 
 // Client interface lease and deployment methods
@@ -40,7 +40,6 @@ type Client interface {
 	TeardownLease(context.Context, mtypes.LeaseID) error
 	Deployments(context.Context) ([]ctypes.Deployment, error)
 	Inventory(context.Context) ([]ctypes.Node, error)
-	ClearHostname(ctx context.Context, ownerAddress cosmostypes.Address, dseq uint64, hostname string) error
 }
 
 type node struct {
@@ -255,6 +254,6 @@ func (c *nullClient) Inventory(context.Context) ([]ctypes.Node, error) {
 	}, nil
 }
 
-func (c *nullClient) ClearHostname(ctx context.Context, ownerAddress cosmostypes.Address, dseq uint64, hostname string) error {
-	return nil
+func (c *nullClient) LeaseHostnames(context.Context, mtypes.LeaseID) ([]string, error) {
+	return nil, nil
 }

--- a/provider/cluster/client.go
+++ b/provider/cluster/client.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"bufio"
 	"context"
+	"errors"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"io"
 	"math/rand"
 	"sync"
@@ -19,7 +21,10 @@ import (
 	mtypes "github.com/ovrclk/akash/x/market/types"
 )
 
-var _ Client = (*nullClient)(nil)
+var (
+	_ Client = (*nullClient)(nil)
+	ErrClearHostnameNoMatches = errors.New("clearing hostname, no matches")
+)
 
 type ReadClient interface {
 	LeaseStatus(context.Context, mtypes.LeaseID) (*ctypes.LeaseStatus, error)
@@ -35,6 +40,7 @@ type Client interface {
 	TeardownLease(context.Context, mtypes.LeaseID) error
 	Deployments(context.Context) ([]ctypes.Deployment, error)
 	Inventory(context.Context) ([]ctypes.Node, error)
+	ClearHostname(ctx context.Context, ownerAddress cosmostypes.Address, dseq uint64, hostname string) error
 }
 
 type node struct {
@@ -247,4 +253,8 @@ func (c *nullClient) Inventory(context.Context) ([]ctypes.Node, error) {
 				},
 			}),
 	}, nil
+}
+
+func (c *nullClient) ClearHostname(ctx context.Context, ownerAddress cosmostypes.Address, dseq uint64, hostname string) error {
+	return nil
 }

--- a/provider/cluster/client.go
+++ b/provider/cluster/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	akashv1 "github.com/ovrclk/akash/pkg/apis/akash.network/v1"
 	"io"
 	"math/rand"
 	"sync"
@@ -31,6 +32,8 @@ type ReadClient interface {
 	LeaseLogs(context.Context, mtypes.LeaseID, string, bool, *int64) ([]*ctypes.ServiceLog, error)
 	ServiceStatus(context.Context, mtypes.LeaseID, string) (*ctypes.ServiceStatus, error)
 	LeaseHostnames(context.Context, mtypes.LeaseID) ([]string, error)
+	AllHostnames(context.Context) ([]ActiveHostname, error)
+	GetManifestGroup(context.Context, mtypes.LeaseID) (bool, akashv1.ManifestGroup, error)
 }
 
 // Client interface lease and deployment methods
@@ -40,6 +43,11 @@ type Client interface {
 	TeardownLease(context.Context, mtypes.LeaseID) error
 	Deployments(context.Context) ([]ctypes.Deployment, error)
 	Inventory(context.Context) ([]ctypes.Node, error)
+}
+
+type ActiveHostname struct {
+	ID mtypes.LeaseID
+	Hostnames []string
 }
 
 type node struct {
@@ -255,5 +263,13 @@ func (c *nullClient) Inventory(context.Context) ([]ctypes.Node, error) {
 }
 
 func (c *nullClient) LeaseHostnames(context.Context, mtypes.LeaseID) ([]string, error) {
+	return nil, nil
+}
+
+func (c *nullClient) GetManifestGroup(context.Context, mtypes.LeaseID) (bool, akashv1.ManifestGroup, error) {
+	return false, akashv1.ManifestGroup{}, nil
+}
+
+func (c *nullClient) AllHostnames(context.Context) ([]ActiveHostname, error) {
 	return nil, nil
 }

--- a/provider/cluster/client.go
+++ b/provider/cluster/client.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	_ Client = (*nullClient)(nil)
-	ErrClearHostnameNoMatches = errors.New("clearing hostname, no matches")
+	_                         Client = (*nullClient)(nil)
+	ErrClearHostnameNoMatches        = errors.New("clearing hostname, no matches")
 )
 
 type ReadClient interface {
@@ -36,7 +36,7 @@ type ReadClient interface {
 // Client interface lease and deployment methods
 type Client interface {
 	ReadClient
-	Deploy(context.Context, mtypes.LeaseID, *manifest.Group) error
+	Deploy(ctx context.Context, lID mtypes.LeaseID, mgroup *manifest.Group, holdHostnames []string) error
 	TeardownLease(context.Context, mtypes.LeaseID) error
 	Deployments(context.Context) ([]ctypes.Deployment, error)
 	Inventory(context.Context) ([]ctypes.Node, error)
@@ -107,7 +107,7 @@ func NullClient() Client {
 	}
 }
 
-func (c *nullClient) Deploy(ctx context.Context, lid mtypes.LeaseID, mgroup *manifest.Group) error {
+func (c *nullClient) Deploy(ctx context.Context, lid mtypes.LeaseID, mgroup *manifest.Group, holdHostnames []string) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/provider/cluster/hostname.go
+++ b/provider/cluster/hostname.go
@@ -221,12 +221,10 @@ type hostnameService struct {
 
 const HostnameSeparator = '.'
 
-func newHostnameService(ctx context.Context, cfg Config) *hostnameService {
-
+func newHostnameService(ctx context.Context, cfg Config, initialData map[string]dtypes.DeploymentID) *hostnameService {
 	blockedHostnames := make([]string, 0)
 	blockedDomains := make([]string, 0)
 	for _, name := range cfg.BlockedHostnames {
-
 		if len(name) != 0 && name[0] == HostnameSeparator {
 			blockedDomains = append(blockedDomains, name)
 			blockedHostnames = append(blockedHostnames, name[1:])
@@ -236,7 +234,7 @@ func newHostnameService(ctx context.Context, cfg Config) *hostnameService {
 	}
 
 	hs := &hostnameService{
-		inUse:            make(map[string]dtypes.DeploymentID),
+		inUse:            make(map[string]dtypes.DeploymentID, len(initialData)),
 		blockedHostnames: blockedHostnames,
 		blockedDomains:   blockedDomains,
 		requests:         make(chan reserveRequest),
@@ -244,6 +242,9 @@ func newHostnameService(ctx context.Context, cfg Config) *hostnameService {
 		releases:         make(chan dtypes.DeploymentID),
 		lc:               lifecycle.New(),
 		prepareRequest: make(chan prepareTransferRequest),
+	}
+	for k, v := range initialData {
+		hs.inUse[k] = v
 	}
 
 	go hs.lc.WatchContext(ctx)

--- a/provider/cluster/hostname.go
+++ b/provider/cluster/hostname.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	lifecycle "github.com/boz/go-lifecycle"
-	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	"github.com/pkg/errors"
 	"strings"
@@ -14,7 +14,7 @@ import (
 type HostnameServiceClient interface {
 	ReserveHostnames(hostnames []string, dID dtypes.DeploymentID) ReservationResult
 	ReleaseHostnames(dID dtypes.DeploymentID)
-	CanReserveHostnames(hostnames []string, ownerAddr cosmostypes.Address) <-chan error
+	CanReserveHostnames(hostnames []string, ownerAddr sdktypes.Address) <-chan error
 	PrepareHostnamesForTransfer(hostnames []string, dID dtypes.DeploymentID) <- chan error
 }
 
@@ -137,7 +137,7 @@ func reserveHostnamesImpl(store map[string]dtypes.DeploymentID, hostnames []stri
 	return
 }
 
-func (sh *SimpleHostnames) CanReserveHostnames(hostnames []string, ownerAddr cosmostypes.Address) <-chan error {
+func (sh *SimpleHostnames) CanReserveHostnames(hostnames []string, ownerAddr sdktypes.Address) <-chan error {
 	sh.lock.Lock()
 	defer sh.lock.Unlock()
 	ch := make(chan error, 1)
@@ -145,7 +145,7 @@ func (sh *SimpleHostnames) CanReserveHostnames(hostnames []string, ownerAddr cos
 	return ch
 }
 
-func canReserveHostnamesImpl(store map[string]dtypes.DeploymentID, hostnames []string, ownerAddr cosmostypes.Address, chErr chan<- error) {
+func canReserveHostnamesImpl(store map[string]dtypes.DeploymentID, hostnames []string, ownerAddr sdktypes.Address, chErr chan<- error) {
 	for _, hostname := range hostnames {
 		usedByDid, inUse := store[hostname]
 
@@ -196,7 +196,7 @@ type reserveRequest struct {
 type canReserveRequest struct {
 	hostnames []string
 	result    chan<- error
-	ownerAddr cosmostypes.Address
+	ownerAddr sdktypes.Address
 }
 
 type prepareTransferRequest struct {
@@ -363,7 +363,7 @@ func (hs *hostnameService) ReleaseHostnames(dID dtypes.DeploymentID) {
 	}
 }
 
-func (hs *hostnameService) CanReserveHostnames(hostnames []string, ownerAddr cosmostypes.Address) <-chan error {
+func (hs *hostnameService) CanReserveHostnames(hostnames []string, ownerAddr sdktypes.Address) <-chan error {
 	returnValue := make(chan error, 1) // Buffer of one so service does not block
 	lowercaseHostnames := make([]string, len(hostnames))
 	for i, hostname := range hostnames {

--- a/provider/cluster/hostname.go
+++ b/provider/cluster/hostname.go
@@ -73,6 +73,7 @@ func prepareHostnamesImpl(store map[string]dtypes.DeploymentID, hostnames []stri
 	for _, hostname := range toChange {
 		store[hostname] = dID
 	}
+	close(errCh)
 }
 
 func (sh *SimpleHostnames) ReserveHostnames(hostnames []string, dID dtypes.DeploymentID) ReservationResult {
@@ -242,6 +243,7 @@ func newHostnameService(ctx context.Context, cfg Config) *hostnameService {
 		canRequest:       make(chan canReserveRequest),
 		releases:         make(chan dtypes.DeploymentID),
 		lc:               lifecycle.New(),
+		prepareRequest: make(chan prepareTransferRequest),
 	}
 
 	go hs.lc.WatchContext(ctx)

--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -3,11 +3,14 @@ package kube
 import (
 	"context"
 	"fmt"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	metricsutils "github.com/ovrclk/akash/util/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	netv1 "k8s.io/api/networking/v1"
 	"os"
 	"path"
+	"strings"
 
 	"k8s.io/client-go/util/flowcontrol"
 
@@ -134,6 +137,93 @@ func openKubeConfig(cfgPath string, log log.Logger) (*rest.Config, error) {
 
 	log.Info("using in cluster kube config")
 	return rest.InClusterConfig()
+}
+
+func (c *client) ClearHostname(ctx context.Context, ownerAddress cosmostypes.Address, dseq uint64, hostname string) error {
+	labelSelector := &strings.Builder{}
+	_, _ = fmt.Fprintf(labelSelector, "%s=%s", akashLeaseOwnerLabelName, ownerAddress.String())
+	_, _ = fmt.Fprintf(labelSelector, ",%s=%d", akashLeaseDSeqLabelName, dseq)
+
+	namespaces, err := c.kc.CoreV1().Namespaces().List(ctx,metav1.ListOptions{
+		TypeMeta:             metav1.TypeMeta{},
+		LabelSelector:        labelSelector.String(),
+		FieldSelector:        "",
+		Watch:                false,
+		AllowWatchBookmarks:  false,
+		ResourceVersion:      "",
+		ResourceVersionMatch: "",
+		TimeoutSeconds:       nil,
+		Limit:                0,
+		Continue:             "",
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if 0 == len(namespaces.Items){
+		return cluster.ErrClearHostnameNoMatches
+	}
+
+	// Note that namespace here is always the empty string
+	leaseNamespace := namespaces.Items[0].Name
+
+	fmt.Printf("found namespace: %+v\n", namespaces.Items[0])
+	c.log.Debug("searching for ingress", "namespace", leaseNamespace, "hostname", hostname)
+
+	ingresses, err := c.kc.NetworkingV1().Ingresses(leaseNamespace).List(ctx, metav1.ListOptions{})
+
+	var ingressToModify netv1.Ingress
+	found := false
+	search:
+	for _, ingress := range ingresses.Items {
+		for _, rule := range ingress.Spec.Rules {
+			if hostname == rule.Host {
+				ingressToModify = ingress
+				found = true
+				break search
+			}
+		}
+	}
+
+	if !found {
+		return cluster.ErrClearHostnameNoMatches
+	}
+
+	rules := ingressToModify.Spec.Rules
+	if len(rules) == 1 { // TODO - I do not think this ever executes???
+		// Delete the Ingress
+		err := c.kc.NetworkingV1().Ingresses(leaseNamespace).Delete(ctx, ingressToModify.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("%w: while deleting ingress %q for host %q", err, ingressToModify.Name, hostname)
+		}
+		return nil
+	}
+
+	newRules := make([]netv1.IngressRule, 0, len(rules) - 1)
+	for _, rule := range rules {
+		if rule.Host != hostname {
+			newRules = append(newRules, rule)
+		}
+	}
+
+	newIngress := netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   ingressToModify.ObjectMeta.Name,
+			Labels: ingressToModify.ObjectMeta.Labels,
+			Namespace: leaseNamespace,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: newRules,
+		},
+	}
+
+	fmt.Printf("updated ingress: %+v\n", newIngress)
+	_, err = c.kc.NetworkingV1().Ingresses(leaseNamespace).Update(ctx, &newIngress, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("%w: while updating ingress %q to remove host %q", err, newIngress.Name, hostname)
+	}
+	return nil
 }
 
 func (c *client) Deployments(ctx context.Context) ([]ctypes.Deployment, error) {

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -261,11 +261,17 @@ func (dm *deploymentManager) doDeploy() error {
 	// Reservation was successful, check to see if any hostnames are being migrated
 	if len(changedHostnames) != 0 {
 		dm.log.Info("deploy taking over hostnames", "count", len(changedHostnames))
+		ownerAddr, err := dm.lease.DeploymentID().GetOwnerAddress()
+		if err != nil {
+			return err
+		}
 
 		// Strip each and every hostname from its existing deployment within kubernetes
 		for _, changedHostname := range changedHostnames {
-			_ = changedHostname
-			//dm.client.ClearHostname(dm.lease.Owner, changedHostname.PreviousDeploymentSequence, changedHostname.Hostname)
+			err = dm.client.ClearHostname(ctx, ownerAddr, changedHostname.PreviousDeploymentSequence, changedHostname.Hostname)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -121,7 +121,7 @@ func (dm *deploymentManager) run() {
 	deployHostnamesCh, runch := dm.startDeploy(true)
 
 	// TODO - update me so that a list does not have to be passed in
-	defer dm.hostnameService.ReleaseHostnames(nil, dm.lease.DeploymentID())
+	defer dm.hostnameService.ReleaseHostnames(dm.lease.DeploymentID())
 
 	var okNotify <-chan struct{}
 

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -149,6 +149,9 @@ func (dm *deploymentManager) run() {
 
 	runch := dm.startDeploy()
 
+	// TODO - somehow at this point if this deployment holds a hostname
+	// which is also requested for use by any other deployment with the same owner
+	// then the hostname should get moved back to the other deployment at this time
 	defer dm.hostnameService.ReleaseHostnames(dm.lease.DeploymentID())
 
 loop:

--- a/provider/cluster/service_transfer_hostnames.go
+++ b/provider/cluster/service_transfer_hostnames.go
@@ -233,6 +233,9 @@ func (xferMgr *transferHostnamesManager) completeTransferWhenReady(ctx context.C
 		skipping := make([]mtypes.LeaseID, 0, len(xferMgr.toPurge))
 		releasedHostnames := make(map[mtypes.LeaseID]struct{})
 		const pollingPeriod = 10*time.Second
+		// TODO - this polling behavior seems to cause a period where the ingress returns 404
+		// because it briefly doesn't have a configured ingress for the hostname. This can probably be solved
+		// by more agressive polling
 		polling := time.NewTicker(pollingPeriod)
 		for {
 			select {

--- a/provider/cluster/service_transfer_hostnames.go
+++ b/provider/cluster/service_transfer_hostnames.go
@@ -2,182 +2,110 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"github.com/ovrclk/akash/provider/event"
 	"github.com/ovrclk/akash/pubsub"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
 	mtypes "github.com/ovrclk/akash/x/market/types"
+	"github.com/tendermint/tendermint/libs/log"
 	"time"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 )
 
 type transferHostnamesRequest struct {
 	hostnames []string
 	destination dtypes.DeploymentID
+	errCh chan <- error
 }
 
-func (s *service) transferHostnames(req transferHostnamesRequest) {
+type transferHostnamesManager struct {
+	hostnames []string
+	ownerAddr sdktypes.Address
+	destinationID dtypes.DeploymentID
+	toPurge map[mtypes.LeaseID]*deploymentManager
+	destination []*deploymentManager
+
+	cancel context.CancelFunc
+
+	log log.Logger
+
+	client Client
+}
+
+var errDestintationDeploymentDoesNotExist = errors.New("destination deployment does not exist")
+var errTransferRunning = errors.New("hostname transfer already running")
+
+func (s *service) transferHostnames(req transferHostnamesRequest) error {
 	ownerAddr, err := req.destination.GetOwnerAddress()
 	if err != nil {
-		return
+		return err
 	}
 
-	var dst *deploymentManager
-	toPurge := make(map[mtypes.LeaseID]*deploymentManager)
+	// One transfer running at any time per owner, to avoid any strange race conditions
+	_, exists := s.xferHostnameManagers[ownerAddr.String()]
+	if exists {
+		return errTransferRunning
+	}
+
+	xferMgr := &transferHostnamesManager{
+		hostnames: req.hostnames,
+		ownerAddr: ownerAddr,
+		destinationID: req.destination,
+		toPurge: make(map[mtypes.LeaseID]*deploymentManager),
+		log : s.log.With("owner", ownerAddr.String()),
+		client: s.client,
+	}
+	s.xferHostnameManagers[ownerAddr.String()] = xferMgr
+
+	// Find all deployment managers that need to be forced to update
 	for managerLeaseID, mgr := range s.managers {
 		leaseOwnerAddr, err := managerLeaseID.DeploymentID().GetOwnerAddress()
 		if err != nil {
-			return
+			return err
 		}
+		// sort into groups to either be purged or the destination groups
 		if req.destination.Equals(managerLeaseID.DeploymentID()) {
-			dst = mgr
+			xferMgr.destination = append(xferMgr.destination, mgr)
 		} else if ownerAddr.Equals(leaseOwnerAddr) {
-			toPurge[managerLeaseID] = mgr
+			xferMgr.toPurge[managerLeaseID] = mgr
 		}
 	}
-
-	log := s.log.With("owner", ownerAddr.String())
 
 	// Check that the destination is running
-	if dst == nil {
-		log.Error("destination deployment does not exist", "dseq", req.destination.DSeq)
-		return
+	if len(xferMgr.destination) == 0 {
+		xferMgr.log.Error("destination deployment does not exist", "dseq", req.destination.DSeq)
+		return errDestintationDeploymentDoesNotExist
 	}
 
-	// TODO - use an exclusive lock to prevent double running this
-	ctx, cancel := context.WithCancel(context.Background())
+	var ctx context.Context
+	ctx, xferMgr.cancel = context.WithCancel(context.Background())
 	go func() {
 		select {
 		case <- s.lc.ShuttingDown():
-			cancel()
+			xferMgr.cancel()
 		case <- ctx.Done():
 			return
 		}
 	}()
 
 	var ready chan struct{}
-	if len(toPurge) != 0 {
+
+	// If there is at least 1 source manager, then run the purge routines
+	if len(xferMgr.toPurge) != 0 {
 		sub, err := s.bus.Subscribe()
 		if err != nil {
-			cancel()
-			return
+			xferMgr.cancel()
+			return err
 		}
-		// Wait for each one to complete
-		toCheck := make(chan mtypes.LeaseID, len(toPurge))
-		go func() {
-			defer sub.Close()
-			// TODO - query the cluster to determine what deployments need to
-			// actually change
-			for k, mgr := range toPurge {
-				err = mgr.force()
-				if err != nil {
-					log.Error("failed forcing purge", "dseq", k.DSeq)
-					cancel()
-					return
-				}
 
-			}
-
-			for {
-				sent := make(map[mtypes.LeaseID]struct{}, len(toPurge))
-				var ev pubsub.Event
-				select {
-				case ev = <-sub.Events():
-
-				case <-ctx.Done():
-					return
-				}
-
-				deploymentEvent, ok := ev.(event.ClusterDeployment)
-				if !ok {
-					continue
-				}
-
-				if deploymentEvent.Status != event.ClusterDeploymentUpdated {
-					continue
-				}
-
-				_, isWaitingOn := toPurge[deploymentEvent.LeaseID]
-				if !isWaitingOn {
-					continue
-				}
-
-				_, alreadySent := sent[deploymentEvent.LeaseID]
-				if !alreadySent {
-					log.Info("Got deployment update event for", "lease", deploymentEvent.LeaseID)
-					toCheck <- deploymentEvent.LeaseID
-					sent[deploymentEvent.LeaseID] = struct{}{}
-				}
-			}
-		}()
-
-		ready = make(chan struct{}, 1)
-		go func () {
-			checking := make([]mtypes.LeaseID, 0, len(toPurge))
-			releasedHostnames := make(map[mtypes.LeaseID]struct{})
-			polling := time.NewTicker(10 * time.Second)
-			for {
-				select {
-				case lID := <-toCheck:
-					checking = append(checking, lID)
-					continue
-				case <-polling.C:
-
-				case <-ctx.Done():
-					return
-				}
-
-				stillChecking := false
-				for _, lID := range checking {
-					_, done := releasedHostnames[lID]
-					if done {
-						continue
-					}
-
-					log.Info("Checking hostnames of", "lease", lID)
-					hostnames, err := s.client.LeaseHostnames(ctx, lID)
-					if err != nil {
-						log.Error("failed checking hostnames of", "lease", lID, "err", err)
-						cancel()
-						return
-					}
-
-					inUse := checkForStringIntersection(req.hostnames, hostnames)
-					if inUse {
-						stillChecking = true
-					} else {
-						releasedHostnames[lID] = struct{}{}
-					}
-
-				}
-
-				if !stillChecking {
-					break
-				}
-			}
-			select {
-				case ready <- struct{}{}:
-				default:
-			}
-		}()
+		toCheck, toSkip := xferMgr.waitForPurge(ctx, sub)
+		ready = make(chan struct{})
+		xferMgr.waitForHostnamesAvailable(ctx, toCheck, toSkip, ready)
 	}
 
-	go func (){
-		if ready != nil {
-			// Wait for everything to be ready or for something to fail
-			select {
-			case <-ready:
-			case <-ctx.Done():
-				return
-			}
-		}
+	xferMgr.completeTransferWhenReady(ctx, ready, s.xferHostnameManagerCh)
 
-		cancel() // Cancel everything
-		log.Info("running final update to takeover hostnames")
-		// Run the destination so it can pickup the hostnames
-		err = dst.force()
-		if err != nil {
-			log.Error("failed final update")
-		}
-	}()
+	return nil
 }
 
 func checkForStringIntersection(lhs, rhs []string) bool{
@@ -194,4 +122,162 @@ func checkForStringIntersection(lhs, rhs []string) bool{
 	}
 
 	return false
+}
+func (xferMgr *transferHostnamesManager) failNow(){
+	xferMgr.cancel()
+}
+
+func (xferMgr *transferHostnamesManager) completeTransferWhenReady(ctx context.Context, ready <- chan struct{}, done chan <- *transferHostnamesManager) {
+	go func (){
+		defer func (){
+			// Tell the parent we are complete
+			done <- xferMgr
+		}()
+
+		if ready != nil {
+			// Wait for everything to be ready or for something to fail
+			select {
+			case <-ready:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		xferMgr.cancel() // Cancel everything
+		xferMgr.log.Info("running final update to takeover hostnames")
+		// Run the destination so it can pickup the hostnames
+		for _, dst := range xferMgr.destination {
+			err := dst.force()
+			if err != nil {
+				xferMgr.log.Error("failed final update", "err", err)
+			}
+		}
+	}()
+}
+
+ func (xferMgr *transferHostnamesManager) waitForPurge(ctx context.Context, sub pubsub.Subscriber) (<- chan mtypes.LeaseID, <- chan mtypes.LeaseID){
+	 toCheck := make(chan mtypes.LeaseID, len(xferMgr.toPurge))
+	 toSkip := make(chan mtypes.LeaseID, len(xferMgr.toPurge))
+
+	 go func() {
+		 defer sub.Close()
+		 sent := make(map[mtypes.LeaseID]struct{}, len(xferMgr.toPurge))
+
+		 for k, mgr := range xferMgr.toPurge {
+			 // query the cluster to determine what deployments need to
+			 // actually change
+			 hostnames, err := xferMgr.client.LeaseHostnames(ctx, k)
+			 if err != nil {
+			 	xferMgr.log.Error("failed checking for hostnames", "dseq", k.DSeq, "err", "err")
+			 	xferMgr.failNow()
+			 	return
+			 }
+			 usesAtLeastOneHostname := checkForStringIntersection(hostnames, xferMgr.hostnames)
+
+			 if !usesAtLeastOneHostname {
+			 	toSkip <- k
+			 	sent[k] = struct{}{} // suppress sending this to the other channel
+			 	continue
+			 }
+
+			 err = mgr.force()
+			 if err != nil {
+				 xferMgr.log.Error("failed forcing purge", "dseq", k.DSeq, "err", err)
+				 xferMgr.failNow()
+				 return
+			 }
+		 }
+
+		 for {
+			 var ev pubsub.Event
+			 select {
+			 case ev = <-sub.Events():
+
+			 case <-ctx.Done():
+				 return
+			 }
+
+			 deploymentEvent, ok := ev.(event.ClusterDeployment)
+			 if !ok {
+				 continue
+			 }
+
+			 if deploymentEvent.Status != event.ClusterDeploymentUpdated {
+				 continue
+			 }
+
+			 _, isWaitingOn := xferMgr.toPurge[deploymentEvent.LeaseID]
+			 if !isWaitingOn {
+				 continue
+			 }
+
+			 _, alreadySent := sent[deploymentEvent.LeaseID]
+			 if !alreadySent {
+				 xferMgr.log.Info("Got deployment update event for", "lease", deploymentEvent.LeaseID)
+				 toCheck <- deploymentEvent.LeaseID
+				 sent[deploymentEvent.LeaseID] = struct{}{}
+			 }
+
+			 if len(sent) == len(xferMgr.toPurge) {
+			 	break
+			 }
+		 }
+	 }()
+
+	 return toCheck, toSkip
+ }
+
+ func (xferMgr *transferHostnamesManager) waitForHostnamesAvailable(ctx context.Context, toCheck <- chan mtypes.LeaseID, toSkip <- chan mtypes.LeaseID, ready chan struct{}) {
+ 	go func() {
+		checking := make([]mtypes.LeaseID, 0, len(xferMgr.toPurge))
+		skipping := make([]mtypes.LeaseID, 0, len(xferMgr.toPurge))
+		releasedHostnames := make(map[mtypes.LeaseID]struct{})
+		const pollingPeriod = 10*time.Second
+		polling := time.NewTicker(pollingPeriod)
+		for {
+			select {
+			case lID := <-toCheck:
+				checking = append(checking, lID)
+				continue
+			case lID := <- toSkip:
+				skipping = append(skipping, lID)
+				continue
+			case <-polling.C:
+				polling.Stop()
+
+			case <-ctx.Done():
+				return
+			}
+
+			stillChecking := false
+			for _, lID := range checking {
+				_, done := releasedHostnames[lID]
+				if done {
+					continue
+				}
+
+				xferMgr.log.Info("Checking hostnames of", "lease", lID)
+				hostnames, err := xferMgr.client.LeaseHostnames(ctx, lID)
+				if err != nil {
+					xferMgr.log.Error("failed checking hostnames of", "lease", lID, "err", err)
+					xferMgr.failNow()
+					return
+				}
+
+				inUse := checkForStringIntersection(xferMgr.hostnames, hostnames)
+				if inUse {
+					stillChecking = true
+				} else {
+					releasedHostnames[lID] = struct{}{}
+				}
+
+			}
+
+			if !stillChecking && len(checking) + len(skipping) == len(xferMgr.toPurge) {
+				break
+			}
+			polling.Reset(pollingPeriod)
+		}
+		close(ready)
+	}()
 }

--- a/provider/cluster/service_transfer_hostnames.go
+++ b/provider/cluster/service_transfer_hostnames.go
@@ -34,17 +34,15 @@ func (s *service) transferHostnames(req transferHostnamesRequest) {
 		}
 	}
 
+	log := s.log.With("owner", ownerAddr.String())
+
 	// Check that the destination is running
 	if dst == nil {
+		log.Error("destination deployment does not exist", "dseq", req.destination.DSeq)
 		return
 	}
 
 	// TODO - use an exclusive lock to prevent double running this
-	sub, err := s.bus.Subscribe()
-	if err != nil {
-		return
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		select {
@@ -55,100 +53,124 @@ func (s *service) transferHostnames(req transferHostnamesRequest) {
 		}
 	}()
 
-	log := s.log.With("owner", ownerAddr.String())
-
-	// Wait for each one to complete
-	toCheck := make(chan mtypes.LeaseID, len(toPurge))
-	go func () {
-		defer sub.Close()
-		// TODO - query the cluster to determine what deployments need to
-		// actually change
-		for _, mgr := range toPurge {
-			err = mgr.force()
-			if err != nil {
-				return
-			}
-
+	var ready chan struct{}
+	if len(toPurge) != 0 {
+		sub, err := s.bus.Subscribe()
+		if err != nil {
+			cancel()
+			return
 		}
-
-
-		for {
-			sent := make(map[mtypes.LeaseID]struct{}, len(toPurge))
-			var ev pubsub.Event
-			select {
-			case ev = <-sub.Events():
-
-			case <-ctx.Done():
-				return
-			}
-
-			deploymentEvent, ok := ev.(event.ClusterDeployment)
-			if !ok {
-				continue
-			}
-
-			if deploymentEvent.Status != event.ClusterDeploymentUpdated {
-				continue
-			}
-
-			_, isWaitingOn := toPurge[deploymentEvent.LeaseID]
-			if !isWaitingOn {
-				continue
-			}
-
-			_, alreadySent := sent[deploymentEvent.LeaseID]
-			if !alreadySent {
-				log.Info("Got deployment update event for", "lease", deploymentEvent.LeaseID)
-				toCheck <- deploymentEvent.LeaseID
-				sent[deploymentEvent.LeaseID] = struct{}{}
-			}
-		}
-	}()
-
-	go func () {
-		checking := make([]mtypes.LeaseID, 0, len(toPurge))
-		releasedHostnames := make(map[mtypes.LeaseID]struct{})
-		polling := time.NewTicker(10 * time.Second)
-		for {
-			select {
-			case lID := <-toCheck:
-				checking = append(checking, lID)
-				continue
-			case <-polling.C:
-
-			case <-ctx.Done():
-				return
-			}
-
-			stillChecking := false
-			for _, lID := range checking {
-				_, done := releasedHostnames[lID]
-				if done {
-					continue
-				}
-
-				log.Info("Checking hostnames of", "lease", lID)
-				hostnames, err := s.client.LeaseHostnames(ctx, lID)
+		// Wait for each one to complete
+		toCheck := make(chan mtypes.LeaseID, len(toPurge))
+		go func() {
+			defer sub.Close()
+			// TODO - query the cluster to determine what deployments need to
+			// actually change
+			for k, mgr := range toPurge {
+				err = mgr.force()
 				if err != nil {
-					log.Error("failed checking hostnames of", "lease", lID, "err", err)
+					log.Error("failed forcing purge", "dseq", k.DSeq)
+					cancel()
 					return
 				}
 
-				inUse := checkForStringIntersection(req.hostnames, hostnames)
-				if inUse {
-					stillChecking = true
-				} else {
-					releasedHostnames[lID] = struct{}{}
-				}
-
 			}
 
+			for {
+				sent := make(map[mtypes.LeaseID]struct{}, len(toPurge))
+				var ev pubsub.Event
+				select {
+				case ev = <-sub.Events():
 
-			if !stillChecking {
-				break
+				case <-ctx.Done():
+					return
+				}
+
+				deploymentEvent, ok := ev.(event.ClusterDeployment)
+				if !ok {
+					continue
+				}
+
+				if deploymentEvent.Status != event.ClusterDeploymentUpdated {
+					continue
+				}
+
+				_, isWaitingOn := toPurge[deploymentEvent.LeaseID]
+				if !isWaitingOn {
+					continue
+				}
+
+				_, alreadySent := sent[deploymentEvent.LeaseID]
+				if !alreadySent {
+					log.Info("Got deployment update event for", "lease", deploymentEvent.LeaseID)
+					toCheck <- deploymentEvent.LeaseID
+					sent[deploymentEvent.LeaseID] = struct{}{}
+				}
+			}
+		}()
+
+		ready = make(chan struct{}, 1)
+		go func () {
+			checking := make([]mtypes.LeaseID, 0, len(toPurge))
+			releasedHostnames := make(map[mtypes.LeaseID]struct{})
+			polling := time.NewTicker(10 * time.Second)
+			for {
+				select {
+				case lID := <-toCheck:
+					checking = append(checking, lID)
+					continue
+				case <-polling.C:
+
+				case <-ctx.Done():
+					return
+				}
+
+				stillChecking := false
+				for _, lID := range checking {
+					_, done := releasedHostnames[lID]
+					if done {
+						continue
+					}
+
+					log.Info("Checking hostnames of", "lease", lID)
+					hostnames, err := s.client.LeaseHostnames(ctx, lID)
+					if err != nil {
+						log.Error("failed checking hostnames of", "lease", lID, "err", err)
+						cancel()
+						return
+					}
+
+					inUse := checkForStringIntersection(req.hostnames, hostnames)
+					if inUse {
+						stillChecking = true
+					} else {
+						releasedHostnames[lID] = struct{}{}
+					}
+
+				}
+
+				if !stillChecking {
+					break
+				}
+			}
+			select {
+				case ready <- struct{}{}:
+				default:
+			}
+		}()
+	}
+
+	go func (){
+		if ready != nil {
+			// Wait for everything to be ready or for something to fail
+			select {
+			case <-ready:
+			case <-ctx.Done():
+				return
 			}
 		}
 
+		cancel() // Cancel everything
 		log.Info("running final update to takeover hostnames")
 		// Run the destination so it can pickup the hostnames
 		err = dst.force()

--- a/provider/cluster/service_transfer_hostnames.go
+++ b/provider/cluster/service_transfer_hostnames.go
@@ -1,0 +1,175 @@
+package cluster
+
+import (
+	"context"
+	"github.com/ovrclk/akash/provider/event"
+	"github.com/ovrclk/akash/pubsub"
+	dtypes "github.com/ovrclk/akash/x/deployment/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	"time"
+)
+
+type transferHostnamesRequest struct {
+	hostnames []string
+	destination dtypes.DeploymentID
+}
+
+func (s *service) transferHostnames(req transferHostnamesRequest) {
+	ownerAddr, err := req.destination.GetOwnerAddress()
+	if err != nil {
+		return
+	}
+
+	var dst *deploymentManager
+	toPurge := make(map[mtypes.LeaseID]*deploymentManager)
+	for managerLeaseID, mgr := range s.managers {
+		leaseOwnerAddr, err := managerLeaseID.DeploymentID().GetOwnerAddress()
+		if err != nil {
+			return
+		}
+		if req.destination.Equals(managerLeaseID.DeploymentID()) {
+			dst = mgr
+		} else if ownerAddr.Equals(leaseOwnerAddr) {
+			toPurge[managerLeaseID] = mgr
+		}
+	}
+
+	// Check that the destination is running
+	if dst == nil {
+		return
+	}
+
+	// TODO - use an exclusive lock to prevent double running this
+	sub, err := s.bus.Subscribe()
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <- s.lc.ShuttingDown():
+			cancel()
+		case <- ctx.Done():
+			return
+		}
+	}()
+
+	log := s.log.With("owner", ownerAddr.String())
+
+	// Wait for each one to complete
+	toCheck := make(chan mtypes.LeaseID, len(toPurge))
+	go func () {
+		defer sub.Close()
+		// TODO - query the cluster to determine what deployments need to
+		// actually change
+		for _, mgr := range toPurge {
+			err = mgr.force()
+			if err != nil {
+				return
+			}
+
+		}
+
+
+		for {
+			sent := make(map[mtypes.LeaseID]struct{}, len(toPurge))
+			var ev pubsub.Event
+			select {
+			case ev = <-sub.Events():
+
+			case <-ctx.Done():
+				return
+			}
+
+			deploymentEvent, ok := ev.(event.ClusterDeployment)
+			if !ok {
+				continue
+			}
+
+			if deploymentEvent.Status != event.ClusterDeploymentUpdated {
+				continue
+			}
+
+			_, isWaitingOn := toPurge[deploymentEvent.LeaseID]
+			if !isWaitingOn {
+				continue
+			}
+
+			_, alreadySent := sent[deploymentEvent.LeaseID]
+			if !alreadySent {
+				log.Info("Got deployment update event for", "lease", deploymentEvent.LeaseID)
+				toCheck <- deploymentEvent.LeaseID
+				sent[deploymentEvent.LeaseID] = struct{}{}
+			}
+		}
+	}()
+
+	go func () {
+		checking := make([]mtypes.LeaseID, 0, len(toPurge))
+		releasedHostnames := make(map[mtypes.LeaseID]struct{})
+		polling := time.NewTicker(10 * time.Second)
+		for {
+			select {
+			case lID := <-toCheck:
+				checking = append(checking, lID)
+				continue
+			case <-polling.C:
+
+			case <-ctx.Done():
+				return
+			}
+
+			stillChecking := false
+			for _, lID := range checking {
+				_, done := releasedHostnames[lID]
+				if done {
+					continue
+				}
+
+				log.Info("Checking hostnames of", "lease", lID)
+				hostnames, err := s.client.LeaseHostnames(ctx, lID)
+				if err != nil {
+					log.Error("failed checking hostnames of", "lease", lID, "err", err)
+					return
+				}
+
+				inUse := checkForStringIntersection(req.hostnames, hostnames)
+				if inUse {
+					stillChecking = true
+				} else {
+					releasedHostnames[lID] = struct{}{}
+				}
+
+			}
+
+
+			if !stillChecking {
+				break
+			}
+		}
+
+		log.Info("running final update to takeover hostnames")
+		// Run the destination so it can pickup the hostnames
+		err = dst.force()
+		if err != nil {
+			log.Error("failed final update")
+		}
+	}()
+}
+
+func checkForStringIntersection(lhs, rhs []string) bool{
+	m := make(map[string]struct{})
+	for _, v := range lhs {
+		m[v] = struct{}{}
+	}
+
+	for _, v := range rhs {
+		_, ok := m[v]
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/provider/event/events.go
+++ b/provider/event/events.go
@@ -38,6 +38,8 @@ func (ev ManifestReceived) ManifestGroup() *manifest.Group {
 type ClusterDeploymentStatus string
 
 const (
+	// ClusterDeploymentUpdated is used whenever the deployment in the cluster is updated but may not be functional
+	ClusterDeploymentUpdated  ClusterDeploymentStatus = "updated"
 	// ClusterDeploymentPending is used when cluster deployment status is pending
 	ClusterDeploymentPending ClusterDeploymentStatus = "pending"
 	// ClusterDeploymentDeployed is used when cluster deployment status is deployed

--- a/provider/gateway/rest/middleware.go
+++ b/provider/gateway/rest/middleware.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -64,6 +65,7 @@ func requireOwner() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				fmt.Printf("no peer certificates\n")
 				http.Error(w, "", http.StatusUnauthorized)
 				return
 			}
@@ -72,6 +74,7 @@ func requireOwner() mux.MiddlewareFunc {
 			// so only thing left to do is get account id stored in the CommonName
 			owner, err := sdk.AccAddressFromBech32(r.TLS.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
+				fmt.Printf("failed extracting owner key from cert\n")
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}

--- a/provider/gateway/rest/middleware.go
+++ b/provider/gateway/rest/middleware.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -65,7 +64,6 @@ func requireOwner() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
-				fmt.Printf("no peer certificates\n")
 				http.Error(w, "", http.StatusUnauthorized)
 				return
 			}
@@ -74,7 +72,6 @@ func requireOwner() mux.MiddlewareFunc {
 			// so only thing left to do is get account id stored in the CommonName
 			owner, err := sdk.AccAddressFromBech32(r.TLS.PeerCertificates[0].Subject.CommonName)
 			if err != nil {
-				fmt.Printf("failed extracting owner key from cert\n")
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}

--- a/provider/gateway/rest/path.go
+++ b/provider/gateway/rest/path.go
@@ -9,6 +9,7 @@ import (
 const (
 	deploymentPathPrefix = "/deployment/{dseq}"
 	leasePathPrefix      = "/lease/{dseq}/{gseq}/{oseq}"
+	hostnamePrefix = "/hostname"
 )
 
 func statusPath() string {

--- a/provider/service.go
+++ b/provider/service.go
@@ -38,6 +38,8 @@ type Client interface {
 	ValidateClient
 	Manifest() manifest.Client
 	Cluster() cluster.Client
+	Hostname() cluster.HostnameServiceClient
+	ClusterService() cluster.Service
 }
 
 // Service is the interface that includes StatusClient interface.
@@ -144,6 +146,14 @@ type service struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	lc     lifecycle.Lifecycle
+}
+
+func (s* service) Hostname() cluster.HostnameServiceClient {
+	return s.cluster.HostnameService()
+}
+
+func (s *service) ClusterService() cluster.Service {
+	return s.cluster
 }
 
 func (s *service) Close() error {

--- a/x/deployment/types/id.go
+++ b/x/deployment/types/id.go
@@ -31,6 +31,10 @@ func (id DeploymentID) String() string {
 	return fmt.Sprintf("%s/%d", id.Owner, id.DSeq)
 }
 
+func (id DeploymentID) GetOwnerAddress() (sdk.Address, error){
+	return sdk.AccAddressFromBech32(id.Owner)
+}
+
 func ParseDeploymentID(val string) (DeploymentID, error) {
 	parts := strings.Split(val, "/")
 	return ParseDeploymentPath(parts)

--- a/x/deployment/types/id.go
+++ b/x/deployment/types/id.go
@@ -31,7 +31,7 @@ func (id DeploymentID) String() string {
 	return fmt.Sprintf("%s/%d", id.Owner, id.DSeq)
 }
 
-func (id DeploymentID) GetOwnerAddress() (sdk.Address, error){
+func (id DeploymentID) GetOwnerAddress() (sdk.Address, error) {
 	return sdk.AccAddressFromBech32(id.Owner)
 }
 


### PR DESCRIPTION
~~This is my first pass at transferring hostnames deployments to the next.~~ Presently, a deployment effectively "owns" a hostname. Once created no other deployment can claim that hostname. This becomes an issue when a user hosts their website on the Akash platform, because they inevitably want to update deployment (to scale up capacity, or whatever) with a new one. Basically we have to somehow support this, to give customers the option of a zero-down time deploy.

The goal of this PR is to move ownership from a deployment level to an owner address level (corresponding to the wallet that originally laid claim to the hostname). Under this system, a domain may be used by any deployment owned by the same owner.

A few basic remarks

1. domains are still 1st come 1st serve. This doesn't solve the domain squatting problem
2. A deployment still gets a procedurally generated hostname as well that looks like random characters & numbers
3. The existing workflow for customers not using domain names is unchanged
4. The existing workflow for customers that want to just teardown their existing lease and suffer some down time is unchanged
5. This does solve the problem of a domain squatter trying to "intercept" a domain they've identified as in use on a provider and hold if for ransom with their own deployment

The way the new system works is

1. If a deployment is the 1st to lay claim to a hostname, the deployment gets the domain and owns
2. If a deployment is not the 1st to lay claim to a hostname, the deployment gets to use the domain name only if the owner addresses match. The existing deployment is evicted from the hostname **when the user requests it.** (see implementation below)

For case 1, this is the same way it works today.

For case 2, the provider considers the hostname to be immediately **owned by the account address**. However, the actual implementation creates all the necessary kubernetes resources, minus any hostnames already in use by the account address.  Hostnames are purged from the prior deployment and added to the new deployment's ingress in Kubernetes **only 
 when the user requests it**. This **allows for** important things: zero downtime deploys & a failed deploy just results in the old deployment continuing to serve data for that hostname.

With respect to the transfer from deployment to another, **this only happens when the user requests. This puts the onus on the customer to manage their hostnames &** gives the customer the flexibility to rollback to old deployments as well. **Creating a deployment that uses a hostname already in use always succeeds, but the hostname is only moved over whenever the user actually requests the provider do this.**

**An example of how this request is made using the command line:**

```
akash provider migrate-hostnames --dseq 1000 --from main --provider akash1uvj4vc3m7pgh5n8jezev08y96nhmgap73z7kqv akash.localhost
```

**In this case, the hostname `akash.localhost` is migrated to the deployment with sequence number 1000.**

This gives customers an easy to way to go rollback a botched update of their website. This capability is inline with what is provided by other cloud providers, although not as simple.

We need to give customers as much better way to see the status of their deployments as identified in my other PR, so I will incorporate as part of those changed another command which allows a customer to query a provider and see what hostnames are in use by the provider (for their address) and what the associated dseq is. At least for hostnames, this gives users a single place they can check the status and determine which dseq actually owns the hostname.

