### PR TITLE
fix: run events handler with command context

### DIFF
--- a/cmd/common/signal.go
+++ b/cmd/common/signal.go
@@ -25,10 +25,10 @@ func watchSignals(ctx context.Context, cancel context.CancelFunc) <-chan struct{
 
 // RunForever runs a function in the background, forever. Returns error in case of failure.
 func RunForever(fn func(ctx context.Context) error) error {
-	return runForeverWithContext(context.Background(), fn)
+	return RunForeverWithContext(context.Background(), fn)
 }
 
-func runForeverWithContext(ctx context.Context, fn func(ctx context.Context) error) error {
+func RunForeverWithContext(ctx context.Context, fn func(ctx context.Context) error) error {
 	ctx, cancel := context.WithCancel(ctx)
 
 	donech := watchSignals(ctx, cancel)

--- a/events/cmd/root.go
+++ b/events/cmd/root.go
@@ -22,7 +22,7 @@ func EventCmd() *cobra.Command {
 		Use:   "events",
 		Short: "Prints out akash events in real time",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return common.RunForever(func(ctx context.Context) error {
+			return common.RunForeverWithContext(cmd.Context(), func(ctx context.Context) error {
 				return getEvents(ctx, cmd, args)
 			})
 		},


### PR DESCRIPTION
allows to catch context cancel if root command
runs with custom context
