### PR TITLE
fix: Correct test coverage script

### DIFF
--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -48,7 +48,7 @@ test-full:
 test-coverage:
 	$(GO) test -tags=$(BUILD_MAINNET) -coverprofile=coverage.txt \
 		-covermode=count \
-		-coverpkg=$(COVER_PACKAGES)
+		-coverpkg=./... $(COVER_PACKAGES)
 
 test-vet:
 	$(GO) vet ./...

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -1,4 +1,4 @@
-COVER_PACKAGES = $(shell go list ./... | grep -v mock | tr "\n" "," | rev | cut -c2- | rev)
+COVER_PACKAGES = $(shell go list ./... | grep -v mock | xargs | tr ' ' ',')
 # This is statically specified in the vagrant configuration
 KUBE_NODE_IP ?= 172.18.8.101
 ###############################################################################

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -1,4 +1,4 @@
-COVER_PACKAGES = $(shell go list ./... | grep -v mock)
+COVER_PACKAGES = $(shell go list ./... | grep -v mock | tr "\n" "," | rev | cut -c2- | rev)
 # This is statically specified in the vagrant configuration
 KUBE_NODE_IP ?= 172.18.8.101
 ###############################################################################
@@ -48,7 +48,8 @@ test-full:
 test-coverage:
 	$(GO) test -tags=$(BUILD_MAINNET) -coverprofile=coverage.txt \
 		-covermode=count \
-		-coverpkg=./... $(COVER_PACKAGES)
+		-coverpkg=$(COVER_PACKAGES) \
+		./...
 
 test-vet:
 	$(GO) vet ./...

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -1,4 +1,4 @@
-COVER_PACKAGES = $(shell go list ./... | grep -v mock | xargs | tr ' ' ',')
+COVER_PACKAGES = $(shell go list ./... | grep -v mock | paste -sd,)
 # This is statically specified in the vagrant configuration
 KUBE_NODE_IP ?= 172.18.8.101
 ###############################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The coverage script was broken till now. Previously, this script was expanding to following command:
