### PR TITLE
fix(_run): add missing clean target for lite

### DIFF
--- a/_run/lite/Makefile
+++ b/_run/lite/Makefile
@@ -28,3 +28,5 @@ provider-service-status:
 		--from      "$(KEY_NAME)" \
 		--provider  "$(PROVIDER_ADDRESS)"
 
+.PHONY: clean-lite
+clean-lite:


### PR DESCRIPTION
Signed-off-by: Artur Troian <troian.ap@gmail.com>
