### PR TITLE
fix(operator): have the IP operator immediately update availability of IPs

### DIFF
--- a/provider/cluster/mocks/metallb_client.go
+++ b/provider/cluster/mocks/metallb_client.go
@@ -33,6 +33,29 @@ func (_m *MetalLBClient) CreateIPPassthrough(ctx context.Context, directive v1be
 	return r0
 }
 
+// DetectPoolChanges provides a mock function with given fields: ctx
+func (_m *MetalLBClient) DetectPoolChanges(ctx context.Context) (<-chan struct{}, error) {
+	ret := _m.Called(ctx)
+
+	var r0 <-chan struct{}
+	if rf, ok := ret.Get(0).(func(context.Context) <-chan struct{}); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan struct{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetIPAddressStatusForLease provides a mock function with given fields: ctx, leaseID
 func (_m *MetalLBClient) GetIPAddressStatusForLease(ctx context.Context, leaseID typesv1beta2.LeaseID) ([]v1beta2.IPLeaseState, error) {
 	ret := _m.Called(ctx, leaseID)

--- a/provider/operator/ipoperator/ip_operator_test.go
+++ b/provider/operator/ipoperator/ip_operator_test.go
@@ -35,6 +35,11 @@ func runIPOperator(t *testing.T, run bool, prerun, fn func(ctx context.Context, 
 	client := &mocks.Client{}
 	mllbc := &mocks.MetalLBClient{}
 	mllbc.On("Stop")
+	poolChangesMock := make(chan struct{})
+	// nolint: golint, gosimple
+	var poolChangesInterface <-chan struct{}
+	poolChangesInterface = poolChangesMock
+	mllbc.On("DetectPoolChanges", mock.Anything).Return(poolChangesInterface, nil)
 
 	ilc := operatorcommon.IgnoreListConfig{
 		FailureLimit: 100,


### PR DESCRIPTION
In the current code the operator won't pickup changes to the pools made in metal LB after it starts, at least not immediately.

This fixes that by periodically polling for the data & triggering a check each time the metal LB config maps change in k8s.