### PR TITLE
fix(node): disable querying lease by provider secondary index

### DIFF
--- a/x/market/keeper/keys/key.go
+++ b/x/market/keeper/keys/key.go
@@ -57,55 +57,7 @@ func OrderPrefixFromFilter(f types.OrderFilters) ([]byte, error) {
 	return filterToPrefix(types.OrderPrefix(), f.Owner, f.DSeq, f.GSeq, f.OSeq, "")
 }
 
-func filterToSecondaryPrefixByProvider(prefix []byte, owner string, dseq uint64, gseq, oseq uint32, provider string) ([]byte, error) {
-	buf := bytes.NewBuffer(prefix)
-
-	if len(provider) == 0 {
-		return buf.Bytes(), nil
-	}
-
-	if _, err := buf.Write(address.MustLengthPrefix(sdkutil.MustAccAddressFromBech32(provider))); err != nil {
-		return nil, err
-	}
-
-	if len(owner) == 0 {
-		return buf.Bytes(), nil
-	}
-
-	if _, err := buf.Write(address.MustLengthPrefix(sdkutil.MustAccAddressFromBech32(owner))); err != nil {
-		return nil, err
-	}
-
-	if dseq == 0 {
-		return buf.Bytes(), nil
-	}
-	if err := binary.Write(buf, binary.BigEndian, dseq); err != nil {
-		return nil, err
-	}
-
-	if gseq == 0 {
-		return buf.Bytes(), nil
-	}
-	if err := binary.Write(buf, binary.BigEndian, gseq); err != nil {
-		return nil, err
-	}
-
-	if oseq == 0 {
-		return buf.Bytes(), nil
-	}
-	if err := binary.Write(buf, binary.BigEndian, oseq); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
 func LeasePrefixFromFilter(f types.LeaseFilters) ([]byte, bool, error) {
-	if len(f.Owner) == 0 && len(f.Provider) != 0 {
-		prefix, err := filterToSecondaryPrefixByProvider(types.SecondaryLeasePrefix(), f.Owner, f.DSeq, f.GSeq, f.OSeq, f.Provider)
-		return prefix, true, err
-	}
-
 	prefix, err := filterToPrefix(types.LeasePrefix(), f.Owner, f.DSeq, f.GSeq, f.OSeq, f.Provider)
 	return prefix, false, err
 }

--- a/x/market/keeper/keys/key_test.go
+++ b/x/market/keeper/keys/key_test.go
@@ -28,6 +28,6 @@ func TestKeysAndSecondaryKeysFilter(t *testing.T) {
 	filter.Owner = ""
 	prefix, isSecondary, err = keys.LeasePrefixFromFilter(filter)
 	require.NoError(t, err)
-	require.True(t, isSecondary)
-	require.Equal(t, types.SecondaryLeasePrefix(), prefix[0:2])
+	require.False(t, isSecondary)
+	require.Equal(t, types.LeasePrefix(), prefix[0:2])
 }


### PR DESCRIPTION
This disables querying by the secondary prefix, since it never got properly populated in the network upgrade.

The keys for the secondary prefix are still written to, just not queried. Otherwise this would wind up constituting a hard fork.