### PR TITLE
build(codegen): install protoc-gen-gocosmos from vendor

### DIFF
--- a/make/codegen.mk
+++ b/make/codegen.mk
@@ -30,7 +30,7 @@ kubetypes: $(K8S_GENERATE_GROUPS)
 	akash.network:v1,v2beta1
 
 .PHONY: proto-gen
-proto-gen: $(PROTOC) $(GRPC_GATEWAY) $(PROTOC_GEN_COSMOS) modvendor
+proto-gen: $(PROTOC) $(GRPC_GATEWAY) $(PROTOC_GEN_GOCOSMOS) modvendor
 	./script/protocgen.sh
 
 .PHONY: proto-swagger-gen

--- a/make/init.mk
+++ b/make/init.mk
@@ -14,42 +14,42 @@ GO                         := GO111MODULE=$(GO111MODULE) go
 # setup .cache bins first in paths to have precedence over already installed same tools for system wide use
 PATH                       := "$(PATH):$(AKASH_DEVCACHE_BIN):$(AKASH_DEVCACHE_NODE_BIN)"
 
-BUF_VERSION                ?= 0.35.1
-PROTOC_VERSION             ?= 3.13.0
-PROTOC_GEN_COSMOS_VERSION  ?= v0.3.1
-GRPC_GATEWAY_VERSION       := $(shell $(GO) list -mod=readonly -m -f '{{ .Version }}' github.com/grpc-ecosystem/grpc-gateway)
-PROTOC_SWAGGER_GEN_VERSION := $(GRPC_GATEWAY_VERSION)
-GOLANGCI_LINT_VERSION      ?= v1.38.0
-GOLANG_VERSION             ?= 1.16.1
-STATIK_VERSION             ?= v0.1.7
-GIT_CHGLOG_VERSION         ?= v0.15.1
-MODVENDOR_VERSION          ?= v0.3.0
-MOCKERY_VERSION            ?= 2.5.1
-K8S_CODE_GEN_VERSION       ?= v0.19.3
+BUF_VERSION                  ?= 0.35.1
+PROTOC_VERSION               ?= 3.13.0
+PROTOC_GEN_GOCOSMOS_VERSION  ?= v0.3.1
+GRPC_GATEWAY_VERSION         := $(shell $(GO) list -mod=readonly -m -f '{{ .Version }}' github.com/grpc-ecosystem/grpc-gateway)
+PROTOC_SWAGGER_GEN_VERSION   := $(GRPC_GATEWAY_VERSION)
+GOLANGCI_LINT_VERSION        ?= v1.38.0
+GOLANG_VERSION               ?= 1.16.1
+STATIK_VERSION               ?= v0.1.7
+GIT_CHGLOG_VERSION           ?= v0.15.1
+MODVENDOR_VERSION            ?= v0.3.0
+MOCKERY_VERSION              ?= 2.5.1
+K8S_CODE_GEN_VERSION         ?= v0.19.3
 
 # <TOOL>_VERSION_FILE points to the marker file for the installed version.
 # If <TOOL>_VERSION_FILE is changed, the binary will be re-downloaded.
-PROTOC_VERSION_FILE            := $(AKASH_DEVCACHE_VERSIONS)/protoc/$(PROTOC_VERSION)
-GRPC_GATEWAY_VERSION_FILE      := $(AKASH_DEVCACHE_VERSIONS)/protoc-gen-grpc-gateway/$(GRPC_GATEWAY_VERSION)
-PROTOC_GEN_COSMOS_VERSION_FILE := $(AKASH_DEVCACHE_VERSIONS)/protoc-gen-cosmos/$(PROTOC_GEN_COSMOS_VERSION)
-STATIK_VERSION_FILE            := $(AKASH_DEVCACHE_VERSIONS)/statik/$(STATIK_VERSION)
-MODVENDOR_VERSION_FILE         := $(AKASH_DEVCACHE_VERSIONS)/modvendor/$(MODVENDOR_VERSION)
-GIT_CHGLOG_VERSION_FILE        := $(AKASH_DEVCACHE_VERSIONS)/git-chglog/$(GIT_CHGLOG_VERSION)
-MOCKERY_VERSION_FILE           := $(AKASH_DEVCACHE_VERSIONS)/mockery/v$(MOCKERY_VERSION)
-K8S_CODE_GEN_VERSION_FILE      := $(AKASH_DEVCACHE_VERSIONS)/k8s-codegen/$(K8S_CODE_GEN_VERSION)
+PROTOC_VERSION_FILE              := $(AKASH_DEVCACHE_VERSIONS)/protoc/$(PROTOC_VERSION)
+GRPC_GATEWAY_VERSION_FILE        := $(AKASH_DEVCACHE_VERSIONS)/protoc-gen-grpc-gateway/$(GRPC_GATEWAY_VERSION)
+PROTOC_GEN_GOCOSMOS_VERSION_FILE := $(AKASH_DEVCACHE_VERSIONS)/protoc-gen-gocosmos/$(PROTOC_GEN_GOCOSMOS_VERSION)
+STATIK_VERSION_FILE              := $(AKASH_DEVCACHE_VERSIONS)/statik/$(STATIK_VERSION)
+MODVENDOR_VERSION_FILE           := $(AKASH_DEVCACHE_VERSIONS)/modvendor/$(MODVENDOR_VERSION)
+GIT_CHGLOG_VERSION_FILE          := $(AKASH_DEVCACHE_VERSIONS)/git-chglog/$(GIT_CHGLOG_VERSION)
+MOCKERY_VERSION_FILE             := $(AKASH_DEVCACHE_VERSIONS)/mockery/v$(MOCKERY_VERSION)
+K8S_CODE_GEN_VERSION_FILE        := $(AKASH_DEVCACHE_VERSIONS)/k8s-codegen/$(K8S_CODE_GEN_VERSION)
 
