### PR TITLE
fix(provider): apply missing volume templates on deployment update

### DIFF
--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -1350,6 +1350,10 @@ func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(E2EApp))
 	suite.Run(t, new(E2EPersistentStorageDefault))
 	suite.Run(t, new(E2EPersistentStorageBeta2))
+	suite.Run(t, new(E2EPersistentStorageDeploymentUpdate))
+	suite.Run(t, new(E2EMigrateHostname))
+	suite.Run(t, new(E2EJWTServer))
+	suite.Run(t, &E2EIPAddress{IntegrationTestSuite{ipMarketplace: true}})
 }
 
 func (s *IntegrationTestSuite) waitForBlocksCommitted(height int) error {

--- a/integration/persistentstorage_test.go
+++ b/integration/persistentstorage_test.go
@@ -28,6 +28,10 @@ type E2EPersistentStorageBeta2 struct {
 	IntegrationTestSuite
 }
 
+type E2EPersistentStorageDeploymentUpdate struct {
+	IntegrationTestSuite
+}
+
 func (s *E2EPersistentStorageDefault) TestDefaultStorageClass() {
 	deploymentPath, err := filepath.Abs("../x/deployment/testdata/deployment-v2-storage-default.yaml")
 	s.Require().NoError(err)
@@ -229,4 +233,101 @@ func (s *E2EPersistentStorageBeta2) TestDedicatedStorageClass() {
 	bodyData, err = ioutil.ReadAll(httpResp.Body)
 	s.Require().NoError(err)
 	s.Require().Equal(testData.String(), string(bodyData))
+}
+
+func (s *E2EPersistentStorageDeploymentUpdate) TestDeploymentUpdate() {
+	// create a deployment
+	deploymentPath, err := filepath.Abs("../x/deployment/testdata/deployment-v2-storage-updateA.yaml")
+	s.Require().NoError(err)
+
+	deploymentID := dtypes.DeploymentID{
+		Owner: s.keyTenant.GetAddress().String(),
+		DSeq:  uint64(102),
+	}
+
+	// Create Deployments
+	res, err := deploycli.TxCreateDeploymentExec(
+		s.validator.ClientCtx,
+		s.keyTenant.GetAddress(),
+		deploymentPath,
+		cliGlobalFlags(fmt.Sprintf("--dseq=%v", deploymentID.DSeq))...,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(3))
+	clitestutil.ValidateTxSuccessful(s.T(), s.validator.ClientCtx, res.Bytes())
+
+	bidID := mtypes.MakeBidID(
+		mtypes.MakeOrderID(dtypes.MakeGroupID(deploymentID, 1), 1),
+		s.keyProvider.GetAddress(),
+	)
+	// check bid
+	_, err = mcli.QueryBidExec(s.validator.ClientCtx, bidID)
+	s.Require().NoError(err)
+
+	// create lease
+	_, err = mcli.TxCreateLeaseExec(
+		s.validator.ClientCtx,
+		bidID,
+		s.keyTenant.GetAddress(),
+		cliGlobalFlags()...,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+	clitestutil.ValidateTxSuccessful(s.T(), s.validator.ClientCtx, res.Bytes())
+
+	// Assert provider made bid and created lease; test query leases ---------
+	resp, err := mcli.QueryLeasesExec(s.validator.ClientCtx.WithOutputFormat("json"))
+	s.Require().NoError(err)
+
+	leaseRes := &mtypes.QueryLeasesResponse{}
+	err = s.validator.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), leaseRes)
+	s.Require().NoError(err)
+
+	s.Require().Len(leaseRes.Leases, 1)
+
+	lease := newestLease(leaseRes.Leases)
+	lid := lease.LeaseID
+	did := lease.GetLeaseID().DeploymentID()
+	s.Require().Equal(s.keyProvider.GetAddress().String(), lid.Provider)
+
+	// Send Manifest to Provider
+	_, err = ptestutil.TestSendManifest(
+		s.validator.ClientCtx.WithOutputFormat("json"),
+		lid.BidID(),
+		deploymentPath,
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, s.keyTenant.GetAddress().String()),
+		fmt.Sprintf("--%s=%s", flags.FlagHome, s.validator.ClientCtx.HomeDir),
+	)
+
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+
+	appURL := fmt.Sprintf("http://%s:%s/", s.appHost, s.appPort)
+	queryAppWithHostname(s.T(), appURL, 50, "testupdatea.localhost")
+
+	deploymentPath, err = filepath.Abs("../x/deployment/testdata/deployment-v2-storage-updateB.yaml")
+	s.Require().NoError(err)
+
+	res, err = deploycli.TxUpdateDeploymentExec(s.validator.ClientCtx,
+		s.keyTenant.GetAddress(),
+		deploymentPath,
+		cliGlobalFlags(fmt.Sprintf("--owner=%s", lease.GetLeaseID().Owner),
+			fmt.Sprintf("--dseq=%v", did.GetDSeq()))...,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+	clitestutil.ValidateTxSuccessful(s.T(), s.validator.ClientCtx, res.Bytes())
+
+	// Send Updated Manifest to Provider
+	_, err = ptestutil.TestSendManifest(
+		s.validator.ClientCtx.WithOutputFormat("json"),
+		lid.BidID(),
+		deploymentPath,
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, s.keyTenant.GetAddress().String()),
+		fmt.Sprintf("--%s=%s", flags.FlagHome, s.validator.ClientCtx.HomeDir),
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(s.waitForBlocksCommitted(2))
+	queryAppWithHostname(s.T(), appURL, 50, "testupdatea.localhost")
+	queryAppWithHostname(s.T(), appURL, 50, "testupdateb.localhost")
 }

--- a/provider/cluster/kube/builder/statefulset.go
+++ b/provider/cluster/kube/builder/statefulset.go
@@ -76,7 +76,7 @@ func (b *statefulSet) Update(obj *appsv1.StatefulSet) (*appsv1.StatefulSet, erro
 	obj.Spec.Template.Labels = b.labels()
 	obj.Spec.Template.Spec.Containers = []corev1.Container{b.container()}
 	obj.Spec.Template.Spec.ImagePullSecrets = b.imagePullSecrets()
-	obj.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{}
+	obj.Spec.VolumeClaimTemplates = b.persistentVolumeClaims()
 
 	return obj, nil
 }

--- a/x/deployment/testdata/deployment-v2-storage-updateA.yaml
+++ b/x/deployment/testdata/deployment-v2-storage-updateA.yaml
@@ -1,0 +1,42 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app
+    expose:
+      - port: 80
+        to:
+          - global: true
+        accept:
+          - testupdatea.localhost
+    params:
+      storage:
+        data:
+          mount: /var/lib/e2e-test
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          - size: "512Mi"
+          - name: data
+            size: "128Mi"
+            attributes:
+              persistent: "true"
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1

--- a/x/deployment/testdata/deployment-v2-storage-updateB.yaml
+++ b/x/deployment/testdata/deployment-v2-storage-updateB.yaml
@@ -1,0 +1,43 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: quay.io/ovrclk/demo-app
+    expose:
+      - port: 80
+        to:
+          - global: true
+        accept:
+          - testupdatea.localhost
+          - testupdateb.localhost
+    params:
+      storage:
+        data:
+          mount: /var/lib/e2e-test
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "0.01"
+        memory:
+          size: "128Mi"
+        storage:
+          - size: "512Mi"
+          - name: data
+            size: "128Mi"
+            attributes:
+              persistent: "true"
+  placement:
+    global:
+      pricing:
+        web:
+          denom: uakt
+          amount: 10
+
+deployment:
+  web:
+    global:
+      profile: web
+      count: 1


### PR DESCRIPTION
if deployment with persistent storage is being updated it should
reuse existing persistent volume templates

ref #286

Signed-off-by: Artur Troian <troian.ap@gmail.com>