### PR TITLE
Use command for services from SDL

### DIFF
--- a/sdl/v2.go
+++ b/sdl/v2.go
@@ -202,6 +202,7 @@ func (sdl *v2) Manifest() (manifest.Manifest, error) {
 				Env:       svc.Env,
 				Resources: compute.Resources.toResourceUnits(),
 				Count:     svcdepl.Count,
+				Command:   svc.Command,
 			}
 
 			for _, expose := range svc.Expose {


### PR DESCRIPTION
It looks like we just were not setting command in the SDL at all. This fixes that 