### PR TITLE
Fix provider behavior around existing bids

### DIFF
--- a/provider/balance_checker_test.go
+++ b/provider/balance_checker_test.go
@@ -52,7 +52,7 @@ func balanceCheckerForTest(t *testing.T, balance int64) (*scaffold, *balanceChec
 		HostURI:    "http://test.localhost:7443",
 		Attributes: nil,
 	}
-	mySession := session.New(myLog, nil, myProvider)
+	mySession := session.New(myLog, nil, myProvider, -1)
 	s.testBus = pubsub.NewBus()
 
 	bc := &balanceChecker{

--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -285,6 +285,8 @@ loop:
 
 				// Bid has been closed (possibly by someone manually closing it on the CLI)
 				bidPlaced = false // bid already not on the blockchain
+				orderCompleteCounter.WithLabelValues("bid-closed-external").Inc()
+				break loop
 			}
 
 		case result := <-groupch:

--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -257,7 +257,6 @@ loop:
 				break loop
 
 			case mtypes.EventOrderClosed:
-
 				// different deployment
 				if !ev.ID.Equals(o.orderID) {
 					break

--- a/provider/bidengine/order.go
+++ b/provider/bidengine/order.go
@@ -25,8 +25,8 @@ import (
 
 // order manages bidding and general lifecycle handling of an order.
 type order struct {
-	orderID   mtypes.OrderID
-	cfg       Config
+	orderID mtypes.OrderID
+	cfg     Config
 
 	session                    session.Session
 	cluster                    cluster.Cluster
@@ -123,7 +123,7 @@ func (o *order) bidTimeoutEnabled() bool {
 	return o.cfg.BidTimeout > time.Duration(0)
 }
 
-func (o *order) getBidTimeout() <- chan time.Time{
+func (o *order) getBidTimeout() <-chan time.Time {
 	if o.bidTimeoutEnabled() {
 		return time.After(o.cfg.BidTimeout)
 	}
@@ -149,9 +149,9 @@ func (o *order) run(checkForExistingBid bool) {
 		group       *dtypes.Group
 		reservation ctypes.Reservation
 
-		won bool
+		won       bool
 		bidPlaced bool
-		msg *mtypes.MsgCreateBid
+		msg       *mtypes.MsgCreateBid
 	)
 
 	// Begin fetching group details immediately.
@@ -430,7 +430,7 @@ loop:
 			}
 		}
 
-		if bidPlaced  {
+		if bidPlaced {
 			o.log.Debug("closing bid")
 			err := o.session.Client().Tx().Broadcast(ctx, &mtypes.MsgCloseBid{
 				BidID: mtypes.MakeBidID(o.orderID, o.session.Provider().Address()),

--- a/provider/bidengine/order_test.go
+++ b/provider/bidengine/order_test.go
@@ -167,9 +167,9 @@ func makeOrderForTest(t *testing.T, checkForExistingBid bool, bidState mtypes.Bi
 		}
 		response := &mtypes.QueryBidResponse{
 			Bid: mtypes.Bid{
-				BidID: bidID,
-				State: bidState,
-				Price: sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(int64(testutil.RandRangeInt(100, 1000)))),
+				BidID:     bidID,
+				State:     bidState,
+				Price:     sdk.NewCoin(testutil.CoinDenom, sdk.NewInt(int64(testutil.RandRangeInt(100, 1000)))),
 				CreatedAt: testBidCreatedAt,
 			},
 		}
@@ -492,12 +492,12 @@ func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 	require.NoError(t, err)
 	cfg := Config{
 		PricingStrategy: pricing,
-		Deposit:         sdk.NewInt64Coin(testutil.CoinDenom,1),
+		Deposit:         sdk.NewInt64Coin(testutil.CoinDenom, 1),
 		BidTimeout:      time.Second,
 		Attributes:      nil,
 	}
 
-	order, scaffold, _ := makeOrderForTest(t, true, mtypes.BidOpen, nil, &cfg,1)
+	order, scaffold, _ := makeOrderForTest(t, true, mtypes.BidOpen, nil, &cfg, 1)
 
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 
@@ -505,23 +505,22 @@ func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 	scaffold.cluster.AssertNotCalled(t, "Reserve", scaffold.orderID, mock.Anything)
 
 	// Should have closed the bid
-	scaffold.txClient.AssertCalled(t,"Broadcast", mock.Anything, &mtypes.MsgCloseBid{
+	scaffold.txClient.AssertCalled(t, "Broadcast", mock.Anything, &mtypes.MsgCloseBid{
 		BidID: mtypes.MakeBidID(order.orderID, scaffold.testAddr),
 	})
 }
-
 
 func Test_ShouldExitWhenAlreadySetAndLost(t *testing.T) {
 	pricing, err := MakeRandomRangePricing()
 	require.NoError(t, err)
 	cfg := Config{
 		PricingStrategy: pricing,
-		Deposit:         sdk.NewInt64Coin(testutil.CoinDenom,1),
+		Deposit:         sdk.NewInt64Coin(testutil.CoinDenom, 1),
 		BidTimeout:      time.Minute,
 		Attributes:      nil,
 	}
 
-	order, scaffold, _ := makeOrderForTest(t, true, mtypes.BidLost, nil, &cfg,testBidCreatedAt)
+	order, scaffold, _ := makeOrderForTest(t, true, mtypes.BidLost, nil, &cfg, testBidCreatedAt)
 
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 
@@ -529,7 +528,7 @@ func Test_ShouldExitWhenAlreadySetAndLost(t *testing.T) {
 	scaffold.cluster.AssertNotCalled(t, "Reserve", scaffold.orderID, mock.Anything)
 
 	// Should not have closed the bid
-	scaffold.txClient.AssertNotCalled(t,"Broadcast", mock.Anything, &mtypes.MsgCloseBid{
+	scaffold.txClient.AssertNotCalled(t, "Broadcast", mock.Anything, &mtypes.MsgCloseBid{
 		BidID: mtypes.MakeBidID(order.orderID, scaffold.testAddr),
 	})
 }
@@ -551,7 +550,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndThenTimeout(t *testing.T) {
 	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
 
 	// Should have closed the bid
-	scaffold.txClient.AssertCalled(t,"Broadcast", mock.Anything, &mtypes.MsgCloseBid{
+	scaffold.txClient.AssertCalled(t, "Broadcast", mock.Anything, &mtypes.MsgCloseBid{
 		BidID: mtypes.MakeBidID(order.orderID, scaffold.testAddr),
 	})
 

--- a/provider/bidengine/provider_attributes_test.go
+++ b/provider/bidengine/provider_attributes_test.go
@@ -43,7 +43,7 @@ func setupProviderAttributesTestScaffold(t *testing.T, ttl time.Duration, client
 
 	retval.queryClient = clientFactory(retval)
 	retval.client.On("Query").Return(retval.queryClient)
-	retval.s = session.New(testutil.Logger(t), retval.client, retval.provider)
+	retval.s = session.New(testutil.Logger(t), retval.client, retval.provider, -1)
 	retval.bus = pubsub.NewBus()
 	var err error
 	retval.service, err = newProviderAttrSignatureServiceInternal(retval.s, retval.bus, ttl)

--- a/provider/cluster/lease_withdraw.go
+++ b/provider/cluster/lease_withdraw.go
@@ -130,8 +130,10 @@ loop:
 	}
 	cancel()
 
-	// The context has been cancelled, so wait for the result now and discard it
-	<-result
+	if result != nil {
+		// The context has been cancelled, so wait for the result now and discard it
+		<-result
+	}
 
 	dw.log.Debug("shutdown complete")
 }

--- a/provider/cluster/manager.go
+++ b/provider/cluster/manager.go
@@ -94,6 +94,7 @@ func newDeploymentManager(s *service, lease mtypes.LeaseID, mgroup *manifest.Gro
 
 	go func() {
 		<-dm.lc.Done()
+		dm.log.Debug("sending manager into channel")
 		s.managerch <- dm
 	}()
 
@@ -143,6 +144,7 @@ func (dm *deploymentManager) run() {
 		if err != nil {
 			dm.log.Error("failed releasing hostnames", "err", err)
 		}
+		dm.log.Debug("hostnames released")
 	}()
 
 loop:
@@ -208,6 +210,7 @@ loop:
 		}
 	}
 
+	dm.log.Debug("shutting down")
 	dm.lc.ShutdownInitiated(shutdownErr)
 
 	if runch != nil {

--- a/provider/cluster/monitor_test.go
+++ b/provider/cluster/monitor_test.go
@@ -24,7 +24,7 @@ func TestMonitorInstantiate(t *testing.T) {
 
 	statusResult := &ctypes.LeaseStatus{}
 	client.On("LeaseStatus", mock.Anything, lid).Return(statusResult, nil)
-	mySession := session.New(myLog, nil, nil)
+	mySession := session.New(myLog, nil, nil, -1)
 
 	lc := lifecycle.New()
 	myDeploymentManager := &deploymentManager{
@@ -59,7 +59,7 @@ func TestMonitorSendsClusterDeploymentPending(t *testing.T) {
 
 	statusResult := &ctypes.LeaseStatus{}
 	client.On("LeaseStatus", mock.Anything, lid).Return(statusResult, nil)
-	mySession := session.New(myLog, nil, nil)
+	mySession := session.New(myLog, nil, nil, -1)
 
 	sub, err := bus.Subscribe()
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestMonitorSendsClusterDeploymentDeployed(t *testing.T) {
 		AvailableReplicas:  0,
 	}
 	client.On("LeaseStatus", mock.Anything, lid).Return(statusResult, nil)
-	mySession := session.New(myLog, nil, nil)
+	mySession := session.New(myLog, nil, nil, -1)
 
 	sub, err := bus.Subscribe()
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestMonitorSendsClusterDeploymentWithForwardedPort(t *testing.T) {
 		Name:         serviceName,
 	}
 	client.On("LeaseStatus", mock.Anything, lid).Return(statusResult, nil)
-	mySession := session.New(myLog, nil, nil)
+	mySession := session.New(myLog, nil, nil, -1)
 
 	sub, err := bus.Subscribe()
 	require.NoError(t, err)

--- a/provider/cmd/manifest.go
+++ b/provider/cmd/manifest.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -97,7 +96,7 @@ func doSendManifest(cmd *cobra.Command, sdlpath string) error {
 			return err
 		}
 
-		err = gclient.SubmitManifest(context.Background(), dseq, mani)
+		err = gclient.SubmitManifest(cmd.Context(), dseq, mani)
 		res := result{
 			Provider: prov,
 			Status:   "PASS",

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -481,7 +481,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	)
 
 	res, err := aclient.Query().Provider(
-		context.Background(),
+		cmd.Context(),
 		&ptypes.QueryProviderRequest{Owner: info.GetAddress().String()},
 	)
 	if err != nil {
@@ -515,7 +515,12 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	session := session.New(log, aclient, pinfo)
+	statusResult, err := cctx.Client.Status(cmd.Context())
+	if err != nil {
+		return err
+	}
+	currentBlockHeight := statusResult.SyncInfo.LatestBlockHeight
+	session := session.New(log, aclient, pinfo, currentBlockHeight)
 
 	if err := cctx.Client.Start(); err != nil {
 		return err

--- a/provider/cmd/status.go
+++ b/provider/cmd/status.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
@@ -42,7 +40,7 @@ func doStatus(cmd *cobra.Command, addr sdk.Address) error {
 		return err
 	}
 
-	result, err := gclient.Status(context.Background())
+	result, err := gclient.Status(cmd.Context())
 	if err != nil {
 		return showErrorToUser(err)
 	}

--- a/provider/manifest/manager_test.go
+++ b/provider/manifest/manager_test.go
@@ -127,7 +127,11 @@ func serviceForManifestTest(t *testing.T, cfg ServiceConfig, mani sdl.SDL, did d
 
 	queryMock.On("ActiveLeasesForProvider", p.Address()).Return([]mtypes.QueryLeaseResponse{}, nil)
 
-	serviceInterface, err := NewService(ctx, session.New(log, clientMock, p), bus, hostnames, cfg)
+	createdAtBlockHeight := int64(-1)
+	if len(leases) != 0 {
+		createdAtBlockHeight = leases[0].GetCreatedAt() - 1
+	}
+	serviceInterface, err := NewService(ctx, session.New(log, clientMock, p, createdAtBlockHeight), bus, hostnames, cfg)
 	require.NoError(t, err)
 
 	svc := serviceInterface.(*service)

--- a/provider/manifest/watchdog_test.go
+++ b/provider/manifest/watchdog_test.go
@@ -41,7 +41,7 @@ func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *
 
 	scaffold.client = &clientmocks.Client{}
 	scaffold.client.On("Tx").Return(txClientMock)
-	sess := session.New(testutil.Logger(t), scaffold.client, &scaffold.provider)
+	sess := session.New(testutil.Logger(t), scaffold.client, &scaffold.provider, -1)
 	require.NotNil(t, sess.Client())
 
 	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout)

--- a/provider/session/session.go
+++ b/provider/session/session.go
@@ -19,17 +19,17 @@ type Session interface {
 // New returns new session instance with provided details
 func New(log log.Logger, client client.Client, provider *ptypes.Provider, createdAtBlockHeight int64) Session {
 	return session{
-		client:   client,
-		provider: provider,
-		log:      log,
+		client:               client,
+		provider:             provider,
+		log:                  log,
 		createdAtBlockHeight: createdAtBlockHeight,
 	}
 }
 
 type session struct {
-	client   client.Client
-	provider *ptypes.Provider
-	log      log.Logger
+	client               client.Client
+	provider             *ptypes.Provider
+	log                  log.Logger
 	createdAtBlockHeight int64
 }
 

--- a/provider/session/session.go
+++ b/provider/session/session.go
@@ -13,14 +13,16 @@ type Session interface {
 	Client() client.Client
 	Provider() *ptypes.Provider
 	ForModule(string) Session
+	CreatedAtBlockHeight() int64
 }
 
 // New returns new session instance with provided details
-func New(log log.Logger, client client.Client, provider *ptypes.Provider) Session {
+func New(log log.Logger, client client.Client, provider *ptypes.Provider, createdAtBlockHeight int64) Session {
 	return session{
 		client:   client,
 		provider: provider,
 		log:      log,
+		createdAtBlockHeight: createdAtBlockHeight,
 	}
 }
 
@@ -28,6 +30,7 @@ type session struct {
 	client   client.Client
 	provider *ptypes.Provider
 	log      log.Logger
+	createdAtBlockHeight int64
 }
 
 func (s session) Log() log.Logger {
@@ -45,4 +48,8 @@ func (s session) Provider() *ptypes.Provider {
 func (s session) ForModule(name string) Session {
 	s.log = s.log.With("module", name)
 	return s
+}
+
+func (s session) CreatedAtBlockHeight() int64 {
+	return s.createdAtBlockHeight
 }

--- a/provider/session/session_test.go
+++ b/provider/session/session_test.go
@@ -1,0 +1,12 @@
+package session
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSessionGetCreatedAt(t *testing.T){
+	const testCreatedAt = int64(13156)
+	s := New(nil,nil,nil, testCreatedAt)
+	assert.Equal(t, s.CreatedAtBlockHeight(), testCreatedAt)
+}

--- a/provider/session/session_test.go
+++ b/provider/session/session_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestSessionGetCreatedAt(t *testing.T){
+func TestSessionGetCreatedAt(t *testing.T) {
 	const testCreatedAt = int64(13156)
-	s := New(nil,nil,nil, testCreatedAt)
+	s := New(nil, nil, nil, testCreatedAt)
 	assert.Equal(t, s.CreatedAtBlockHeight(), testCreatedAt)
 }

--- a/testutil/channel_wait.go
+++ b/testutil/channel_wait.go
@@ -34,12 +34,12 @@ func ChannelWaitForValueUpTo(t *testing.T, waitOn interface{}, waitFor time.Dura
 }
 
 const waitForDefault = 10 * time.Second
-func ChannelWaitForValue(t *testing.T, waitOn interface{}) interface{} {
 
+func ChannelWaitForValue(t *testing.T, waitOn interface{}) interface{} {
 	return ChannelWaitForValueUpTo(t, waitOn, waitForDefault)
 }
 
-func ChannelWaitForCloseUpTo(t *testing.T, waitOn interface{}, waitFor time.Duration)  {
+func ChannelWaitForCloseUpTo(t *testing.T, waitOn interface{}, waitFor time.Duration) {
 	cases := make([]reflect.SelectCase, 2)
 	cases[0] = reflect.SelectCase{
 		Dir:  reflect.SelectRecv,
@@ -58,7 +58,6 @@ func ChannelWaitForCloseUpTo(t *testing.T, waitOn interface{}, waitFor time.Dura
 	idx, v, ok := reflect.Select(cases)
 	if !ok {
 		return // Channel closed, everything OK
-		t.Fatal("Channel has been closed")
 	}
 	if idx != 0 {
 		t.Fatalf("channel not closed after waiting %v seconds", waitOn)

--- a/testutil/channel_wait.go
+++ b/testutil/channel_wait.go
@@ -33,7 +33,40 @@ func ChannelWaitForValueUpTo(t *testing.T, waitOn interface{}, waitFor time.Dura
 	return v.Interface()
 }
 
+const waitForDefault = 10 * time.Second
 func ChannelWaitForValue(t *testing.T, waitOn interface{}) interface{} {
-	const waitForDefault = 10 * time.Second
+
 	return ChannelWaitForValueUpTo(t, waitOn, waitForDefault)
+}
+
+func ChannelWaitForCloseUpTo(t *testing.T, waitOn interface{}, waitFor time.Duration)  {
+	cases := make([]reflect.SelectCase, 2)
+	cases[0] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(waitOn),
+		Send: reflect.Value{},
+	}
+
+	delayChan := time.After(waitFor)
+
+	cases[1] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(delayChan),
+		Send: reflect.Value{},
+	}
+
+	idx, v, ok := reflect.Select(cases)
+	if !ok {
+		return // Channel closed, everything OK
+		t.Fatal("Channel has been closed")
+	}
+	if idx != 0 {
+		t.Fatalf("channel not closed after waiting %v seconds", waitOn)
+	}
+
+	t.Fatalf("got unexpected message: %v", v.Interface())
+}
+
+func ChannelWaitForClose(t *testing.T, waitOn interface{}) {
+	ChannelWaitForCloseUpTo(t, waitOn, waitForDefault)
 }


### PR DESCRIPTION
There were a few issues brought up here that I fixed

1. If the provider finds a bid on startup, apply the standard timeout to it before closing
2. If the provider finds a bid on startup, make sure it is in the bid open state
3. If the provider finds a bid on startup that is very old, close it immediately
4. If the provider order goroutine gets a bid closed event for that order then terminate. This means someone did it with the CLI most likely
5. Don't close the bid on bid created. The bid is already in the `BidLost` state due to the way the market module is implemented. The network basically closes it for us, saving us fees.

**Code style stuff**

1. Remove `order.bidPlaced`. I don't know why this was a member variable. It is just a local variable now.
2. Add a helper for computing bid timeout
3. Add a helper for determining if bid timeout is enabled
4. Add created at block height to provider session, indicating when the session object was created at
5. I estimated block time at 5 seconds, since I don't want to fetch it from the order goroutine
6. Remove our pervasive use of `context.Background()` in the provider commands. I don't know how this ever got there but `cmd.Context()` is the correct context to be using