### PR TITLE
fix lease events time

### DIFF
--- a/provider/cluster/kube/client.go
+++ b/provider/cluster/kube/client.go
@@ -270,7 +270,10 @@ func newEventsFeedWatch(ctx context.Context, events watch.Interface) ctypes.Even
 	done:
 		for {
 			select {
-			case obj := <-events.ResultChan():
+			case obj, ok := <-events.ResultChan():
+				if !ok {
+					break done
+				}
 				evt := obj.Object.(*eventsv1.Event)
 				if !wtch.SendEvent(evt) {
 					break done

--- a/provider/cluster/types/types.go
+++ b/provider/cluster/types/types.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"time"
-
 	eventsv1 "k8s.io/api/events/v1"
 
 	"github.com/ovrclk/akash/manifest"
@@ -87,7 +85,6 @@ type LeaseEvent struct {
 	Type                string           `json:"type" yaml:"type"`
 	ReportingController string           `json:"reportingController,omitempty" yaml:"reportingController"`
 	ReportingInstance   string           `json:"reportingInstance,omitempty" yaml:"reportingInstance"`
-	Time                time.Time        `json:"time" yaml:"time"`
 	Reason              string           `json:"reason" yaml:"reason"`
 	Note                string           `json:"note" yaml:"note"`
 	Object              LeaseEventObject `json:"object" yaml:"object"`

--- a/provider/gateway/rest/router.go
+++ b/provider/gateway/rest/router.go
@@ -691,7 +691,6 @@ done:
 				Type:                evt.Type,
 				ReportingController: evt.ReportingController,
 				ReportingInstance:   evt.ReportingInstance,
-				Time:                evt.EventTime.Time,
 				Reason:              evt.Reason,
 				Note:                evt.Note,
 				Object: cltypes.LeaseEventObject{


### PR DESCRIPTION
This fixes two things

1. Lease events had 0 for time, kubernetes never gives us this data so we can't provide it
2. There was a panic in the provider that caused it to crash. We were trying to cast nil to a type which obviously doesn't work