### PR TITLE
manifest watchdog stop fix

### DIFF
--- a/provider/gateway/rest/router.go
+++ b/provider/gateway/rest/router.go
@@ -383,7 +383,7 @@ func validateHandler(log log.Logger, cl provider.ValidateClient) http.HandlerFun
 	}
 }
 
-func createManifestHandler(_ log.Logger, mclient pmanifest.Client) http.HandlerFunc {
+func createManifestHandler(log log.Logger, mclient pmanifest.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		var mani manifest.Manifest
 		decoder := json.NewDecoder(req.Body)
@@ -405,6 +405,7 @@ func createManifestHandler(_ log.Logger, mclient pmanifest.Client) http.HandlerF
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			}
+			log.Error("manifest submit failed", "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/provider/manifest/watchdog_test.go
+++ b/provider/manifest/watchdog_test.go
@@ -72,6 +72,7 @@ func TestWatchdogStops(t *testing.T) {
 	wd, scaffold := makeWatchdogTestScaffold(t, 1*time.Minute)
 
 	wd.stop() // ask it to stop immediately
+	wd.stop() // ask it to stop a second time, this is expected usage
 
 	select {
 	case <-wd.lc.Done():


### PR DESCRIPTION
Fixes

1. only allow a manifest watchdog to be stopped once
2. log manifest errors