### PR TITLE
ci(codecov): update action to v2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           go-version: "${{ env.GOLANG_VERSION }}"
       - run: make test-coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
 
   lint:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 ignore:
   - "**/*.pb.go"
+  - "**/*.pb.gw.go"
   - "**/mocks/.*"
   - "**/kubernetes_mock/.*"
   - "pkg"


### PR DESCRIPTION
v1 has been deprecated on [Feb 1 2022](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1)
ignore coverage of *.pb.gw.go files

Signed-off-by: Artur Troian <troian.ap@gmail.com>