### PR TITLE
fix(ingress): increase global body size limit

### DIFF
--- a/_run/ingress-nginx.yaml
+++ b/_run/ingress-nginx.yaml
@@ -36,6 +36,7 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
+  proxy-body-size: 10m
 ---
 # Source: ingress-nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/_run/kube/Makefile
+++ b/_run/kube/Makefile
@@ -40,3 +40,7 @@ provider-service-status:
 .PHONY: provider-lease-ping
 provider-lease-ping:
 	curl -sIH "Host: hello.localhost" localhost:$(KIND_HTTP_PORT)
+
+.PHONY: clean-kube
+clean-kube:
+	# noop


### PR DESCRIPTION
Increase `client_max_body_size` to "10m" from "1m".

fixes #1300