### PR TITLE
build(lint): install and use golangci-lint from cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ include make/init.mk
 DOCKER_RUN            := docker run --rm -v $(shell pwd):/workspace -w /workspace
 DOCKER_BUF            := $(DOCKER_RUN) bufbuild/buf:$(BUF_VERSION)
 DOCKER_CLANG          := $(DOCKER_RUN) tendermintdev/docker-build-proto
-GOLANGCI_LINT          = $(DOCKER_RUN) --network none golangci/golangci-lint:$(GOLANGCI_LINT_VERSION)-alpine golangci-lint run
-LINT                   = $(GOLANGCI_LINT) ./... --disable-all --deadline=5m --enable
+GOLANGCI_LINT_RUN     := $(GOLANGCI_LINT) run
+LINT                   = $(GOLANGCI_LINT_RUN) ./... --disable-all --deadline=5m --enable
+
 TEST_DOCKER_REPO      := ovrclk/akashtest
 
 GORELEASER_CONFIG      = .goreleaser.yaml

--- a/make/init.mk
+++ b/make/init.mk
@@ -19,7 +19,7 @@ PROTOC_VERSION               ?= 3.13.0
 PROTOC_GEN_GOCOSMOS_VERSION  ?= v0.3.1
 GRPC_GATEWAY_VERSION         := $(shell $(GO) list -mod=readonly -m -f '{{ .Version }}' github.com/grpc-ecosystem/grpc-gateway)
 PROTOC_SWAGGER_GEN_VERSION   := $(GRPC_GATEWAY_VERSION)
-GOLANGCI_LINT_VERSION        ?= v1.38.0
+GOLANGCI_LINT_VERSION        ?= v1.45.2
 GOLANG_VERSION               ?= 1.16.1
 STATIK_VERSION               ?= v0.1.7
 GIT_CHGLOG_VERSION           ?= v0.15.1
