### PR TITLE
fix(provider): correct deployment failure on multiple service exposure

### DIFF
--- a/manifest/types.go
+++ b/manifest/types.go
@@ -73,7 +73,6 @@ type ServiceExpose struct {
 	Port         uint16 // Port on the container
 	ExternalPort uint16 // Port on the service definition
 	Proto        ServiceProtocol
-	Service      string
 	Global       bool
 	Hosts        []string
 }

--- a/pkg/apis/akash.network/v1/types.go
+++ b/pkg/apis/akash.network/v1/types.go
@@ -270,7 +270,6 @@ func (mse ManifestServiceExpose) toAkash() (manifest.ServiceExpose, error) {
 		Port:         mse.Port,
 		ExternalPort: mse.ExternalPort,
 		Proto:        proto,
-		Service:      mse.Service,
 		Global:       mse.Global,
 		Hosts:        mse.Hosts,
 	}, nil
@@ -281,7 +280,6 @@ func manifestServiceExposeFromAkash(amse manifest.ServiceExpose) ManifestService
 		Port:         amse.Port,
 		ExternalPort: amse.ExternalPort,
 		Proto:        amse.Proto.ToString(),
-		Service:      amse.Service,
 		Global:       amse.Global,
 		Hosts:        amse.Hosts,
 	}

--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -546,9 +546,9 @@ exposeCheckLoop:
 					Port:         expose.Port,
 					ExternalPort: expose.ExternalPort,
 					Proto:        proto,
-					Service:      expose.Service,
-					Global:       expose.Global,
-					Hosts:        expose.Hosts,
+					//Service:      expose.Service,
+					Global: expose.Global,
+					Hosts:  expose.Hosts,
 				}
 				if util.ShouldBeIngress(mse) {
 					hasIngress = true

--- a/provider/cluster/kube/client_test.go
+++ b/provider/cluster/kube/client_test.go
@@ -478,7 +478,6 @@ func TestServiceStatusWithIngress(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 9000,
 				Proto:        "TCP",
-				Service:      "echo",
 				Global:       false,
 				Hosts:        nil,
 			},
@@ -497,9 +496,9 @@ func TestServiceStatusWithIngress(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 80,
 				Proto:        "TCP",
-				Service:      "echo",
-				Global:       true,
-				Hosts:        []string{"atest.localhost"},
+
+				Global: true,
+				Hosts:  []string{"atest.localhost"},
 			},
 		},
 	}
@@ -585,9 +584,9 @@ func TestServiceStatusWithIngressError(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 9000,
 				Proto:        "TCP",
-				Service:      "echo",
-				Global:       false,
-				Hosts:        nil,
+
+				Global: false,
+				Hosts:  nil,
 			},
 		},
 	}
@@ -604,9 +603,9 @@ func TestServiceStatusWithIngressError(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 80,
 				Proto:        "TCP",
-				Service:      "echo",
-				Global:       true,
-				Hosts:        []string{"atest.localhost"},
+
+				Global: true,
+				Hosts:  []string{"atest.localhost"},
 			},
 		},
 	}
@@ -671,9 +670,9 @@ func TestServiceStatusWithoutIngress(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 9000,
 				Proto:        "TCP",
-				Service:      "echo",
-				Global:       false,
-				Hosts:        nil,
+
+				Global: false,
+				Hosts:  nil,
 			},
 		},
 	}
@@ -690,9 +689,9 @@ func TestServiceStatusWithoutIngress(t *testing.T) {
 				Port:         9000,
 				ExternalPort: 80,
 				Proto:        "TCP",
-				Service:      "echo",
-				Global:       false,
-				Hosts:        []string{"atest.localhost"},
+
+				Global: false,
+				Hosts:  []string{"atest.localhost"},
 			},
 		},
 	}

--- a/sdl/v2_test.go
+++ b/sdl/v2_test.go
@@ -221,3 +221,26 @@ func Test_v2_Parse_DeploymentNameServiceNameMismatch(t *testing.T) {
 	require.Len(t, mani.GetGroups()[0].Services[0].Expose[0].Hosts, 1)
 	require.Equal(t, mani.GetGroups()[0].Services[0].Expose[0].Hosts[0], "ahostname.com")
 }
+
+func Test_V2_Parse_MultipleServiceTo(t *testing.T) {
+	obj, err := ReadFile("./_testdata/multiple_service_to.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	m, err := obj.Manifest()
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	g := m.GetGroups()[0]
+
+	s := g.Services[0]
+	require.Equal(t, "hello-world", s.Name)
+	require.Len(t, s.Expose, 2)
+}
+
+func Test_V2_Parse_MultipleServiceToMultipleDeploy(t *testing.T) {
+	obj, err := ReadFile("./_testdata/multiple_service_to_multiple_deploy.yaml")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), `hello-world.dcloud1: cannot expose to "test-1", no service by that name in this deployment group`)
+	require.Nil(t, obj)
+}

--- a/testutil/manifest_app.go
+++ b/testutil/manifest_app.go
@@ -55,10 +55,9 @@ func (mg manifestGeneratorApp) Service(t testing.TB) manifest.Service {
 
 func (mg manifestGeneratorApp) ServiceExpose(t testing.TB) manifest.ServiceExpose {
 	return manifest.ServiceExpose{
-		Port:    80,
-		Service: "demo",
-		Global:  true,
-		Proto:   "TCP",
+		Port:   80,
+		Global: true,
+		Proto:  "TCP",
 		Hosts: []string{
 			Hostname(t),
 		},

--- a/testutil/manifest_overflow.go
+++ b/testutil/manifest_overflow.go
@@ -61,7 +61,6 @@ func (mg manifestGeneratorOverflow) ServiceExpose(t testing.TB) manifest.Service
 		Port:         math.MaxUint16,
 		ExternalPort: math.MaxUint16,
 		Proto:        "TCP",
-		Service:      "svc",
 		Global:       true,
 		Hosts: []string{
 			Hostname(t),

--- a/testutil/manifest_rand.go
+++ b/testutil/manifest_rand.go
@@ -50,7 +50,6 @@ func (mg manifestGeneratorRand) ServiceExpose(t testing.TB) manifest.ServiceExpo
 		Port:         uint16(rand.Intn(math.MaxUint16)), // nolint: gosec
 		ExternalPort: uint16(rand.Intn(math.MaxUint16)), // nolint: gosec
 		Proto:        "TCP",
-		Service:      "svc",
 		Global:       true,
 		Hosts: []string{
 			Hostname(t),

--- a/validation/manifest_cross_validation_test.go
+++ b/validation/manifest_cross_validation_test.go
@@ -147,7 +147,6 @@ func TestManifestWithEndpointMismatchA(t *testing.T) {
 		Port:         2000,
 		ExternalPort: 0,
 		Proto:        manifest.TCP,
-		Service:      "",
 		Global:       true,
 		Hosts:        nil,
 	}


### PR DESCRIPTION
After looking at what happened with @tombeynon 's deployment, the provider tried to tell kubernetes to use the same port twice on a service (which is basically just an IP address inside Kubernetes). I think whenever I refactored some of the manifest code, I made an error and had it create multiple definitions for the same service. Due to the way we deploy into kubernetes, each service can always see any other service for the same deployment group running in kubernetes. This works because of how our network security policies are applied to the deployments in the namespace. 

The `to` field is mostly an annotation in other words. If we ever get a cross-provider VPN working then it would probably actually be something we can use to determine what needs to be cross-connected. 

I just changed the code not to create multiple definitions for the same port and to validate that the requested service is actually accessible. 