```
GO111MODULE=on go test -tags= -coverprofile=coverage.txt \
        -covermode=count \
        -coverpkg=github.com/ovrclk/akash/app github.com/ovrclk/akash/app/params github.com/ovrclk/akash/client github.com/ovrclk/akash/client/broadcaster github.com/ovrclk/akash/client/docs
/statik github.com/ovrclk/akash/cmd/akash github.com/ovrclk/akash/cmd/akash/cmd github.com/ovrclk/akash/cmd/common github.com/ovrclk/akash/deploy/cmd github.com/ovrclk/akash/docgen github.co
m/ovrclk/akash/events github.com/ovrclk/akash/events/cmd github.com/ovrclk/akash/integration github.com/ovrclk/akash/manifest github.com/ovrclk/akash/pkg/apis/akash.network/v1 github.com/ovr
clk/akash/pkg/client/clientset/versioned github.com/ovrclk/akash/pkg/client/clientset/versioned/fake github.com/ovrclk/akash/pkg/client/clientset/versioned/scheme github.com/ovrclk/akash/pkg
/client/clientset/versioned/typed/akash.network/v1 github.com/ovrclk/akash/pkg/client/clientset/versioned/typed/akash.network/v1/fake github.com/ovrclk/akash/pkg/client/informers/externalver
sions github.com/ovrclk/akash/pkg/client/informers/externalversions/akash.network github.com/ovrclk/akash/pkg/client/informers/externalversions/akash.network/v1 github.com/ovrclk/akash/pkg/c
lient/informers/externalversions/internalinterfaces github.com/ovrclk/akash/pkg/client/listers/akash.network/v1 github.com/ovrclk/akash/provider github.com/ovrclk/akash/provider/bidengine gi
thub.com/ovrclk/akash/provider/cluster github.com/ovrclk/akash/provider/cluster/kube github.com/ovrclk/akash/provider/cluster/types github.com/ovrclk/akash/provider/cluster/util github.com/o
vrclk/akash/provider/cmd github.com/ovrclk/akash/provider/event github.com/ovrclk/akash/provider/gateway/rest github.com/ovrclk/akash/provider/gateway/utils github.com/ovrclk/akash/provider/
manifest github.com/ovrclk/akash/provider/session github.com/ovrclk/akash/provider/testutil github.com/ovrclk/akash/pubsub github.com/ovrclk/akash/sdkutil github.com/ovrclk/akash/sdl github.
com/ovrclk/akash/testutil github.com/ovrclk/akash/testutil/cli github.com/ovrclk/akash/testutil/state github.com/ovrclk/akash/types github.com/ovrclk/akash/types/unit github.com/ovrclk/akash
/util/ctxlog github.com/ovrclk/akash/util/legacy/v013 github.com/ovrclk/akash/util/metrics github.com/ovrclk/akash/util/runner github.com/ovrclk/akash/util/validation github.com/ovrclk/akash
/util/wsutil github.com/ovrclk/akash/validation github.com/ovrclk/akash/validation/constants github.com/ovrclk/akash/x/audit github.com/ovrclk/akash/x/audit/client/cli github.com/ovrclk/akas
h/x/audit/client/rest github.com/ovrclk/akash/x/audit/handler github.com/ovrclk/akash/x/audit/keeper github.com/ovrclk/akash/x/audit/legacy/v013 github.com/ovrclk/akash/x/audit/query github.
com/ovrclk/akash/x/audit/types github.com/ovrclk/akash/x/cert github.com/ovrclk/akash/x/cert/client/cli github.com/ovrclk/akash/x/cert/handler github.com/ovrclk/akash/x/cert/keeper github.co
m/ovrclk/akash/x/cert/legacy/v013 github.com/ovrclk/akash/x/cert/simulation github.com/ovrclk/akash/x/cert/types github.com/ovrclk/akash/x/cert/utils github.com/ovrclk/akash/x/deployment git
hub.com/ovrclk/akash/x/deployment/client/cli github.com/ovrclk/akash/x/deployment/client/rest github.com/ovrclk/akash/x/deployment/handler github.com/ovrclk/akash/x/deployment/keeper github.
com/ovrclk/akash/x/deployment/legacy/v013 github.com/ovrclk/akash/x/deployment/query github.com/ovrclk/akash/x/deployment/simulation github.com/ovrclk/akash/x/deployment/types github.com/ovr
clk/akash/x/escrow github.com/ovrclk/akash/x/escrow/client/cli github.com/ovrclk/akash/x/escrow/client/rest github.com/ovrclk/akash/x/escrow/keeper github.com/ovrclk/akash/x/escrow/legacy/v0
13 github.com/ovrclk/akash/x/escrow/query github.com/ovrclk/akash/x/escrow/types github.com/ovrclk/akash/x/market github.com/ovrclk/akash/x/market/client/cli github.com/ovrclk/akash/x/market
/client/rest github.com/ovrclk/akash/x/market/handler github.com/ovrclk/akash/x/market/hooks github.com/ovrclk/akash/x/market/keeper github.com/ovrclk/akash/x/market/legacy/v013 github.com/o
vrclk/akash/x/market/query github.com/ovrclk/akash/x/market/simulation github.com/ovrclk/akash/x/market/types github.com/ovrclk/akash/x/provider github.com/ovrclk/akash/x/provider/client/cli
 github.com/ovrclk/akash/x/provider/client/rest github.com/ovrclk/akash/x/provider/config github.com/ovrclk/akash/x/provider/handler github.com/ovrclk/akash/x/provider/keeper github.com/ovrc
lk/akash/x/provider/legacy/v013 github.com/ovrclk/akash/x/provider/query github.com/ovrclk/akash/x/provider/simulation github.com/ovrclk/akash/x/provider/types
```

This resulted in only the first package in the list, i.e., `github.com/ovrclk/akash/app` being used as `-coverpkg`, while rest of the packages after that were arguments to the `go test` command. So, it was running tests in all of the remaining packages and was using them to measure the coverage of only `github.com/ovrclk/akash/app`, resulting in the coverage being reported too high while it was actually something else overall.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/ovrclk/akash/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/ovrclk/akash/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
