### PR TITLE
fix(sdkutil): get txhash from serialized tx rather than response

### DIFF
--- a/sdkutil/broadcast.go
+++ b/sdkutil/broadcast.go
@@ -3,6 +3,7 @@ package sdkutil
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -19,7 +20,7 @@ import (
 )
 
 const (
-	broadcastBlockRetryTimeout = 30 * time.Second
+	broadcastBlockRetryTimeout = 300 * time.Second
 	broadcastBlockRetryPeriod  = time.Second
 
 	// sadface.
@@ -33,27 +34,27 @@ const (
 	notFoundErrorMessageSuffix = ") not found"
 )
 
-func BroadcastTX(ctx client.Context, flags *pflag.FlagSet, msgs ...sdk.Msg) error {
+func BroadcastTX(ctx context.Context, cctx client.Context, flags *pflag.FlagSet, msgs ...sdk.Msg) error {
 
 	// rewrite of https://github.com/cosmos/cosmos-sdk/blob/ca98fda6eae597b1e7d468f96d030b6d905748d7/client/tx/tx.go#L29
 	// to add continuing retries if broadcast-mode=block fails with a timeout.
 
-	txf := tx.NewFactoryCLI(ctx, flags)
+	txf := tx.NewFactoryCLI(cctx, flags)
 
-	if ctx.GenerateOnly {
-		return tx.GenerateTx(ctx, txf, msgs...)
+	if cctx.GenerateOnly {
+		return tx.GenerateTx(cctx, txf, msgs...)
 	}
 
-	txf, err := tx.PrepareFactory(ctx, txf)
+	txf, err := tx.PrepareFactory(cctx, txf)
 	if err != nil {
 		return err
 	}
 
-	txf, err = adjustGas(ctx, txf, msgs...)
+	txf, err = adjustGas(cctx, txf, msgs...)
 	if err != nil {
 		return err
 	}
-	if ctx.Simulate {
+	if cctx.Simulate {
 		return nil
 	}
 
@@ -62,56 +63,52 @@ func BroadcastTX(ctx client.Context, flags *pflag.FlagSet, msgs ...sdk.Msg) erro
 		return err
 	}
 
-	ok, err := confirmTx(ctx, txb)
+	ok, err := confirmTx(cctx, txb)
 	if !ok || err != nil {
 		return err
 	}
 
-	err = tx.Sign(txf, ctx.GetFromName(), txb, true)
+	err = tx.Sign(txf, cctx.GetFromName(), txb, true)
 	if err != nil {
 		return err
 	}
 
-	txBytes, err := ctx.TxConfig.TxEncoder()(txb.GetTx())
+	txBytes, err := cctx.TxConfig.TxEncoder()(txb.GetTx())
 	if err != nil {
 		return err
 	}
 
-	res, err := doBroadcast(ctx, broadcastBlockRetryTimeout, txBytes)
+	res, err := doBroadcast(ctx, cctx, broadcastBlockRetryTimeout, txBytes)
 	if err != nil {
 		return err
 	}
 
-	return ctx.PrintProto(res)
+	return cctx.PrintProto(res)
 
 }
 
-func doBroadcast(ctx client.Context, timeout time.Duration, txb ttypes.Tx) (*sdk.TxResponse, error) {
-	switch ctx.BroadcastMode {
+func doBroadcast(ctx context.Context, cctx client.Context, timeout time.Duration, txb ttypes.Tx) (*sdk.TxResponse, error) {
+	switch cctx.BroadcastMode {
 	case flags.BroadcastSync:
-		return ctx.BroadcastTxSync(txb)
+		return cctx.BroadcastTxSync(txb)
 	case flags.BroadcastAsync:
-		return ctx.BroadcastTxAsync(txb)
+		return cctx.BroadcastTxAsync(txb)
 	}
 
+	hash := hex.EncodeToString(txb.Hash())
+
 	// broadcast-mode=block
-
 	// submit with mode commit/block
-	cres, err := ctx.BroadcastTxCommit(txb)
-
-	switch {
-	case err == nil:
-		// no error, return
+	cres, err := cctx.BroadcastTxCommit(txb)
+	if err == nil {
+		// good job
+		return cres, nil
+	} else if !strings.HasSuffix(err.Error(), timeoutErrorMessage) {
 		return cres, err
-	case err.Error() != timeoutErrorMessage:
-		// other error, return
-		return cres, err
-	default:
-		// timeout error, continue on to retry
 	}
 
 	// loop
-	lctx, cancel := context.WithTimeout(context.Background(), timeout)
+	lctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	for lctx.Err() == nil {
@@ -124,7 +121,7 @@ func doBroadcast(ctx client.Context, timeout time.Duration, txb ttypes.Tx) (*sdk
 		}
 
 		// check transaction
-		res, err := authclient.QueryTx(ctx, cres.TxHash)
+		res, err := authclient.QueryTx(cctx, hash)
 		if err == nil {
 			return res, nil
 		}

--- a/x/audit/client/cli/tx.go
+++ b/x/audit/client/cli/tx.go
@@ -85,7 +85,7 @@ func cmdCreateProviderAttributes() *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -125,7 +125,7 @@ func cmdDeleteProviderAttributes() *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/cert/client/cli/tx.go
+++ b/x/cert/client/cli/tx.go
@@ -27,7 +27,6 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/ovrclk/akash/sdkutil"
 	"github.com/ovrclk/akash/x/cert/types"
@@ -107,7 +106,7 @@ func cmdRevoke() *cobra.Command {
 				serial = cert.SerialNumber.String()
 			}
 
-			return doRevoke(cctx, cmd.Flags(), serial)
+			return doRevoke(cmd, cctx, serial)
 		},
 	}
 
@@ -158,7 +157,7 @@ func handleCreate(cctx sdkclient.Context, cmd *cobra.Command, pemFile string, do
 	}
 
 	if !toGenesis {
-		return sdkutil.BroadcastTX(cctx, cmd.Flags(), msg)
+		return sdkutil.BroadcastTX(cmd.Context(), cctx, cmd.Flags(), msg)
 	}
 
 	return addCertToGenesis(cmd, types.GenesisCertificate{
@@ -258,12 +257,12 @@ func doCreateCmd(cmd *cobra.Command, domains []string) error {
 						return err
 					}
 
-					return sdkutil.BroadcastTX(cctx, cmd.Flags(), msg)
+					return sdkutil.BroadcastTX(cmd.Context(), cctx, cmd.Flags(), msg)
 				}
 			}
 		} else {
 			if res.Certificates[0].Certificate.IsState(types.CertificateValid) {
-				err = doRevoke(cctx, cmd.Flags(), x509cert.SerialNumber.String())
+				err = doRevoke(cmd, cctx, x509cert.SerialNumber.String())
 				if err == nil {
 					removeFile = true
 				}
@@ -509,7 +508,7 @@ func createAuthPem(cmd *cobra.Command, pemFile string, domains []string) (*types
 	return msg, nil
 }
 
-func doRevoke(cctx sdkclient.Context, flags *pflag.FlagSet, serial string) error {
+func doRevoke(cmd *cobra.Command, cctx sdkclient.Context, serial string) error {
 	msg := &types.MsgRevokeCertificate{
 		ID: types.CertificateID{
 			Owner:  cctx.FromAddress.String(),
@@ -517,7 +516,7 @@ func doRevoke(cctx sdkclient.Context, flags *pflag.FlagSet, serial string) error
 		},
 	}
 
-	return sdkutil.BroadcastTX(cctx, flags, msg)
+	return sdkutil.BroadcastTX(cmd.Context(), cctx, cmd.Flags(), msg)
 }
 
 func getConfirmation(cmd *cobra.Command, prompt string) (bool, error) {

--- a/x/deployment/client/cli/tx.go
+++ b/x/deployment/client/cli/tx.go
@@ -104,7 +104,7 @@ func cmdCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -141,7 +141,7 @@ func cmdDeposit(key string) *cobra.Command {
 				Amount: deposit,
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -169,7 +169,7 @@ func cmdClose(key string) *cobra.Command {
 
 			msg := &types.MsgCloseDeployment{ID: id}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -218,7 +218,7 @@ func cmdUpdate(key string) *cobra.Command {
 				msg.Groups = append(msg.Groups, *group)
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -268,7 +268,7 @@ func cmdGroupClose(_ string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -304,7 +304,7 @@ func cmdGroupPause(_ string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -340,7 +340,7 @@ func cmdGroupStart(_ string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -85,7 +85,7 @@ func cmdBidCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -121,7 +121,7 @@ func cmdBidClose(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -170,7 +170,7 @@ func cmdLeaseCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -205,7 +205,7 @@ func cmdLeaseWithdraw(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -240,7 +240,7 @@ func cmdLeaseClose(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 

--- a/x/provider/client/cli/tx.go
+++ b/x/provider/client/cli/tx.go
@@ -57,7 +57,7 @@ func cmdCreate(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 
@@ -93,7 +93,7 @@ func cmdUpdate(key string) *cobra.Command {
 				return err
 			}
 
-			return sdkutil.BroadcastTX(clientCtx, cmd.Flags(), msg)
+			return sdkutil.BroadcastTX(cmd.Context(), clientCtx, cmd.Flags(), msg)
 		},
 	}
 


### PR DESCRIPTION
Pass command context to the BroadcastTX allows tests to
properly handle context.Cancel

fixes #1432

Signed-off-by: Artur Troian <troian.ap@gmail.com>