### PR TITLE
fix(testutil): guard testWriter with mutex

### DIFF
--- a/testutil/log.go
+++ b/testutil/log.go
@@ -1,21 +1,26 @@
 package testutil
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
 
 func Logger(t testing.TB) log.Logger {
-	return log.NewTMLogger(testWriter{t})
+	return log.NewTMLogger(&testWriter{TB: t})
 }
 
 // Source: https://git.sr.ht/~samwhited/testlog/tree/b1b3e8e82fd6990e91ce9d0fbcbe69ac2d9b1f98/testlog.go
 type testWriter struct {
 	testing.TB
+	lock sync.Mutex
 }
 
-func (tw testWriter) Write(p []byte) (int, error) {
+func (tw *testWriter) Write(p []byte) (int, error) {
+	defer tw.lock.Unlock()
+	tw.lock.Lock()
+
 	tw.Helper()
 	tw.Logf("%s", p)
 	return len(p), nil


### PR DESCRIPTION
prevents data race in logger during tests

Signed-off-by: Artur Troian <troian.ap@gmail.com>

