### PR TITLE
fix(provider): If a pod is not ready, do not try and launch a shell

### DIFF
--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	sdktest "github.com/cosmos/cosmos-sdk/testutil"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	ctypes "github.com/ovrclk/akash/provider/cluster/types/v1beta2"
@@ -1056,62 +1055,68 @@ func (s *E2EDeploymentUpdate) TestE2ELeaseShell() {
 		fmt.Sprintf("--%s=%s", flags.FlagHome, s.validator.ClientCtx.HomeDir),
 	}
 
-	const attempts = 30
-	const pollingPeriod = time.Second
-
 	var out sdktest.BufferWriter
 
-	i := 0
-	for ; i != attempts; i++ {
-		out, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	leaseShellCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	logged := make(map[string]struct{})
+	// Loop until we get a shell or the context times out
+	for {
+		select {
+		case <-leaseShellCtx.Done():
+			s.T().Fatalf("context is done while trying to run lease-shell: %v", leaseShellCtx.Err())
+			return
+		default:
+		}
+		out, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 			lID, 0, false, false, "web", "/bin/echo", "foo")
 		if err != nil {
-			if errors.Is(err, rest.ErrLeaseShellProviderError) {
-				s.T().Logf("encountered %v waiting before next attempt", err)
-				time.Sleep(pollingPeriod)
-				continue
+			_, hasBeenLogged := logged[err.Error()]
+			if !hasBeenLogged {
+				// Don't spam an error message in a test, that is very annoying
+				s.T().Logf("encountered %v, waiting before next attempt", err)
+				logged[err.Error()] = struct{}{}
 			}
-
-			// Fail now
-			s.T().Fatalf("failed while trying to run lease-shell: %v", err)
+			time.Sleep(100 * time.Millisecond)
+			continue // Try again until the context times out
 		}
 		require.NotNil(s.T(), out)
 		break
 	}
-	require.NotEqual(s.T(), attempts, i, "failed to run lease shell after %d attempts", attempts)
 
 	// Test failure cases now
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 0, false, false, "web", "/bin/baz", "foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*command could not be executed because it does not exist.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 0, false, false, "web", "baz", "foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*command could not be executed because it does not exist.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 0, false, false, "web", "baz", "foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*command could not be executed because it does not exist.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 99, false, false, "web", "/bin/echo", "foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*pod index out of range.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 99, false, false, "web", "/bin/echo", "foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*pod index out of range.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 0, false, false, "web", "/bin/cat", "/foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*remote process exited with code 1.*", err.Error())
 
-	_, err = ptestutil.TestLeaseShell(s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
+	_, err = ptestutil.TestLeaseShell(leaseShellCtx, s.validator.ClientCtx.WithOutputFormat("json"), extraArgs,
 		lID, 99, false, false, "notaservice", "/bin/echo", "/foo")
 	require.Error(s.T(), err)
 	require.Regexp(s.T(), ".*no such service exists with that name.*", err.Error())

--- a/provider/cluster/kube/client_exec.go
+++ b/provider/cluster/kube/client_exec.go
@@ -105,7 +105,7 @@ loop:
 	isReady := false
 	for _, cond := range selectedPod.Status.Conditions {
 		if cond.Type == corev1.PodReady {
-			 isReady = cond.Status == corev1.ConditionTrue
+			isReady = cond.Status == corev1.ConditionTrue
 		}
 	}
 

--- a/provider/cluster/kube/client_exec.go
+++ b/provider/cluster/kube/client_exec.go
@@ -101,6 +101,18 @@ loop:
 	default:
 	}
 
+	// Check the conditions, make sure the pod is marked as ready
+	isReady := false
+	for _, cond := range selectedPod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			 isReady = cond.Status == corev1.ConditionTrue
+		}
+	}
+
+	if !isReady {
+		return nil, fmt.Errorf("%w: the service is not ready", cluster.ErrExecServiceNotRunning)
+	}
+
 	podName := selectedPod.Name
 	containerName := serviceName // Container name is always the same as the service name
 

--- a/provider/cluster/kube/client_exec_test.go
+++ b/provider/cluster/kube/client_exec_test.go
@@ -1,18 +1,42 @@
 package kube
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	crd "github.com/ovrclk/akash/pkg/apis/akash.network/v2beta1"
+	akashclient_fake "github.com/ovrclk/akash/pkg/client/clientset/versioned/fake"
+	"github.com/ovrclk/akash/provider/cluster"
+	"github.com/ovrclk/akash/provider/cluster/kube/builder"
+	"github.com/ovrclk/akash/sdl"
+	"github.com/ovrclk/akash/testutil"
+	mtypes "github.com/ovrclk/akash/x/market/types/v1beta2"
+	"errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"net/http"
+	"net/url"
+	"path/filepath"
 	"sort"
 	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
