### PR TITLE
fix(provider): fix detection logic around names

### DIFF
--- a/provider/cluster/kube/cluster_ip_connections.go
+++ b/provider/cluster/kube/cluster_ip_connections.go
@@ -58,7 +58,7 @@ func (c *client) PurgeDeclaredIP(ctx context.Context, leaseID mtypes.LeaseID, se
 
 func (c *client) DeclareIP(ctx context.Context, lID mtypes.LeaseID, serviceName string, port uint32, externalPort uint32, proto manifest.ServiceProtocol, sharingKey string, overwrite bool) error {
 	// Note: This interface expects sharing key to contain a value that is unique per deployment owner, in this
-	// case it is the bech32 address
+	// case it is the bech32 address, or a derivative thereof
 	resourceName := strings.ToLower(fmt.Sprintf("%s-%s-%d", sharingKey, proto.ToString(), externalPort))
 
 	c.log.Debug("checking for resource", "resource-name", resourceName)

--- a/provider/cluster/util/ip_sharing_key.go
+++ b/provider/cluster/util/ip_sharing_key.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 )
 
-var allowedIpEndpointNameRegex = regexp.MustCompile(`^[a-z0-9\-]+$`)
+var allowedIPEndpointNameRegex = regexp.MustCompile(`^[a-z0-9\-]+$`)
 
 func MakeIPSharingKey(lID mtypes.LeaseID, endpointName string) string {
 
 	effectiveName := endpointName
-	if !allowedIpEndpointNameRegex.MatchString(endpointName) {
+	if !allowedIPEndpointNameRegex.MatchString(endpointName) {
 		h := sha256.New()
 		_, err := io.WriteString(h, endpointName)
 		if err != nil {

--- a/provider/cluster/util/ip_sharing_key.go
+++ b/provider/cluster/util/ip_sharing_key.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 )
 
+var allowedIpEndpointNameRegex = regexp.MustCompile(`^[a-z0-9\-]+$`)
+
 func MakeIPSharingKey(lID mtypes.LeaseID, endpointName string) string {
-	allowedRegex := regexp.MustCompile(`^[a-z0-9\-]+$`)
+
 	effectiveName := endpointName
-	if !allowedRegex.MatchString(endpointName) {
+	if !allowedIpEndpointNameRegex.MatchString(endpointName) {
 		h := sha256.New()
 		_, err := io.WriteString(h, endpointName)
 		if err != nil {

--- a/provider/cluster/util/ip_sharing_key.go
+++ b/provider/cluster/util/ip_sharing_key.go
@@ -11,14 +11,13 @@ import (
 )
 
 func MakeIPSharingKey(lID mtypes.LeaseID, endpointName string) string {
-	allowedRegex := regexp.MustCompile(`[a-z0-9\-]+`)
+	allowedRegex := regexp.MustCompile(`^[a-z0-9\-]+$`)
 	effectiveName := endpointName
 	if !allowedRegex.MatchString(endpointName) {
 		h := sha256.New()
 		_, err := io.WriteString(h, endpointName)
 		if err != nil {
 			panic(err)
-
 		}
 		effectiveName = strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(h.Sum(nil)[0:15]))
 	}

--- a/provider/cluster/util/ip_sharing_key_test.go
+++ b/provider/cluster/util/ip_sharing_key_test.go
@@ -1,0 +1,31 @@
+package util_test
+
+import (
+	"github.com/ovrclk/akash/provider/cluster/util"
+	"github.com/ovrclk/akash/testutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPassesThroughNames(t *testing.T) {
+	leaseID := testutil.LeaseID(t)
+
+	sharingKey := util.MakeIPSharingKey(leaseID, "foobar")
+	require.Contains(t, sharingKey, "foobar")
+}
+
+func TestFiltersUnderscore(t *testing.T) {
+	leaseID := testutil.LeaseID(t)
+
+	sharingKey := util.MakeIPSharingKey(leaseID, "me_you")
+	require.NotContains(t, sharingKey, "me_you")
+}
+
+func TestFiltersUpperccase(t *testing.T) {
+	leaseID := testutil.LeaseID(t)
+
+	sharingKey := util.MakeIPSharingKey(leaseID, "meYOU")
+	require.NotContains(t, sharingKey, "meYOU")
+
+	require.Equal(t, sharingKey, leaseID.GetOwner()+"-ip-ps9pn7rkocct7m9ivtovuktb")
+}


### PR DESCRIPTION
The old regexp allowed partial matches, which is bogus and spurious. The regexp must validate the entire input string. It must be hashed if it fails.
