### PR TITLE
test: upgrade kind kube cluster version

### DIFF
--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -4,7 +4,7 @@
 # image's name in GH Actions.
 export KIND_NAME ?= $(shell basename $$PWD)
 
-KINDEST_VERSION  ?= v1.21.1
+KINDEST_VERSION  ?= v1.22.2
 KIND_IMG         ?= kindest/node:$(KINDEST_VERSION)
 
 K8S_CONTEXT      ?= $(shell kubectl config current-context)


### PR DESCRIPTION
Just bump up our kind version to the latest, since we are still using kind to test a bunch of stuff.