### PR TITLE
fix(provider): if no metal LB pools are configured, return 0 availabl…

### DIFF
--- a/_docs/provider/kube/metallb-service.yaml
+++ b/_docs/provider/kube/metallb-service.yaml
@@ -30,7 +30,6 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            name: akash-services
-            kubernetes.io/metadata.name: ingress-nginx
+            kubernetes.io/metadata.name: akash-services
         podSelector: 
           matchLabels: {}

--- a/provider/cluster/kube/metallb/client.go
+++ b/provider/cluster/kube/metallb/client.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 
 	kubeclienterrors "github.com/ovrclk/akash/provider/cluster/kube/errors"
 )
@@ -68,6 +69,7 @@ type client struct {
 
 	sda    clusterutil.ServiceDiscoveryAgent
 	client clusterutil.ServiceClient
+	l      sync.Locker
 
 	poolName string
 }
@@ -102,6 +104,7 @@ func NewClient(configPath string, logger log.Logger, poolName string, endpoint *
 		sda:      sda,
 		kube:     kc,
 		poolName: poolName,
+		l:        &sync.Mutex{},
 
 		log: logger.With("client", "metallb"),
 	}, nil
@@ -110,6 +113,17 @@ func NewClient(configPath string, logger log.Logger, poolName string, endpoint *
 
 func (c *client) Stop() {
 	c.sda.Stop()
+}
+
+func (c *client) setupClient(ctx context.Context) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+	if c.client != nil {
+		return nil
+	}
+	var err error
+	c.client, err = c.sda.GetClient(ctx, false, false)
+	return err
 }
 
 /*
@@ -121,12 +135,9 @@ can get stuff like this to access metal lb metrics
 */
 
 func (c *client) GetIPAddressUsage(ctx context.Context) (uint, uint, error) {
-	if c.client == nil {
-		var err error
-		c.client, err = c.sda.GetClient(ctx, false, false)
-		if err != nil {
-			return math.MaxUint32, math.MaxUint32, err
-		}
+	err := c.setupClient(ctx)
+	if err != nil {
+		return math.MaxUint32, math.MaxUint32, err
 	}
 
 	request, err := c.client.CreateRequest(ctx, http.MethodGet, metricsPath, nil)
@@ -162,6 +173,7 @@ func (c *client) GetIPAddressUsage(ctx context.Context) (uint, uint, error) {
 	setAvailable := false
 	inUse := uint(0)
 	setInUse := false
+	poolsFound := make(map[string]struct{})
 	for _, entry := range mf {
 		if setInUse && setAvailable {
 			break
@@ -192,6 +204,9 @@ func (c *client) GetIPAddressUsage(ctx context.Context) (uint, uint, error) {
 					continue
 				}
 
+				// Record all pool names found, for debugging purposes
+				poolsFound[labelEntry.GetValue()] = struct{}{}
+
 				if labelEntry.GetValue() != c.poolName {
 					continue
 				}
@@ -204,7 +219,11 @@ func (c *client) GetIPAddressUsage(ctx context.Context) (uint, uint, error) {
 	}
 
 	if !setInUse || !setAvailable {
-		return math.MaxUint32, math.MaxUint32, fmt.Errorf("%w: data not found in metrics response", errMetalLB)
+		if len(poolsFound) == 0 {
+			c.log.Debug("no pools configured on Metal LB")
+		} else {
+			c.log.Debug("pools configured on Metal LB, but none matching", "configured-pool-name", c.poolName, "quantity-configured", len(poolsFound))
+		}
 	}
 
 	return inUse, available, nil

--- a/provider/cluster/operatorclients/hostname_operator_client.go
+++ b/provider/cluster/operatorclients/hostname_operator_client.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"net"
 	"net/http"
+	"sync"
 )
 
 const (
@@ -26,6 +27,7 @@ type hostnameOperatorClient struct {
 	sda    clusterutil.ServiceDiscoveryAgent
 	client clusterutil.ServiceClient
 	log    log.Logger
+	l      sync.Locker
 }
 
 func NewHostnameOperatorClient(logger log.Logger, kubeConfig *rest.Config, endpoint *net.SRV) (HostnameOperatorClient, error) {
@@ -37,11 +39,14 @@ func NewHostnameOperatorClient(logger log.Logger, kubeConfig *rest.Config, endpo
 	return &hostnameOperatorClient{
 		log: logger.With("operator", "hostname"),
 		sda: sda,
+		l:   &sync.Mutex{},
 	}, nil
 
 }
 
 func (hopc *hostnameOperatorClient) newRequest(ctx context.Context, method string, path string, body io.Reader) (*http.Request, error) {
+	hopc.l.Lock()
+	defer hopc.l.Unlock()
 	if nil == hopc.client {
 		var err error
 		hopc.client, err = hopc.sda.GetClient(ctx, false, false)


### PR DESCRIPTION
This does 3 things

1. fix the network policy to have the right namespace
2. fix the initialization of the client to not have races
3. if metal LB has no pools of IPs, just report 0 availability.