-MODVENDOR                       = $(AKASH_DEVCACHE_BIN)/modvendor
-SWAGGER_COMBINE                 = $(AKASH_DEVCACHE_NODE_BIN)/swagger-combine
-PROTOC_SWAGGER_GEN             := $(AKASH_DEVCACHE_BIN)/protoc-swagger-gen
-PROTOC                         := $(AKASH_DEVCACHE_BIN)/protoc
-STATIK                         := $(AKASH_DEVCACHE_BIN)/statik
-PROTOC_GEN_COSMOS              := $(AKASH_DEVCACHE_BIN)/protoc-gen-cosmos
-GRPC_GATEWAY                   := $(AKASH_DEVCACHE_BIN)/protoc-gen-grpc-gateway
-GIT_CHGLOG                     := $(AKASH_DEVCACHE_BIN)/git-chglog
-MOCKERY                        := $(AKASH_DEVCACHE_BIN)/mockery
-K8S_GENERATE_GROUPS            := $(AKASH_ROOT)/vendor/k8s.io/code-generator/generate-groups.sh
-K8S_GO_TO_PROTOBUF             := $(AKASH_DEVCACHE_BIN)/go-to-protobuf
-KIND                           := kind
-NPM                            := npm
+MODVENDOR                         = $(AKASH_DEVCACHE_BIN)/modvendor
+SWAGGER_COMBINE                   = $(AKASH_DEVCACHE_NODE_BIN)/swagger-combine
+PROTOC_SWAGGER_GEN               := $(AKASH_DEVCACHE_BIN)/protoc-swagger-gen
+PROTOC                           := $(AKASH_DEVCACHE_BIN)/protoc
+STATIK                           := $(AKASH_DEVCACHE_BIN)/statik
+PROTOC_GEN_GOCOSMOS              := $(AKASH_DEVCACHE_BIN)/protoc-gen-gocosmos
+GRPC_GATEWAY                     := $(AKASH_DEVCACHE_BIN)/protoc-gen-grpc-gateway
+GIT_CHGLOG                       := $(AKASH_DEVCACHE_BIN)/git-chglog
+MOCKERY                          := $(AKASH_DEVCACHE_BIN)/mockery
+K8S_GENERATE_GROUPS              := $(AKASH_ROOT)/vendor/k8s.io/code-generator/generate-groups.sh
+K8S_GO_TO_PROTOBUF               := $(AKASH_DEVCACHE_BIN)/go-to-protobuf
+KIND                             := kind
+NPM                              := npm
 
 include $(AKASH_ROOT)/make/setup-cache.mk

--- a/make/setup-cache.mk
+++ b/make/setup-cache.mk
@@ -21,14 +21,14 @@ $(PROTOC_VERSION_FILE): $(AKASH_DEVCACHE)
 	touch $@
 $(PROTOC): $(PROTOC_VERSION_FILE)
 
-$(PROTOC_GEN_COSMOS_VERSION_FILE): $(AKASH_DEVCACHE)
-	@echo "installing protoc-gen-cosmos $(PROTOC_GEN_COSMOS_VERSION) ..."
-	rm -f $(PROTOC_GEN_COSMOS)
-	GOBIN=$(AKASH_DEVCACHE_BIN) go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@$(PROTOC_GEN_COSMOS_VERSION)
+$(PROTOC_GEN_GOCOSMOS_VERSION_FILE): $(AKASH_DEVCACHE) modvendor
+	@echo "installing protoc-gen-gocosmos $(PROTOC_GEN_GOCOSMOS_VERSION) ..."
+	rm -f $(PROTOC_GEN_GOCOSMOS)
+	GOBIN=$(AKASH_DEVCACHE_BIN) $(GO) install $(ROOT_DIR)/vendor/github.com/regen-network/cosmos-proto/protoc-gen-gocosmos
 	rm -rf "$(dir $@)"
 	mkdir -p "$(dir $@)"
 	touch $@
-$(PROTOC_GEN_COSMOS): $(PROTOC_GEN_COSMOS_VERSION_FILE)
+$(PROTOC_GEN_GOCOSMOS): $(PROTOC_GEN_GOCOSMOS_VERSION_FILE)
 
 $(GRPC_GATEWAY_VERSION_FILE): $(AKASH_DEVCACHE)
 	@echo "Installing protoc-gen-grpc-gateway $(GRPC_GATEWAY_VERSION) ..."

--- a/tools.go
+++ b/tools.go
@@ -3,8 +3,9 @@
 
 package tools
 
-//nolint
+// nolint
 import (
+	_ "github.com/regen-network/cosmos-proto/protoc-gen-gocosmos"
 	_ "k8s.io/code-generator"
 	_ "sigs.k8s.io/kind"
 )


### PR DESCRIPTION
protoc-gen-gocosmos uses replace in modules which prevents
direct install via link
refactor names of the variables related to protoc-gen-gocosmos

Signed-off-by: Artur Troian <troian.ap@gmail.com>