### PR TITLE
fix(sdl): Do not allow service names starting with a number

### DIFF
--- a/validation/manifest.go
+++ b/validation/manifest.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	serviceNameValidationRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	serviceNameValidationRegex = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
 	hostnameMaxLen             = 255
 )
 

--- a/validation/manifest_test.go
+++ b/validation/manifest_test.go
@@ -331,13 +331,11 @@ func TestManifestWithBadServiceNameIsInvalid(t *testing.T) {
 
 func TestManifestWithServiceNameIsValid(t *testing.T) {
 	m := simpleManifest()
-	m[0].Services[0].Name = "12345" // allows all numbers
-	err := validation.ValidateManifest(m)
-	require.NoError(t, err)
 
-	m[0].Services[0].Name = "9aaa-bar" // allows starting with a number
-	err = validation.ValidateManifest(m)
-	require.NoError(t, err)
+	m[0].Services[0].Name = "9aaa-bar" // does not allow starting with a number
+	err := validation.ValidateManifest(m)
+	require.ErrorIs(t, err, validation.ErrInvalidManifest)
+	require.Regexp(t, "^.*name is invalid.*$", err)
 }
 
 func TestManifestWithDuplicateHostIsInvalid(t *testing.T) {


### PR DESCRIPTION
@arno01 found that a service name starting with a number never comes online in Kubernetes and causes all sort of errors & failures.

We already have some validation around this, so I just updated the regex & the associated tests to block out anything starting with a number. It never worked anyways.