+
+const (
+	execTestServiceName = "web"
+	)
+
+var errNoSPDYInTest = errors.New("SPDY connections blocked in test")
 
 func TestSortablePodsSorting(t *testing.T) {
 	v := sortablePods{
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "z"}},
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "a"}},
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "b"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "z"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
 	}
 
 	sort.Sort(v)
@@ -24,9 +48,9 @@ func TestSortablePodsSorting(t *testing.T) {
 
 func TestSortablePodsAlreadySorted(t *testing.T) {
 	v := sortablePods{
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "a"}},
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "b"}},
-		corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "c"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+		corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "c"}},
 	}
 
 	sort.Sort(v)
@@ -40,4 +64,265 @@ func TestExecResultImpl(t *testing.T) {
 	v := execResult{exitCode: 133}
 
 	require.Equal(t, 133, v.ExitCode())
+}
+
+type execScaffold struct {
+	settings builder.Settings
+	leaseID mtypes.LeaseID
+
+	deploymentSDL sdl.SDL
+	crdManifest *crd.Manifest
+
+	akashFake *akashclient_fake.Clientset
+	kubeFake *kubefake.Clientset
+
+	client Client
+
+	ctx context.Context
+
+}
+
+type fakeRoundTripper int
+
+func (fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("joe")
+}
+
+func withExecTestScaffold(t *testing.T, changePod func(pod *corev1.Pod) error, test func(s *execScaffold)){
+	s := &execScaffold{}
+
+	s.leaseID = testutil.LeaseID(t)
+	s.settings = builder.Settings{
+		DeploymentIngressStaticHosts: true,
+		DeploymentIngressDomain:      "*.foo.bar.com",
+	}
+
+	settingCtx := context.WithValue(context.Background(), builder.SettingsKey, s.settings)
+	var cancel context.CancelFunc
+	s.ctx, cancel = context.WithTimeout(settingCtx, 30 *time.Second)
+	defer cancel()
+
+	deploymentPath, err := filepath.Abs("../../../x/deployment/testdata/deployment-v2.yaml")
+	require.NoError(t, err)
+
+	s.deploymentSDL, err = sdl.ReadFile(deploymentPath)
+	require.NoError(t, err)
+	require.NotNil(t, s.deploymentSDL)
+
+	mani, err := s.deploymentSDL.Manifest()
+	require.NoError(t, err)
+	require.Len(t, mani, 1)
+
+	s.crdManifest, err = crd.NewManifest(testKubeClientNs, s.leaseID, &mani[0])
+	require.NoError(t, err)
+	require.NotNil(t, s.crdManifest)
+
+	s.akashFake = akashclient_fake.NewSimpleClientset(s.crdManifest)
+	s.kubeFake = kubefake.NewSimpleClientset()
+
+	pod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "testpod0",
+			Labels:                     map[string]string{
+				"akash.network/manifest-service" : execTestServiceName,
+			},
+		},
+		Status:     corev1.PodStatus{
+			Phase:                      corev1.PodRunning,
+			Conditions:                 []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	if changePod != nil {
+		err = changePod(pod)
+		require.NoError(t, err)
+	}
+
+	_, err = s.kubeFake.CoreV1().Pods(s.crdManifest.Name).Create(s.ctx, pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	myLog := testutil.Logger(t)
+
+		s.client = &client{
+		kc:                s.kubeFake,
+		ac:                s.akashFake,
+		ns:                testKubeClientNs,
+		log:               myLog.With("mode", "test-kube-provider-client"),
+		kubeContentConfig: &rest.Config{
+			/**
+			The Transport and Dial members of this aren't used because a SPDY transport is created. The only
+			opportunity to hijack that is in the Proxy function
+			 */
+			Host:                "localhost:1234", // Never connected to, just needs to be something valid
+			APIPath:             "/client-exec-test",
+			UserAgent:           "client_exec_test.go",
+			Username: "theusername",
+			Password: "thepassword",
+			Proxy: func(req *http.Request) (*url.URL, error){
+				return nil, errNoSPDYInTest
+			},
+		},
+	}
+
+	test(s)
+}
+
+func TestClientExec(t *testing.T) {
+	withExecTestScaffold(t, nil, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		result, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			"web",
+			0,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		// The arguments are completed valid, so we expect the code to try & establish a SPDY connection
+		// which has been hijacked & blocked by the scaffold
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SPDY connections blocked")
+		require.Nil(t, result)
+	})
+}
+
+func TestClientExecTty(t *testing.T) {
+	withExecTestScaffold(t, nil, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		stdin := &bytes.Buffer{}
+
+		result, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			"web",
+			0,
+			[]string{"/bin/true"},
+			stdin,
+			stdout,
+			stderr,
+			true,
+			nil)
+		// The arguments are completed valid, so we expect the code to try & establish a SPDY connection
+		// which has been hijacked & blocked by the scaffold
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SPDY connections blocked")
+		require.Nil(t, result)
+	})
+}
+
+func TestClientExecWrongServiceName(t *testing.T) {
+	withExecTestScaffold(t, nil, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		_, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			"nottheservice",
+			0,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		require.ErrorIs(t, err, cluster.ErrExecNoServiceWithName)
+	})
+}
+
+func TestClientExecWrongPodIndex(t *testing.T) {
+	withExecTestScaffold(t, nil, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		_, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			execTestServiceName,
+			9999,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		require.ErrorIs(t, err, cluster.ErrExecPodIndexOutOfRange)
+	})
+}
+
+func TestClientExecPodNotRunning(t *testing.T) {
+	withExecTestScaffold(t, func(pod *corev1.Pod) error {
+		pod.Status.Phase = corev1.PodSucceeded
+		return nil
+	}, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		_, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			execTestServiceName,
+			0,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		require.ErrorIs(t, err, cluster.ErrExecServiceNotRunning)
+		require.Contains(t, err.Error(), "service has completed")
+	})
+}
+
+func TestClientExecPodFailed(t *testing.T) {
+	withExecTestScaffold(t, func(pod *corev1.Pod) error {
+		pod.Status.Phase = corev1.PodFailed
+		return nil
+	}, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		_, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			execTestServiceName,
+			0,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		require.ErrorIs(t, err, cluster.ErrExecServiceNotRunning)
+		require.Contains(t, err.Error(), "service has failed")
+	})
+}
+
+func TestClientExecPodNotReady(t *testing.T) {
+	withExecTestScaffold(t, func(pod *corev1.Pod) error {
+		pod.Status.Conditions[0].Status = corev1.ConditionFalse
+		return nil
+	}, func(s *execScaffold){
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		_, err := s.client.Exec(s.ctx,
+			s.leaseID,
+			execTestServiceName,
+			0,
+			[]string{"/bin/true"},
+			nil,
+			stdout,
+			stderr,
+			false,
+			nil)
+		require.ErrorIs(t, err, cluster.ErrExecServiceNotRunning)
+		require.Contains(t, err.Error(), "service is not ready")
+	})
 }

