### PR TITLE
akash image: bump debian version

### DIFF
--- a/_build/Dockerfile.akash
+++ b/_build/Dockerfile.akash
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 COPY ./akash /bin/
 


### PR DESCRIPTION
Just bumping the image to the current stable Debian release.

One of the reasons is that I have noticed that akash-node from Helm Charts [is using aria2](https://github.com/ovrclk/helm-charts/blob/64e02cb0fd8b83bf32beacc0a68d934a33ce0340/charts/akash-node/templates/configmap.yaml#L21) v1.34 from debian:buster, which is too old to understand TLS v1.3:

```
02/07 21:58:21 [WARN] aria2c had to connect to the other side using an unknown TLS protocol. The integrity and confidentiality of the connection might be compromised.
Peer: cosmos-snapshots.s3.filebase.com (135.148.54.72:443)
```

Made a simple test by building the Dockerfile.akash, running the "akash version" from inside, did not give an error.

PR for master -> https://github.com/ovrclk/akash/pull/1516
