### PR TITLE
reduce default bid amount

### DIFF
--- a/x/market/types/params.go
+++ b/x/market/types/params.go
@@ -9,7 +9,7 @@ import (
 var _ paramtypes.ParamSet = (*Params)(nil)
 
 var (
-	DefaultBidMinDeposit        = sdk.NewCoin("uakt", sdk.NewInt(50000000))
+	DefaultBidMinDeposit        = sdk.NewCoin("uakt", sdk.NewInt(5000000))
 	defaultOrderMaxBids  uint32 = 20
 	maxOrderMaxBids      uint32 = 500
 )


### PR DESCRIPTION
Prop 12 has passed, the lowest effective bid accepted is 5,000,000 uakt. This lowers the default amount to match.