--- a/provider/cluster/kube/client_test.go
+++ b/provider/cluster/kube/client_test.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"context"
+	"k8s.io/client-go/rest"
 	"testing"
 
 	manifest "github.com/ovrclk/akash/manifest/v2beta1"
@@ -35,10 +36,11 @@ const testKubeClientNs = "nstest1111"
 func clientForTest(t *testing.T, kc kubernetes.Interface, ac akashclient.Interface) Client {
 	myLog := testutil.Logger(t)
 	result := &client{
-		kc:  kc,
-		ac:  ac,
-		log: myLog.With("mode", "test-kube-provider-client"),
-		ns:  testKubeClientNs,
+		kc:                kc,
+		ac:                ac,
+		ns:                testKubeClientNs,
+		log:               myLog.With("mode", "test-kube-provider-client"),
+		kubeContentConfig: &rest.Config{},
 	}
 
 	return result

--- a/provider/testutil/provider.go
+++ b/provider/testutil/provider.go
@@ -59,7 +59,7 @@ func TestSendManifest(clientCtx client.Context, id mtypes.BidID, sdlPath string,
 	return testutilcli.ExecTestCLICmd(context.Background(), clientCtx, cobraCmd, args...)
 }
 
-func TestLeaseShell(clientCtx client.Context, extraArgs []string, lID mtypes.LeaseID, replicaIndex int, tty bool, stdin bool, serviceName string, cmd ...string) (sdktest.BufferWriter, error) {
+func TestLeaseShell(ctx context.Context, clientCtx client.Context, extraArgs []string, lID mtypes.LeaseID, replicaIndex int, tty bool, stdin bool, serviceName string, cmd ...string) (sdktest.BufferWriter, error) {
 	args := []string{
 		fmt.Sprintf("--provider=%s", lID.Provider),
 		fmt.Sprintf("--replica-index=%d", replicaIndex),
@@ -81,7 +81,7 @@ func TestLeaseShell(clientCtx client.Context, extraArgs []string, lID mtypes.Lea
 	cobraCmd := pcmd.LeaseShellCmd()
 	releaseCmdLock()
 
-	return testutilcli.ExecTestCLICmd(context.Background(), clientCtx, cobraCmd, args...)
+	return testutilcli.ExecTestCLICmd(ctx, clientCtx, cobraCmd, args...)
 }
 
 func TestMigrateHostname(clientCtx client.Context, leaseID mtypes.LeaseID, dseq uint64, hostname string, cmd ...string) (sdktest.BufferWriter, error) {


### PR DESCRIPTION
In the implementation for the provider lease shell code that talks to kubernetes, just check that the pod is actually ready before launching a shell. If not, give the user a clear error message as to what is going on here.

I also added a bunch of tests for this code since it turned out to be to relatively easy.