### PR TITLE
fix: set DefaultBidMinDeposit same value as mainnet-2

### DIFF
--- a/x/market/types/v1beta2/params.go
+++ b/x/market/types/v1beta2/params.go
@@ -9,7 +9,7 @@ import (
 var _ paramtypes.ParamSet = (*Params)(nil)
 
 var (
-	DefaultBidMinDeposit        = sdk.NewCoin("uakt", sdk.NewInt(50000000))
+	DefaultBidMinDeposit        = sdk.NewCoin("uakt", sdk.NewInt(5000000))
 	defaultOrderMaxBids  uint32 = 20
 	maxOrderMaxBids      uint32 = 500
 )


### PR DESCRIPTION
allows genereting test genesis with params identical to
the mainnet

Signed-off-by: Artur Troian <troian.ap@gmail.com>
