### PR TITLE
fix(provider): add docstrings to migrate endpoint & hostname commands

### DIFF
--- a/provider/cmd/migrate_endpoints.go
+++ b/provider/cmd/migrate_endpoints.go
@@ -60,7 +60,7 @@ func migrateEndpoints(cmd *cobra.Command, args []string) error {
 func MigrateEndpointsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "migrate-endpoints",
-		Short:        "",
+		Short:        "migrate endpoints between deployments on the same provider",
 		SilenceUsage: true,
 		RunE:         migrateEndpoints,
 	}

--- a/provider/cmd/migrate_hostnames.go
+++ b/provider/cmd/migrate_hostnames.go
@@ -59,7 +59,7 @@ func migrateHostnames(cmd *cobra.Command, args []string) error {
 func MigrateHostnamesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "migrate-hostnames",
-		Short:        "",
+		Short:        "migrate hostnames between deployments on the same provider",
 		SilenceUsage: true,
 		RunE:         migrateHostnames,
 	}


### PR DESCRIPTION
This adds the missing description of these commands