@@ -37,6 +37,7 @@ MODVENDOR_VERSION_FILE           := $(AKASH_DEVCACHE_VERSIONS)/modvendor/$(MODVE
 GIT_CHGLOG_VERSION_FILE          := $(AKASH_DEVCACHE_VERSIONS)/git-chglog/$(GIT_CHGLOG_VERSION)
 MOCKERY_VERSION_FILE             := $(AKASH_DEVCACHE_VERSIONS)/mockery/v$(MOCKERY_VERSION)
 K8S_CODE_GEN_VERSION_FILE        := $(AKASH_DEVCACHE_VERSIONS)/k8s-codegen/$(K8S_CODE_GEN_VERSION)
+GOLANGCI_LINT_VERSION_FILE       := $(AKASH_DEVCACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 
 MODVENDOR                         = $(AKASH_DEVCACHE_BIN)/modvendor
 SWAGGER_COMBINE                   = $(AKASH_DEVCACHE_NODE_BIN)/swagger-combine
@@ -51,5 +52,6 @@ K8S_GENERATE_GROUPS              := $(AKASH_ROOT)/vendor/k8s.io/code-generator/g
 K8S_GO_TO_PROTOBUF               := $(AKASH_DEVCACHE_BIN)/go-to-protobuf
 KIND                             := kind
 NPM                              := npm
+GOLANGCI_LINT                    := $(AKASH_DEVCACHE_BIN)/golangci-lint
 
 include $(AKASH_ROOT)/make/setup-cache.mk

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -7,9 +7,9 @@ SUBLINTERS = deadcode \
 			ineffassign \
 			unparam \
 			staticcheck \
-			golint \
+			revive \
 			gosec \
-			scopelint \
+			exportloopref \
 			prealloc
 # TODO: ^ gochecknoglobals
 
@@ -19,17 +19,17 @@ SUBLINTERS = deadcode \
 test-sublinters: $(patsubst %, test-sublinter-%,$(SUBLINTERS))
 
 .PHONY: test-lint-all
-test-lint-all:
-	$(GOLANGCI_LINT) ./... --issues-exit-code=0 --deadline=10m
+test-lint-all: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT_RUN) ./... --issues-exit-code=0 --deadline=10m
 
 .PHONY: test-sublinter-misspell
-test-sublinter-misspell:
+test-sublinter-misspell: $(GOLANGCI_LINT)
 	$(LINT) misspell --no-config
 
 .PHONY: test-sublinter-ineffassign
-test-sublinter-ineffassign:
+test-sublinter-ineffassign: $(GOLANGCI_LINT)
 	$(LINT) ineffassign --no-config
 
 .PHONY: test-sublinter-%
-test-sublinter-%:
+test-sublinter-%: $(GOLANGCI_LINT)
 	$(LINT) $*

--- a/make/setup-cache.mk
+++ b/make/setup-cache.mk
@@ -77,6 +77,15 @@ $(MOCKERY_VERSION_FILE): $(AKASH_DEVCACHE)
 	touch $@
 $(MOCKERY): $(MOCKERY_VERSION_FILE)
 
+$(GOLANGCI_LINT_VERSION_FILE): $(AKASH_DEVCACHE)
+	@echo "installing golangci-lint $(GOLANGCI_LINT_VERSION) ..."
+	rm -f $(MOCKERY)
+	GOBIN=$(AKASH_DEVCACHE_BIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	rm -rf "$(dir $@)"
+	mkdir -p "$(dir $@)"
+	touch $@
+$(GOLANGCI_LINT): $(GOLANGCI_LINT_VERSION_FILE)
+
 $(K8S_CODE_GEN_VERSION_FILE): $(AKASH_DEVCACHE) modvendor
 	@echo "installing k8s code-generator $(K8S_CODE_GEN_VERSION) ..."
 	rm -f $(K8S_GO_TO_PROTOBUF)

--- a/provider/cluster/monitor.go
+++ b/provider/cluster/monitor.go
@@ -2,28 +2,31 @@ package cluster
 
 import (
 	"context"
-	"github.com/ovrclk/akash/provider/cluster/util"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"math/rand"
 	"time"
 
-	lifecycle "github.com/boz/go-lifecycle"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/ovrclk/akash/provider/cluster/util"
+
+	"github.com/boz/go-lifecycle"
+	"github.com/tendermint/tendermint/libs/log"
+
 	manifest "github.com/ovrclk/akash/manifest/v2beta1"
 	"github.com/ovrclk/akash/provider/event"
 	"github.com/ovrclk/akash/provider/session"
 	"github.com/ovrclk/akash/pubsub"
 	"github.com/ovrclk/akash/util/runner"
 	mtypes "github.com/ovrclk/akash/x/market/types/v1beta2"
-	"github.com/tendermint/tendermint/libs/log"
 )
 
 const (
 	monitorMaxRetries        = 40
-	monitorRetryPeriodMin    = time.Second * 4
+	monitorRetryPeriodMin    = time.Second * 4 // nolint revive
 	monitorRetryPeriodJitter = time.Second * 15
 
-	monitorHealthcheckPeriodMin    = time.Second * 10
+	monitorHealthcheckPeriodMin    = time.Second * 10 // nolint revive
 	monitorHealthcheckPeriodJitter = time.Second * 5
 )
 

--- a/x/deployment/simulation/operations.go
+++ b/x/deployment/simulation/operations.go
@@ -23,10 +23,10 @@ import (
 
 // Simulation operation weights constants
 const (
-	OpWeightMsgCreateDeployment = "op_weight_msg_create_deployment"
-	OpWeightMsgUpdateDeployment = "op_weight_msg_update_deployment"
-	OpWeightMsgCloseDeployment  = "op_weight_msg_close_deployment"
-	OpWeightMsgCloseGroup       = "op_weight_msg_close_group"
+	OpWeightMsgCreateDeployment = "op_weight_msg_create_deployment" // nolint gosec
+	OpWeightMsgUpdateDeployment = "op_weight_msg_update_deployment" // nolint gosec
+	OpWeightMsgCloseDeployment  = "op_weight_msg_close_deployment"  // nolint gosec
+	OpWeightMsgCloseGroup       = "op_weight_msg_close_group"       // nolint gosec
 )
 
 // WeightedOperations returns all the operations from the module with their respective weights

--- a/x/escrow/genesis.go
+++ b/x/escrow/genesis.go
@@ -18,7 +18,7 @@ func ValidateGenesis(data *types.GenesisState) error {
 
 	for idx, account := range data.Accounts {
 		if err := account.ValidateBasic(); err != nil {
-			return errors.Wrapf(err, "error with account %s (idx %v):", account.ID, idx)
+			return errors.Wrapf(err, "error with account %s (idx %v)", account.ID, idx)
 		}
 		if _, found := amap[account.ID]; found {
 			return errors.Wrapf(types.ErrAccountExists, "duplicate account %s (idx %v)", account.ID, idx)
@@ -28,7 +28,7 @@ func ValidateGenesis(data *types.GenesisState) error {
 
 	for idx, payment := range data.Payments {
 		if err := payment.ValidateBasic(); err != nil {
-			return errors.Wrapf(err, "error with payment %s %s (idx %v):", payment.AccountID, payment.PaymentID, idx)
+			return errors.Wrapf(err, "error with payment %s %s (idx %v)", payment.AccountID, payment.PaymentID, idx)
 		}
 
 		// make sure there's an account

--- a/x/market/simulation/operations.go
+++ b/x/market/simulation/operations.go
@@ -13,6 +13,7 @@ import (
 
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
 	appparams "github.com/ovrclk/akash/app/params"
 	keepers "github.com/ovrclk/akash/x/market/handler"
 	types "github.com/ovrclk/akash/x/market/types/v1beta2"
@@ -20,9 +21,9 @@ import (
 
 // Simulation operation weights constants
 const (
-	OpWeightMsgCreateBid  = "op_weight_msg_create_bid"
-	OpWeightMsgCloseBid   = "op_weight_msg_close_bid"
-	OpWeightMsgCloseLease = "op_weight_msg_close_lease"
+	OpWeightMsgCreateBid  = "op_weight_msg_create_bid"  // nolint gosec
+	OpWeightMsgCloseBid   = "op_weight_msg_close_bid"   // nolint gosec
+	OpWeightMsgCloseLease = "op_weight_msg_close_lease" // nolint gosec
 )
 
 // WeightedOperations returns all the operations from the module with their respective weights

--- a/x/provider/simulation/operations.go
+++ b/x/provider/simulation/operations.go
@@ -22,8 +22,8 @@ import (
 
 // Simulation operation weights constants
 const (
-	OpWeightMsgCreate = "op_weight_msg_create"
-	OpWeightMsgUpdate = "op_weight_msg_update"
+	OpWeightMsgCreate = "op_weight_msg_create" // nolint gosec
+	OpWeightMsgUpdate = "op_weight_msg_update" // nolint gosec
 )
 
 // WeightedOperations returns all the operations from the module with their respective weights


### PR DESCRIPTION
fixes #ENG-286
speeds up lint process
replace deprecated linters

Signed-off-by: Artur Troian <troian.ap@gmail.com>