### PR TITLE
simpler plaintext export & import of keys

### DIFF
--- a/cmd/akash/cmd/export_import_packed_keys.go
+++ b/cmd/akash/cmd/export_import_packed_keys.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"io"
+	"strings"
+
+	"encoding/base64"
+	"encoding/hex"
+	"github.com/cosmos/cosmos-sdk/crypto"
+
+	//codeclegacy "github.com/cosmos/cosmos-sdk/codec/legacy"
+	//"github.com/btcsuite/btcd/btcec"
+)
+
+const PLAIN_TEXT_HEADER = "PT"
+
+var errInputMissingHeader = errors.New("invalid input: missing header")
+var errInputTruncated = errors.New("invalid input: truncated")
+var errInputInvalidBase64 = errors.New("invalid input: base64 decode failed")
+var errKeyringEmpty = errors.New("keyring is empty, no keys to export")
+var errKeyExists = errors.New("at least one key already exists, overwrite must be enabled ")
+const (
+	flagOverwrite = "overwrite"
+)
+
+func importPacked(cmd *cobra.Command, args []string) error {
+	clientCtx, err := client.GetClientQueryContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	keyNames := []string{}
+	if len(args) == 0 {
+		allKeys, err := clientCtx.Keyring.List()
+		if err != nil {
+			return err
+		}
+		for _, key := range allKeys {
+			keyNames = append(keyNames, key.GetName())
+		}
+	} else {
+		keyNames = args
+	}
+
+	input := cmd.InOrStdin()
+	if len(args) == 1 {
+		input = strings.NewReader(args[0])
+	}
+
+	inputBytes, err := io.ReadAll(input)
+	if err != nil {
+		return err
+	}
+	inputStr := string(inputBytes)
+	inputParts := strings.Split(inputStr, ",")
+	if len(inputParts) < 3 {
+		return errInputTruncated
+	}
+	if inputParts[0] != PLAIN_TEXT_HEADER {
+		return errInputMissingHeader
+	}
+
+	inputParts = inputParts[1:]
+	if len(inputParts) % 2 != 0 {
+		return errInputTruncated
+	}
+	packedKeys := make(map[string][]byte)
+	for i := 0; i != len(inputParts); i+=2 {
+		data, err := base64.RawURLEncoding.DecodeString(inputParts[i+1])
+		if err != nil {
+			return errInputInvalidBase64
+		}
+		packedKeys[inputParts[i]] = data
+	}
+
+	unsafeKeyring := keyring.NewUnsafe(clientCtx.Keyring)
+	overwriteOk, err := cmd.Flags().GetBool(flagOverwrite)
+	if err != nil {
+		return err
+	}
+
+	existingKeys, err := unsafeKeyring.List()
+	if err != nil {
+		return err
+	}
+
+	existingKeyNames := make(map[string]struct{})
+	for _, existingKey := range existingKeys {
+		existingKeyNames[existingKey.GetName()] = struct{}{}
+	}
+	for keyName := range packedKeys {
+		_, exists := existingKeyNames[keyName]
+		if exists {
+			if overwriteOk {
+				err = unsafeKeyring.Delete(keyName)
+				if err != nil {
+					return err
+				}
+			} else {
+				return errKeyExists
+			}
+		}
+	}
+
+
+	const notPassword = "secret"
+	for keyName, keyBytes := range packedKeys {
+		k := &secp256k1.PrivKey{
+			Key: keyBytes,
+		}
+
+		armored := crypto.EncryptArmorPrivKey(k, notPassword, string(hd.Secp256k1Type))
+		err = unsafeKeyring.ImportPrivKey(keyName, armored, notPassword)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func exportPacked(cmd *cobra.Command, args []string) error {
+	clientCtx, err := client.GetClientQueryContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	keyNames := []string{}
+	if len(args) == 0 {
+		allKeys, err := clientCtx.Keyring.List()
+		if err != nil {
+			return err
+		}
+		for _, key := range allKeys {
+			keyNames = append(keyNames, key.GetName())
+		}
+		if len(keyNames) == 0 {
+			return errKeyringEmpty
+		}
+	} else {
+		keyNames = args
+	}
+
+	unsafeKeyring := keyring.NewUnsafe(clientCtx.Keyring)
+	cmd.Printf("%s,", PLAIN_TEXT_HEADER)
+
+	for i, keyName := range keyNames {
+		hexPrivKey, err := unsafeKeyring.UnsafeExportPrivKeyHex(keyName)
+		if err != nil {
+			return err
+		}
+		privKey, err := hex.DecodeString(hexPrivKey)
+		if err != nil {
+			return err
+		}
+		privKeyB64 := base64.RawURLEncoding.EncodeToString(privKey)
+
+		cmd.Printf("%s,%s", keyName, privKeyB64)
+
+		if i != len(keyNames) - 1 {
+			cmd.Print(",")
+		}
+	}
+
+	return nil
+}
+
+func exportPackedCmd() *cobra.Command{
+	cmd := &cobra.Command{
+		Use:                        "export-packed",
+		Aliases:                    nil,
+		SuggestFor:                 nil,
+		Short:                      "export-packed",
+		Long:                       "",
+		Example:                    "",
+		ValidArgs:                  nil,
+		ValidArgsFunction:          nil,
+		Args:                       nil,
+		ArgAliases:                 nil,
+		BashCompletionFunction:     "",
+		Deprecated:                 "",
+		Annotations:                nil,
+		Version:                    "",
+		PersistentPreRun:           nil,
+		PersistentPreRunE:          nil,
+		PreRun:                     nil,
+		PreRunE:                    nil,
+		Run:                        nil,
+		RunE:                       exportPacked,
+		PostRun:                    nil,
+		PostRunE:                   nil,
+		PersistentPostRun:          nil,
+		PersistentPostRunE:         nil,
+		FParseErrWhitelist:         cobra.FParseErrWhitelist{},
+		CompletionOptions:          cobra.CompletionOptions{},
+		TraverseChildren:           false,
+		Hidden:                     false,
+		SilenceErrors:              false,
+		SilenceUsage:               false,
+		DisableFlagParsing:         false,
+		DisableAutoGenTag:          false,
+		DisableFlagsInUseLine:      false,
+		DisableSuggestions:         false,
+		SuggestionsMinimumDistance: 0,
+	}
+
+	return cmd
+}
+
+func importPackedCmd() *cobra.Command{
+	cmd := &cobra.Command{
+		Use:                        "import-packed",
+		Aliases:                    nil,
+		SuggestFor:                 nil,
+		Short:                      "import-packed",
+		Long:                       "",
+		Example:                    "",
+		ValidArgs:                  nil,
+		ValidArgsFunction:          nil,
+		Args:                       nil,
+		ArgAliases:                 nil,
+		BashCompletionFunction:     "",
+		Deprecated:                 "",
+		Annotations:                nil,
+		Version:                    "",
+		PersistentPreRun:           nil,
+		PersistentPreRunE:          nil,
+		PreRun:                     nil,
+		PreRunE:                    nil,
+		Run:                        nil,
+		RunE:                       importPacked,
+		PostRun:                    nil,
+		PostRunE:                   nil,
+		PersistentPostRun:          nil,
+		PersistentPostRunE:         nil,
+		FParseErrWhitelist:         cobra.FParseErrWhitelist{},
+		CompletionOptions:          cobra.CompletionOptions{},
+		TraverseChildren:           false,
+		Hidden:                     false,
+		SilenceErrors:              false,
+		SilenceUsage:               false,
+		DisableFlagParsing:         false,
+		DisableAutoGenTag:          false,
+		DisableFlagsInUseLine:      false,
+		DisableSuggestions:         false,
+		SuggestionsMinimumDistance: 0,
+	}
+
+	cmd.Flags().Bool(flagOverwrite, false, "overwrite existing keys")
+
+	return cmd
+}
+

--- a/cmd/akash/cmd/export_import_packed_keys.go
+++ b/cmd/akash/cmd/export_import_packed_keys.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"io"
@@ -15,19 +17,24 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto"
 )
 
-const PLAIN_TEXT_HEADER = "PT"
+const PlainTextHeader = "PT"
 
 var errInputMissingHeader = errors.New("invalid input: missing header")
 var errInputTruncated = errors.New("invalid input: truncated")
 var errInputInvalidBase64 = errors.New("invalid input: base64 decode failed")
 var errKeyringEmpty = errors.New("keyring is empty, no keys to export")
 var errKeyExists = errors.New("at least one key already exists, overwrite must be enabled ")
+var errCannotExportKey = errors.New("cannot export key")
 
 const (
 	flagOverwrite = "overwrite"
 )
 
 func importPacked(cmd *cobra.Command, args []string) error {
+	overwriteOk, err := cmd.Flags().GetBool(flagOverwrite)
+	if err != nil {
+		return err
+	}
 	clientCtx, err := client.GetClientQueryContext(cmd)
 	if err != nil {
 		return err
@@ -47,14 +54,19 @@ func importPacked(cmd *cobra.Command, args []string) error {
 	if len(inputParts) < 3 {
 		return errInputTruncated
 	}
-	if inputParts[0] != PLAIN_TEXT_HEADER {
+	// The first component should always be the header
+	if inputParts[0] != PlainTextHeader {
 		return errInputMissingHeader
 	}
 
-	inputParts = inputParts[1:]
+	// Remove the header
+	inputParts = inputParts[1:] // Remove the header
+	// Check the remaining length is even, since it is pairs
 	if len(inputParts)%2 != 0 {
 		return errInputTruncated
 	}
+
+	// Decode each key
 	packedKeys := make(map[string][]byte)
 	for i := 0; i != len(inputParts); i += 2 {
 		data, err := base64.RawURLEncoding.DecodeString(inputParts[i+1])
@@ -65,29 +77,26 @@ func importPacked(cmd *cobra.Command, args []string) error {
 	}
 
 	unsafeKeyring := keyring.NewUnsafe(clientCtx.Keyring)
-	overwriteOk, err := cmd.Flags().GetBool(flagOverwrite)
-	if err != nil {
-		return err
-	}
-
 	existingKeys, err := unsafeKeyring.List()
 	if err != nil {
 		return err
 	}
-
 	existingKeyNames := make(map[string]struct{})
 	for _, existingKey := range existingKeys {
 		existingKeyNames[existingKey.GetName()] = struct{}{}
 	}
 	for keyName := range packedKeys {
+		// Check if each key being imported already exists
 		_, exists := existingKeyNames[keyName]
 		if exists {
 			if overwriteOk {
+				// Delete the key if configured to overwrite
 				err = unsafeKeyring.Delete(keyName)
 				if err != nil {
 					return err
 				}
 			} else {
+				// Return an error since overwriting is not allowed
 				return errKeyExists
 			}
 		}
@@ -95,10 +104,10 @@ func importPacked(cmd *cobra.Command, args []string) error {
 
 	const notPassword = "secret"
 	for keyName, keyBytes := range packedKeys {
+		// Create a key, armor it, then import it
 		k := &secp256k1.PrivKey{
 			Key: keyBytes,
 		}
-
 		armored := crypto.EncryptArmorPrivKey(k, notPassword, string(hd.Secp256k1Type))
 		err = unsafeKeyring.ImportPrivKey(keyName, armored, notPassword)
 		if err != nil {
@@ -131,11 +140,14 @@ func exportPacked(cmd *cobra.Command, args []string) error {
 	}
 
 	unsafeKeyring := keyring.NewUnsafe(clientCtx.Keyring)
-	cmd.Printf("%s,", PLAIN_TEXT_HEADER)
+	cmd.Printf("%s,", PlainTextHeader)
 
 	for i, keyName := range keyNames {
 		hexPrivKey, err := unsafeKeyring.UnsafeExportPrivKeyHex(keyName)
 		if err != nil {
+			if errors.Is(err, sdkerrors.ErrKeyNotFound) {
+				return fmt.Errorf("%w: no key with name %q", errCannotExportKey, keyName)
+			}
 			return err
 		}
 		privKey, err := hex.DecodeString(hexPrivKey)
@@ -143,9 +155,7 @@ func exportPacked(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		privKeyB64 := base64.RawURLEncoding.EncodeToString(privKey)
-
 		cmd.Printf("%s,%s", keyName, privKeyB64)
-
 		if i != len(keyNames)-1 {
 			cmd.Print(",")
 		}
@@ -156,41 +166,12 @@ func exportPacked(cmd *cobra.Command, args []string) error {
 
 func exportPackedCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                        "export-packed",
-		Aliases:                    nil,
-		SuggestFor:                 nil,
-		Short:                      "export-packed",
-		Long:                       "",
-		Example:                    "",
-		ValidArgs:                  nil,
-		ValidArgsFunction:          nil,
-		Args:                       nil,
-		ArgAliases:                 nil,
-		BashCompletionFunction:     "",
-		Deprecated:                 "",
-		Annotations:                nil,
-		Version:                    "",
-		PersistentPreRun:           nil,
-		PersistentPreRunE:          nil,
-		PreRun:                     nil,
-		PreRunE:                    nil,
-		Run:                        nil,
-		RunE:                       exportPacked,
-		PostRun:                    nil,
-		PostRunE:                   nil,
-		PersistentPostRun:          nil,
-		PersistentPostRunE:         nil,
-		FParseErrWhitelist:         cobra.FParseErrWhitelist{},
-		CompletionOptions:          cobra.CompletionOptions{},
-		TraverseChildren:           false,
-		Hidden:                     false,
-		SilenceErrors:              false,
-		SilenceUsage:               false,
-		DisableFlagParsing:         false,
-		DisableAutoGenTag:          false,
-		DisableFlagsInUseLine:      false,
-		DisableSuggestions:         false,
-		SuggestionsMinimumDistance: 0,
+		Use:           "export-packed",
+		Short:         "export-packed",
+		Args:          cobra.MinimumNArgs(0),
+		RunE:          exportPacked,
+		Hidden:        true,
+		SilenceErrors: true,
 	}
 
 	return cmd
@@ -198,41 +179,14 @@ func exportPackedCmd() *cobra.Command {
 
 func importPackedCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                        "import-packed",
-		Aliases:                    nil,
-		SuggestFor:                 nil,
-		Short:                      "import-packed",
-		Long:                       "",
-		Example:                    "",
-		ValidArgs:                  nil,
-		ValidArgsFunction:          nil,
-		Args:                       nil,
-		ArgAliases:                 nil,
-		BashCompletionFunction:     "",
-		Deprecated:                 "",
-		Annotations:                nil,
-		Version:                    "",
-		PersistentPreRun:           nil,
-		PersistentPreRunE:          nil,
-		PreRun:                     nil,
-		PreRunE:                    nil,
-		Run:                        nil,
-		RunE:                       importPacked,
-		PostRun:                    nil,
-		PostRunE:                   nil,
-		PersistentPostRun:          nil,
-		PersistentPostRunE:         nil,
-		FParseErrWhitelist:         cobra.FParseErrWhitelist{},
-		CompletionOptions:          cobra.CompletionOptions{},
-		TraverseChildren:           false,
-		Hidden:                     false,
-		SilenceErrors:              false,
-		SilenceUsage:               false,
-		DisableFlagParsing:         false,
-		DisableAutoGenTag:          false,
-		DisableFlagsInUseLine:      false,
-		DisableSuggestions:         false,
-		SuggestionsMinimumDistance: 0,
+		Use:                "import-packed",
+		Short:              "import-packed",
+		Args:               cobra.MaximumNArgs(1),
+		RunE:               importPacked,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{},
+		CompletionOptions:  cobra.CompletionOptions{},
+		Hidden:             true,
+		SilenceErrors:      true,
 	}
 
 	cmd.Flags().Bool(flagOverwrite, false, "overwrite existing keys")

--- a/cmd/akash/cmd/export_import_packed_keys.go
+++ b/cmd/akash/cmd/export_import_packed_keys.go
@@ -4,18 +4,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"io"
 	"strings"
 
 	"encoding/base64"
 	"encoding/hex"
 	"github.com/cosmos/cosmos-sdk/crypto"
-
-	//codeclegacy "github.com/cosmos/cosmos-sdk/codec/legacy"
-	//"github.com/btcsuite/btcd/btcec"
 )
 
 const PLAIN_TEXT_HEADER = "PT"
@@ -25,6 +22,7 @@ var errInputTruncated = errors.New("invalid input: truncated")
 var errInputInvalidBase64 = errors.New("invalid input: base64 decode failed")
 var errKeyringEmpty = errors.New("keyring is empty, no keys to export")
 var errKeyExists = errors.New("at least one key already exists, overwrite must be enabled ")
+
 const (
 	flagOverwrite = "overwrite"
 )
@@ -33,19 +31,6 @@ func importPacked(cmd *cobra.Command, args []string) error {
 	clientCtx, err := client.GetClientQueryContext(cmd)
 	if err != nil {
 		return err
-	}
-
-	keyNames := []string{}
-	if len(args) == 0 {
-		allKeys, err := clientCtx.Keyring.List()
-		if err != nil {
-			return err
-		}
-		for _, key := range allKeys {
-			keyNames = append(keyNames, key.GetName())
-		}
-	} else {
-		keyNames = args
 	}
 
 	input := cmd.InOrStdin()
@@ -67,11 +52,11 @@ func importPacked(cmd *cobra.Command, args []string) error {
 	}
 
 	inputParts = inputParts[1:]
-	if len(inputParts) % 2 != 0 {
+	if len(inputParts)%2 != 0 {
 		return errInputTruncated
 	}
 	packedKeys := make(map[string][]byte)
-	for i := 0; i != len(inputParts); i+=2 {
+	for i := 0; i != len(inputParts); i += 2 {
 		data, err := base64.RawURLEncoding.DecodeString(inputParts[i+1])
 		if err != nil {
 			return errInputInvalidBase64
@@ -107,7 +92,6 @@ func importPacked(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-
 
 	const notPassword = "secret"
 	for keyName, keyBytes := range packedKeys {
@@ -162,7 +146,7 @@ func exportPacked(cmd *cobra.Command, args []string) error {
 
 		cmd.Printf("%s,%s", keyName, privKeyB64)
 
-		if i != len(keyNames) - 1 {
+		if i != len(keyNames)-1 {
 			cmd.Print(",")
 		}
 	}
@@ -170,7 +154,7 @@ func exportPacked(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func exportPackedCmd() *cobra.Command{
+func exportPackedCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "export-packed",
 		Aliases:                    nil,
@@ -212,7 +196,7 @@ func exportPackedCmd() *cobra.Command{
 	return cmd
 }
 
-func importPackedCmd() *cobra.Command{
+func importPackedCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "import-packed",
 		Aliases:                    nil,
@@ -255,4 +239,3 @@ func importPackedCmd() *cobra.Command{
 
 	return cmd
 }
-

--- a/cmd/akash/cmd/export_import_packed_keys_test.go
+++ b/cmd/akash/cmd/export_import_packed_keys_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ovrclk/akash/testutil"
+	testutilcli "github.com/ovrclk/akash/testutil/cli"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	cfg     network.Config
+	network *network.Network
+
+	cctx client.Context
+}
+
+func (s *IntegrationTestSuite) SetupSuite() {
+	s.T().Log("setting up integration test suite")
+
+	cfg := testutil.DefaultConfig()
+	cfg.NumValidators = 2
+	// cfg.EnableLogging = true
+
+	s.cfg = cfg
+	s.network = network.New(s.T(), cfg)
+
+	s.cctx = s.network.Validators[0].ClientCtx
+	kr := s.cctx.Keyring
+	for i := 0; i != 10; i++ {
+		keyName := fmt.Sprintf("testkey-%d", i)
+		_, _, err := kr.NewMnemonic(keyName, keyring.English, sdk.FullFundraiserPath, "", hd.Secp256k1)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *IntegrationTestSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.network.Cleanup()
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}
+
+func (s *IntegrationTestSuite) TestExportKeyDoesNotExist() {
+	args := []string{"foobar"}
+	_, err := testutilcli.ExecTestCLICmd(context.Background(), s.cctx, exportPackedCmd(), args...)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "no key with name")
+}
+
+func (s *IntegrationTestSuite) TestExportOneKey() {
+	args := []string{"testkey-3"}
+	output, err := testutilcli.ExecTestCLICmd(context.Background(), s.cctx, exportPackedCmd(), args...)
+	s.Require().NoError(err)
+	s.Require().Greater(len(output.String()), len(PlainTextHeader))
+}
+
+func (s *IntegrationTestSuite) TestExportImportPackedKeysRoundTrip() {
+	output, err := testutilcli.ExecTestCLICmd(context.Background(), s.cctx, exportPackedCmd())
+	s.Require().NoError(err)
+	s.Require().Greater(len(output.String()), len(PlainTextHeader))
+
+	// Try and import the keys back in without the overwrite flag
+	args := []string{output.String()}
+	_, err = testutilcli.ExecTestCLICmd(context.Background(), s.cctx, importPackedCmd(), args...)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errKeyExists)
+
+	// Import into another keyring
+	cctxB := s.network.Validators[1].ClientCtx
+	krB := cctxB.Keyring
+	// Asser the key cannot be found
+	_, err = krB.Key("testkey-3")
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, sdkerrors.ErrKeyNotFound)
+	_, err = testutilcli.ExecTestCLICmd(context.Background(), cctxB, importPackedCmd(), args...)
+	s.Require().NoError(err)
+
+	// Assert the key can be found
+	_, err = krB.Key("testkey-3")
+	s.Require().NoError(err)
+
+	// Assert the keys are the same
+	krAUnsafe := keyring.NewUnsafe(s.cctx.Keyring)
+	krBUnsafe := keyring.NewUnsafe(krB)
+
+	valA, err := krAUnsafe.UnsafeExportPrivKeyHex("testkey-1")
+	s.Require().NoError(err)
+	valB, err := krBUnsafe.UnsafeExportPrivKeyHex("testkey-1")
+	s.Require().NoError(err)
+	s.Require().Equal(valA, valB)
+
+	// Try and import the keys back into the original one with the overwrite flag
+	args = []string{fmt.Sprintf("--%s", flagOverwrite), output.String()}
+	_, err = testutilcli.ExecTestCLICmd(context.Background(), s.cctx, importPackedCmd(), args...)
+	s.Require().NoError(err)
+
+}

--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -120,7 +120,6 @@ func Execute(rootCmd *cobra.Command) error {
 	return executor.ExecuteContext(ctx)
 }
 
-
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	sdkutil.InitSDKConfig()
 	rootCmd.AddCommand(
@@ -155,7 +154,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	keyCommand.AddCommand(
 		exportPackedCmd(),
 		importPackedCmd(),
-		)
+	)
 	rootCmd.SetOut(rootCmd.OutOrStdout())
 	rootCmd.SetErr(rootCmd.ErrOrStderr())
 

--- a/cmd/akash/cmd/root.go
+++ b/cmd/akash/cmd/root.go
@@ -120,6 +120,7 @@ func Execute(rootCmd *cobra.Command) error {
 	return executor.ExecuteContext(ctx)
 }
 
+
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	sdkutil.InitSDKConfig()
 	rootCmd.AddCommand(
@@ -139,6 +140,22 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		debug.Cmd(),
 	)
 
+	var keyCommand *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "keys" {
+			keyCommand = cmd
+			break
+		}
+	}
+
+	if keyCommand == nil {
+		panic("cannot find keys command to modify")
+	}
+
+	keyCommand.AddCommand(
+		exportPackedCmd(),
+		importPackedCmd(),
+		)
 	rootCmd.SetOut(rootCmd.OutOrStdout())
 	rootCmd.SetErr(rootCmd.ErrOrStderr())
 


### PR DESCRIPTION
The existing export / import functionality for keys serves end-users well. For programmatic purposes (like running a provider in a docker container) it's painful. The default export format is a PEM file which contains whitespace & is encrypted.

This adds an `akash keys export-packed` and `akash keys import-packed` functionality that can import a specific set of keys or the entire wallet. The output is a single line without whitespace that is not encrypted.

For example:

```
$ akash keys export-packed bob
PT,bob,DHkoAZCbPKi1IC2fEH4FMTPl4IA8tcCqJyMBkJDQhgc
```

This `import-packed` command takes this string as either input on stdin or as a single command line argument. It won't overwrite keys by default, but has an option for that.

If you're using a ledger or OS keyring you would get prompted to unlock the device. But this isn't really a concern because this isn't meant for end users. I've hidden these commands in the help because we don't want end users accidentally winding up using them and exporting their keys to plaintext.