### PR TITLE
fix(cli): remove references to 'matched' bids and orders

### DIFF
--- a/x/market/client/cli/flags.go
+++ b/x/market/client/cli/flags.go
@@ -119,7 +119,7 @@ func LeaseIDFromFlags(flags *pflag.FlagSet, opts ...dcli.MarketOption) (types.Le
 // AddOrderFilterFlags add flags to filter for order list
 func AddOrderFilterFlags(flags *pflag.FlagSet) {
 	flags.String("owner", "", "order owner address to filter")
-	flags.String("state", "", "order state to filter (open,matched,closed)")
+	flags.String("state", "", "order state to filter (open,closed)")
 	flags.Uint64("dseq", 0, "deployment sequence to filter")
 	flags.Uint32("gseq", 1, "group sequence to filter")
 	flags.Uint32("oseq", 1, "order sequence to filter")
@@ -151,7 +151,7 @@ func OrderFiltersFromFlags(flags *pflag.FlagSet) (types.OrderFilters, error) {
 // AddBidFilterFlags add flags to filter for bid list
 func AddBidFilterFlags(flags *pflag.FlagSet) {
 	flags.String("owner", "", "bid owner address to filter")
-	flags.String("state", "", "bid state to filter (open,matched,lost,closed)")
+	flags.String("state", "", "bid state to filter (open,lost,closed)")
 	flags.Uint64("dseq", 0, "deployment sequence to filter")
 	flags.Uint32("gseq", 1, "group sequence to filter")
 	flags.Uint32("oseq", 1, "order sequence to filter")

--- a/x/market/keeper/keeper.go
+++ b/x/market/keeper/keeper.go
@@ -167,13 +167,13 @@ func (k Keeper) CreateLease(ctx sdk.Context, bid types.Bid) {
 	}
 }
 
-// OnOrderMatched updates order state to matched
+// OnOrderMatched updates order state to active
 func (k Keeper) OnOrderMatched(ctx sdk.Context, order types.Order) {
 	order.State = types.OrderActive
 	k.updateOrder(ctx, order)
 }
 
-// OnBidActive updates bid state to matched
+// OnBidActive updates bid state to active
 func (k Keeper) OnBidMatched(ctx sdk.Context, bid types.Bid) {
 	bid.State = types.BidActive
 	k.updateBid(ctx, bid)

--- a/x/market/simulation/operations.go
+++ b/x/market/simulation/operations.go
@@ -171,7 +171,7 @@ func SimulateMsgCloseBid(ak govtypes.AccountKeeper, ks keepers.Keepers) simtypes
 		})
 
 		if len(bids) == 0 {
-			return simtypes.NoOpMsg(types.ModuleName, types.MsgTypeCloseBid, "no matched bids found"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.MsgTypeCloseBid, "no active bids found"), nil, nil
 		}
 
 		// Get random bid


### PR DESCRIPTION
The CLI still contains references to matched bids & orders, which never really existed on mainnet in the first place.