### PR TITLE
Ingress configuration options

### DIFF
--- a/_run/kube/deployment.yaml
+++ b/_run/kube/deployment.yaml
@@ -7,6 +7,10 @@ services:
     expose:
       - port: 80
         as: 80
+        http_options:
+          max_body_size: 2097152
+          next_cases: 
+            - off
         accept:
           - hello.localhost
         to:

--- a/manifest/types.go
+++ b/manifest/types.go
@@ -75,4 +75,14 @@ type ServiceExpose struct {
 	Proto        ServiceProtocol
 	Global       bool
 	Hosts        []string
+	HTTPOptions  ServiceExposeHTTPOptions
+}
+
+type ServiceExposeHTTPOptions struct {
+	MaxBodySize uint32
+	ReadTimeout uint32
+	SendTimeout uint32
+	NextTries   uint32
+	NextTimeout uint32
+	NextCases   []string
 }

--- a/sdl/_testdata/simple_httpoptions.yaml
+++ b/sdl/_testdata/simple_httpoptions.yaml
@@ -1,0 +1,53 @@
+---
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        http_options:
+          max_body_size: 1
+          read_timeout: 2
+          send_timeout: 3
+          next_tries: 4
+          next_timeout: 5
+          next_cases: 
+             - off
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+      - port: 12345
+        to:
+          - global: true
+        proto: udp
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uakt
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/sdl/v2.go
+++ b/sdl/v2.go
@@ -1,6 +1,7 @@
 package sdl
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -9,6 +10,33 @@ import (
 	providerUtil "github.com/ovrclk/akash/provider/cluster/util"
 	"github.com/ovrclk/akash/types"
 	dtypes "github.com/ovrclk/akash/x/deployment/types"
+)
+
+const (
+	nextCaseError         = "error"
+	nextCaseTimeout       = "timeout"
+	nextCase500           = "500"
+	nextCase502           = "502"
+	nextCase503           = "503"
+	nextCase504           = "504"
+	nextCase403           = "403"
+	nextCase404           = "404"
+	nextCase400           = "429"
+	nextCaseOff           = "off"
+	defaultMaxBodySize    = uint32(1048576)
+	upperLimitBodySize    = uint32(104857600)
+	defaultReadTimeout    = uint32(60000)
+	upperLimitReadTimeout = defaultReadTimeout
+	defaultSendTimeout    = uint32(60000)
+	upperLimitSendTimeout = defaultSendTimeout
+	defaultNextTries      = uint32(3)
+)
+
+var (
+	defaultNextCases                 = []string{nextCaseError, nextCaseTimeout}
+	errCannotSpecifyOffAndOtherCases = errors.New("if 'off' is specified, no other cases may be specified")
+	errUnknownNextCase               = errors.New("next case is unknown")
+	errHTTPOptionNotAllowed          = errors.New("http option not allowed")
 )
 
 type v2 struct {
@@ -24,11 +52,92 @@ type v2ExposeTo struct {
 }
 
 type v2Expose struct {
-	Port   uint16
-	As     uint16
-	Proto  string       `yaml:"proto,omitempty"`
-	To     []v2ExposeTo `yaml:"to,omitempty"`
-	Accept v2Accept     `yaml:"accept"`
+	Port        uint16
+	As          uint16
+	Proto       string        `yaml:"proto,omitempty"`
+	To          []v2ExposeTo  `yaml:"to,omitempty"`
+	Accept      v2Accept      `yaml:"accept"`
+	HTTPOptions v2HTTPOptions `yaml:"http_options"`
+}
+
+type v2HTTPOptions struct {
+	MaxBodySize uint32   `yaml:"max_body_size"`
+	ReadTimeout uint32   `yaml:"read_timeout"`
+	SendTimeout uint32   `yaml:"send_timeout"`
+	NextTries   uint32   `yaml:"next_tries"`
+	NextTimeout uint32   `yaml:"next_timeout"`
+	NextCases   []string `yaml:"next_cases"`
+}
+
+func (ho v2HTTPOptions) any() bool {
+	return len(ho.NextCases) != 0 ||
+		ho.MaxBodySize != 0 ||
+		ho.ReadTimeout != 0 ||
+		ho.SendTimeout != 0 ||
+		ho.NextTries != 0 ||
+		ho.NextTimeout != 0
+}
+
+func (ho v2HTTPOptions) asManifest() (manifest.ServiceExposeHTTPOptions, error) {
+	maxBodySize := ho.MaxBodySize
+	if 0 == maxBodySize {
+		maxBodySize = defaultMaxBodySize
+	} else if maxBodySize > upperLimitBodySize {
+		return manifest.ServiceExposeHTTPOptions{}, fmt.Errorf("%w: body size cannot be greater than %d bytes", errHTTPOptionNotAllowed, upperLimitBodySize)
+	}
+
+	readTimeout := ho.ReadTimeout
+	if 0 == readTimeout {
+		readTimeout = defaultReadTimeout
+	} else if readTimeout > upperLimitReadTimeout {
+		return manifest.ServiceExposeHTTPOptions{}, fmt.Errorf("%w: read timeout cannot be greater than %d ms", errHTTPOptionNotAllowed, upperLimitReadTimeout)
+	}
+
+	sendTimeout := ho.SendTimeout
+	if 0 == sendTimeout {
+		sendTimeout = defaultSendTimeout
+	} else if sendTimeout > upperLimitSendTimeout {
+		return manifest.ServiceExposeHTTPOptions{}, fmt.Errorf("%w: send timeout cannot be greater than %d ms", errHTTPOptionNotAllowed, upperLimitSendTimeout)
+	}
+
+	nextTries := ho.NextTries
+	if 0 == nextTries {
+		nextTries = defaultNextTries
+	}
+
+	nextCases := ho.NextCases
+	if len(nextCases) == 0 {
+		nextCases = defaultNextCases
+	} else {
+		for _, nextCase := range nextCases {
+			switch nextCase {
+			case nextCaseOff:
+				if len(nextCases) != 1 {
+					return manifest.ServiceExposeHTTPOptions{}, errCannotSpecifyOffAndOtherCases
+				}
+			case nextCaseError:
+			case nextCaseTimeout:
+			case nextCase500:
+			case nextCase502:
+			case nextCase503:
+			case nextCase504:
+			case nextCase403:
+			case nextCase404:
+			case nextCase400:
+			default:
+				return manifest.ServiceExposeHTTPOptions{}, fmt.Errorf("%w: %q", errUnknownNextCase, nextCase)
+			}
+		}
+	}
+
+	return manifest.ServiceExposeHTTPOptions{
+		MaxBodySize: maxBodySize,
+		ReadTimeout: readTimeout,
+		SendTimeout: sendTimeout,
+		NextTries:   nextTries,
+		NextTimeout: ho.NextTimeout,
+		NextCases:   nextCases,
+	}, nil
 }
 
 type v2Dependency struct {
@@ -217,12 +326,18 @@ func (sdl *v2) Manifest() (manifest.Manifest, error) {
 					return manifest.Manifest{}, err
 				}
 
+				httpOptions, err := expose.HTTPOptions.asManifest()
+				if err != nil {
+					return manifest.Manifest{}, err
+				}
+
 				serviceExpose := manifest.ServiceExpose{
 					Port:         expose.Port,
 					ExternalPort: expose.As,
 					Proto:        proto,
 					Global:       false,
 					Hosts:        expose.Accept.Items,
+					HTTPOptions:  httpOptions,
 				}
 
 				if len(expose.To) != 0 {


### PR DESCRIPTION
This gives users the options in their SDL to configure

1. read timeout
2. send timeout
3. body size limits
4. number of retries (for when replicas > 1)
5. retry cases
6. retry timeout

These become annotations that control our kubernetes NGINX ingress controller. There are some limits on these values, for example I have it so body size can't be more than 50 MB right now.

If this isn't specified in the SDL the defaults are the same as what is in effect today on everyone's ingress controller.