### PR TITLE
hostname operator  - ignore problematic namespaces

### DIFF
--- a/_docs/kustomize/akash-hostname-operator/deployment.yaml
+++ b/_docs/kustomize/akash-hostname-operator/deployment.yaml
@@ -23,13 +23,44 @@ spec:
         command: ["/bin/sh", "/boot/run.sh"]
         ports:
           - name: status
-            containerPort: 8188
+            containerPort: 8085
         env:
           - name: AKASH_K8S_MANIFEST_NS
             valueFrom:
               configMapKeyRef:
                 name: akash-provider-config
                 key: k8s-manifest-ns
+          - name: AKASH_PRUNE_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: prune-interval
+          - name: AKASH_IGNORE_LIST_ENTRY_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: ignore-list-entry-limit
+          - name: AKASH_WEB_REFRESH_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: web-refresh-interval
+          - name: AKASH_RETRY_DELAY
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: retry-delay
+          - name: AKASH_IGNORE_LIST_AGE_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: ignore-list-age-limit
+          - name: AKASH_EVENT_FAILURE_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                name: akash-hostname-operator-config
+                key: event-failure-limit
+
         volumeMounts:
           - name: boot
             mountPath: /boot

--- a/_docs/kustomize/akash-hostname-operator/ingress.yaml
+++ b/_docs/kustomize/akash-hostname-operator/ingress.yaml
@@ -3,10 +3,11 @@ kind: Ingress
 metadata:
   name: akash-hostname-operator
   annotations:
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
 
 spec:
+  ingressClassName: "akash-ingress-class"
   rules:
     - host: akash-hostname-operator.localhost
       http:

--- a/_docs/kustomize/akash-hostname-operator/kustomization.yaml
+++ b/_docs/kustomize/akash-hostname-operator/kustomization.yaml
@@ -15,3 +15,11 @@ configMapGenerator:
   - name: akash-provider-config
     literals:
       - k8s-manifest-ns=lease
+  - name: akash-hostname-operator-config
+    literals:
+      - prune-interval=600s
+      - ignore-list-entry-limit=131072
+      - web-refresh-interval=5s
+      - retry-delay=3s
+      - ignore-list-age-limit=2613600s
+      - event-failure-limit=3

--- a/_docs/kustomize/akash-hostname-operator/service.yaml
+++ b/_docs/kustomize/akash-hostname-operator/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: akash-hostname-operator
 spec:
+  selector:
+    akash.network/component: akash-hostname-operator
   ports:
     - name: status
-      port: 8188
+      port: 8085

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -313,7 +313,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	go func() {
 		s.T().Log("starting hostname operator for test")
 		_, err := ptestutil.RunLocalHostnameOperator(s.ctx, cctx)
-		s.Require().ErrorIs(err, context.Canceled)
+		s.Require().NoError(err)
 	}()
 
 	s.Require().NoError(s.network.WaitForNextBlock())

--- a/provider/cmd/hostname_operator.go
+++ b/provider/cmd/hostname_operator.go
@@ -139,7 +139,7 @@ func (op *hostnameOperator) webRouter() http.Handler {
 }
 
 var errObservationStopped = errors.New("observation stopped")
