### PR TITLE
fix(test): flapping call count on provider attributes mock

### DIFF
--- a/provider/bidengine/provider_attributes_test.go
+++ b/provider/bidengine/provider_attributes_test.go
@@ -120,6 +120,10 @@ func TestProvAttrCachesValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, attrs, 1)
 
+	// fetching provider attributes prevents call check below from flapping between values 1 and 2
+	_, err = scaffold.service.GetAttributes()
+	require.NoError(t, err)
+
 	scaffold.stop(t)
 
 	// Should have 2 calls


### PR DESCRIPTION
fetch provider attributes to prevent call check from flapping between values 1 and 2

fixes fails like this https://github.com/ovrclk/akash/runs/4564809822?check_suite_focus=true#step:6:214

Signed-off-by: Artur Troian <troian.ap@gmail.com>