### PR TITLE
WIP: Use polling logic for transactions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,12 +1,6 @@
 package app
 
 import (
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"time"
-
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -48,6 +42,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mint"
 	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
@@ -58,17 +59,16 @@ import (
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
 	tmjson "github.com/tendermint/tendermint/libs/json"
+	"path/filepath"
+	"time"
+
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/ovrclk/akash/x/inflation"
 
-	"github.com/cosmos/cosmos-sdk/x/params"
-	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
-	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
-	"github.com/cosmos/cosmos-sdk/x/staking"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"io"
+	"net/http"
+	"os"
 
 	"github.com/ovrclk/akash/x/audit"
 	"github.com/ovrclk/akash/x/cert"

--- a/events/cmd/root.go
+++ b/events/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"github.com/tendermint/tendermint/libs/log"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -54,8 +56,10 @@ func getEvents(ctx context.Context, cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	logger := log.NewTMLogger(os.Stderr)
+
 	group.Go(func() error {
-		return events.Publish(ctx, cctx.Client, "akash-cli", bus)
+		return events.PublishFromPolling(ctx, logger, cctx.Client, bus)
 	})
 
 	group.Go(func() error {

--- a/provider/cluster/inventory.go
+++ b/provider/cluster/inventory.go
@@ -216,6 +216,7 @@ func (is *inventoryService) resourcesToCommit(rgroup atypes.ResourceGroup) atype
 	replacedResources := make([]dtypes.Resource, 0)
 
 	for _, resource := range rgroup.GetResources() {
+
 		runits := atypes.ResourceUnits{
 			CPU: &atypes.CPU{
 				Units:      clusterUtil.ComputeCommittedResources(is.config.CPUCommitLevel, resource.Resources.GetCPU().GetUnits()),

--- a/provider/cmd/run.go
+++ b/provider/cmd/run.go
@@ -615,7 +615,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	}
 
 	group.Go(func() error {
-		return events.Publish(ctx, cctx.Client, "provider-cli", bus)
+		return events.PublishFromPolling(ctx, logger, cctx.Client, bus)
 	})
 
 	group.Go(func() error {


### PR DESCRIPTION
This picks up each transaction and broadcasts it using the mechanism I added to our cosmos SDK fork.

It looks like we were subscribing to some other events, but I don't think we ever used those.

**Note**: this won't pass until I merge the PR for the cosmos SDK fork & then update `go.mod` here.