-var errExpectedResourceNotFound = fmt.Errorf("%w: resource not found")
+var errExpectedResourceNotFound = fmt.Errorf("%w: resource not found", errObservationStopped)
 
 func (op *hostnameOperator) monitorUntilError(parentCtx context.Context) error {
 	/*

--- a/provider/cmd/hostname_operator_test.go
+++ b/provider/cmd/hostname_operator_test.go
@@ -172,7 +172,7 @@ func TestHostnameOperatorApplyDelete(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.xyz"
+	const hostname = "qux.test"
 	// Shove in something so we can confirm it is deleted
 	s.op.hostnames[hostname] = managedHostname{}
 
@@ -205,7 +205,7 @@ func TestHostnameOperatorApplyDeleteFails(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "lsn.io"
+	const hostname = "lsn.test"
 	// Shove in something so we can confirm it is deleted
 	s.op.hostnames[hostname] = managedHostname{}
 
@@ -233,7 +233,7 @@ func TestHostnameOperatorApplyAddNoManifestGroup(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.io"
+	const hostname = "qux.test"
 
 	leaseID := testutil.LeaseID(t)
 	ev := testHostnameResourceEv{
@@ -265,7 +265,7 @@ func TestHostnameOperatorApplyAddWithError(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "zab.io"
+	const hostname = "zab.test"
 
 	leaseID := testutil.LeaseID(t)
 	ev := testHostnameResourceEv{
@@ -295,7 +295,7 @@ func TestHostnameOperatorIgnoresAfterLimit(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.io"
+	const hostname = "qux.test"
 
 	leaseID := testutil.LeaseID(t)
 
@@ -329,7 +329,7 @@ func TestHostnameOperatorApplyAdd(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.io"
+	const hostname = "qux.test"
 
 	const externalPort = 41333
 	leaseID := testutil.LeaseID(t)
@@ -385,7 +385,7 @@ func TestHostnameOperatorApplyAddMultipleServices(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.io"
+	const hostname = "qux.test"
 
 	const externalPort = 41333
 	leaseID := testutil.LeaseID(t)
@@ -457,7 +457,7 @@ func TestHostnameOperatorApplyUpdate(t *testing.T) {
 	require.NotNil(t, s)
 	defer s.cancel()
 
-	const hostname = "qux.io"
+	const hostname = "qux.test"
 
 	const externalPort = 41333
 	leaseID := testutil.LeaseID(t)

--- a/provider/cmd/hostname_operator_types.go
+++ b/provider/cmd/hostname_operator_types.go
@@ -8,62 +8,62 @@ import (
 )
 
 type managedHostname struct {
-lastEvent    ctypes.HostnameResourceEvent
-presentLease mtypes.LeaseID
+	lastEvent    ctypes.HostnameResourceEvent
+	presentLease mtypes.LeaseID
 
-presentServiceName  string
-presentExternalPort uint32
-lastChangeAt time.Time
+	presentServiceName  string
+	presentExternalPort uint32
+	lastChangeAt        time.Time
 }
 
 type preparedResultData struct {
-preparedAt time.Time
-data []byte
+	preparedAt time.Time
+	data       []byte
 }
 
 type preparedResult struct {
-needsPrepare bool
-data *atomic.Value
+	needsPrepare bool
+	data         *atomic.Value
 }
 
 func newPreparedResult() preparedResult {
-result := preparedResult{
-data: new(atomic.Value),
-needsPrepare: true,
-}
-result.set([]byte{})
-return result
+	result := preparedResult{
+		data:         new(atomic.Value),
+		needsPrepare: true,
+	}
+	result.set([]byte{})
+	return result
 }
 
 func (pr *preparedResult) flag() {
-pr.needsPrepare = true
+	pr.needsPrepare = true
 }
 
 func (pr *preparedResult) set(data []byte) {
-pr.needsPrepare = false
-pr.data.Store(preparedResultData{
-preparedAt: time.Now(),
-data:       data,
-})
+	pr.needsPrepare = false
+	pr.data.Store(preparedResultData{
+		preparedAt: time.Now(),
+		data:       data,
+	})
 }
 
 func (pr *preparedResult) get() preparedResultData {
-return (pr.data.Load()).(preparedResultData)
+	return (pr.data.Load()).(preparedResultData)
 }
+
 type ignoreListEntry struct {
 	failureCount uint
-	failedAt time.Time
-	lastError error
-	hostnames map[string]struct{}
+	failedAt     time.Time
+	lastError    error
+	hostnames    map[string]struct{}
 }
 
-
 type hostnameOperatorConfig struct {
-	listenAddress string
-	pruneInterval time.Duration
+	listenAddress        string
+	pruneInterval        time.Duration
 	ignoreListEntryLimit uint
-	ignoreListAgeLimit time.Duration
-	webRefreshInterval time.Duration
-	retryDelay time.Duration
-	eventFailureLimit uint
+	ignoreListAgeLimit   time.Duration
+	webRefreshInterval   time.Duration
+	retryDelay           time.Duration
+	eventFailureLimit    uint
 }

--- a/provider/cmd/hostname_operator_types.go
+++ b/provider/cmd/hostname_operator_types.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	ctypes "github.com/ovrclk/akash/provider/cluster/types"
+	mtypes "github.com/ovrclk/akash/x/market/types"
+	"sync/atomic"
+	"time"
+)
+
+type managedHostname struct {
+lastEvent    ctypes.HostnameResourceEvent
+presentLease mtypes.LeaseID
+
+presentServiceName  string
+presentExternalPort uint32
+lastChangeAt time.Time
+}
+
+type preparedResultData struct {
+preparedAt time.Time
+data []byte
+}
+
+type preparedResult struct {
+needsPrepare bool
+data *atomic.Value
+}
+
+func newPreparedResult() preparedResult {
+result := preparedResult{
+data: new(atomic.Value),
+needsPrepare: true,
+}
+result.set([]byte{})
+return result
+}
+
+func (pr *preparedResult) flag() {
+pr.needsPrepare = true
+}
+
+func (pr *preparedResult) set(data []byte) {
+pr.needsPrepare = false
+pr.data.Store(preparedResultData{
+preparedAt: time.Now(),
+data:       data,
+})
+}
+
+func (pr *preparedResult) get() preparedResultData {
+return (pr.data.Load()).(preparedResultData)
+}
+type ignoreListEntry struct {
+	failureCount uint
+	failedAt time.Time
+	lastError error
+	hostnames map[string]struct{}
+}
+
+
+type hostnameOperatorConfig struct {
+	listenAddress string
+	pruneInterval time.Duration
+	ignoreListEntryLimit uint
+	ignoreListAgeLimit time.Duration
+	webRefreshInterval time.Duration
+	retryDelay time.Duration
+	eventFailureLimit uint
+}


### PR DESCRIPTION
There are sometimes CRDs from zombie or otherwise left over deployments that cause an error. Right now the hostname operator spins on that error.

The goal of this PR is to allow the hostname operator to move past that error by eventually just ignoring the problematic CRDs. They still should be removed but for now this is probably a best case workaround

**Changes**

1. Detect any errors correlating to a resource in kubernetes not found and track the count of them
2. Once the threshold is reached (3 by default) ignore subsequent events from those leases, they are probably a zombie
3. Ignored leases are tracked in a list that is pruned if it gets too large
4. Make all values that make sense to be configurable via flags, but should probably be set environmental variables
5. Add a read only HTTP interface
6. Add an endpoint for getting the state of the managed hostnames
7. Add an endpoint for getting the state of the ignored leases

The only errors that are tracked are those corresponding to a resource not being found, this is usually a missing namespace in production. General errors such as network connectivity, etc. aren't considered permanent and could result in all CRDs being ignored which is bad.

The ignored leases list is trimmed periodically if it is too large. By default the limit is over 100k entries, so hopefully we don't have many zombies running around. The pruning process tries to get rid of old entries first but always make sure to trim it down below the configured value. Otherwise an out of memory condition could happen.

The HTTP listener is setup to just have two endpoints for exposing data that is already there. We have no real way presently other than using the logs to figure out what the operator is doing. This should help with that. It also gives the namespace in k8s that would be associated with any potential entry, to aid in debugging.

The HTTP responses are not created dynamically. To avoid the use of any locks, the operator just periodically re-renders the responses if the data has changed. This avoids having to introduce any locks around the data and is probably more performant than rendering on each request anyways. The default interval for the speed at which the data is updated is 5 seconds. The `Last-Modified` header on the response indicates whenever the data was actually created, just to be clear to anyone looking at it.

I updated the deployment stuff in `_docs`  for the hostname operator to make sure the Ingress object exposes the new endpoint as intended.
