### PR TITLE
Fix withdrawal period after 1st iteration

### DIFF
--- a/provider/balance_checker.go
+++ b/provider/balance_checker.go
@@ -150,7 +150,7 @@ loop:
 		case withdrawAll := <-withdrawAllResult:
 
 			withdrawAllResult = nil
-			withdrawalTicker.Reset(bc.cfg.PollingPeriod) // Re-enable the timer
+			withdrawalTicker.Reset(bc.cfg.WithdrawalPeriod) // Re-enable the timer
 			if err := withdrawAll.Error(); err != nil {
 				bc.log.Error("failed to started withdrawals", "err", err)
 			}


### PR DESCRIPTION
After the 1st iteration of the withdrawal period, the wrong value is used to reset the timer for all subsequent attempts. This is bad because it causes withdrawals to happen entirely too often.