### PR TITLE
fix(docs): move the metal LB service network policy to the _docs directory

### DIFF
--- a/_docs/provider/kube/metallb-service.yaml
+++ b/_docs/provider/kube/metallb-service.yaml
@@ -31,9 +31,6 @@ spec:
       - namespaceSelector:
           matchLabels:
             name: akash-services
-            kubernetes.io/metadata.name: ingress-nginxq
+            kubernetes.io/metadata.name: ingress-nginx
         podSelector: 
           matchLabels: {}
-#    ports:
-#    - protocol: TCP
-#      port: 6379

--- a/_run/common-kind.mk
+++ b/_run/common-kind.mk
@@ -37,7 +37,7 @@ INGRESS_CLASS_CONFIG_PATH ?= ../ingress-nginx-class.yaml
 CALICO_MANIFEST     ?= https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 METALLB_CONFIG_PATH ?= ../metallb.yaml
 METALLB_IP_CONFIG_PATH ?= ../kind-config-metal-lb-ip.yaml
-METALLB_SERVICE_PATH ?= ../metallb-service.yaml
+METALLB_SERVICE_PATH ?= ../../_docs/provider/kube/metallb-service.yaml
 
 IMAGE_NAME_FILE ?= ./docker_image.txt
 


### PR DESCRIPTION
This needs to be in `_docs` since it is something end users needs to create in Kubernetes when setting up a provider, if they want to lease IP addresses.