### PR TITLE
use k8s cluster default imagePullPolicy

### DIFF
--- a/_docs/kustomize/akash-hostname-operator/deployment.yaml
+++ b/_docs/kustomize/akash-hostname-operator/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: akash-hostname-operator
         image: ghcr.io/ovrclk/akash:stable
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         command: ["/bin/sh", "/boot/run.sh"]
         ports:
           - name: status

--- a/_docs/kustomize/akash-node/deployment.yaml
+++ b/_docs/kustomize/akash-node/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: akash-node
           image: ghcr.io/ovrclk/akash:stable
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [ "/bin/sh" , "/boot/run.sh" ]
           env:
 

--- a/_docs/kustomize/akash-provider/deployment.yaml
+++ b/_docs/kustomize/akash-provider/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: akash-provider
           image: ghcr.io/ovrclk/akash:stable
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [ "/bin/sh", "/boot/run.sh" ]
           env:
 

--- a/provider/cluster/kube/builder/workload.go
+++ b/provider/cluster/kube/builder/workload.go
@@ -53,7 +53,6 @@ func (b *workload) container() corev1.Container {
 			Limits:   make(corev1.ResourceList),
 			Requests: make(corev1.ResourceList),
 		},
-		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot:             &falseValue,
 			Privileged:               &falseValue,


### PR DESCRIPTION
K8s sets "IfNotPresent" image pull policy by default when it is not
explicitly set. As well as it sets the image pull policy to "Always" for
the images with ":latest" tag or the ones that do not specify the tag.

The intention is to keep this default and widely accepted behavior.

This also avoids surprises as when one would deploy, say "nginx:latest",
he will get the latest patched nginx instead of an old cached by the
provider image full of CVE's.

fixes #1354

----

## Tested

I've tested this on my provider.

Docker image with this fix `andrey01/akash:issue-1354`. (built with `FROM ubuntu:jammy` in `_build/Dockerfile.akash`)



## force tag nginx:latest as nginx:1.20.0

```
# crictl pull nginx:1.20.0
# ctr --namespace=k8s.io image tag --force docker.io/library/nginx:1.20.0 docker.io/library/nginx:latest
# crictl images |grep nginx | grep -E '1.20.0|1.21.4|1.23|latest'
docker.io/library/nginx                                1.20.0                   7ab27dbbfbdf4       53.7MB
docker.io/library/nginx                                latest                   7ab27dbbfbdf4       53.7MB
docker.io/library/nginx                                1.21.4                   f6987c8d6ed59       56.7MB
docker.io/library/nginx                                1.23.0                   41b0e86104ba6       56.7MB
```

## SDL deploy: nginx:latest

K8s cluster set imagePullPolicy to Always as expected.

```
root@node1:~# kubectl -n $ns get deploy -o yaml | grep -iE 'image|imagepull'
          image: nginx:latest
          imagePullPolicy: Always
```

Events:

```
{
  "type": "Normal",
  "reason": "Pulled",
  "note": "Successfully pulled image \"nginx:latest\" in 4.783600147s",
  "object": {
    "kind": "Pod",
    "namespace": "oil0ke7vhpccs0m4bdp2uqohh74i38fn5qutrdktgo30u",
    "name": "app-8555689669-blg9n"
  },
  "lease_id": {
    "owner": "akash1h24fljt7p0nh82cq0za0uhsct3sfwsfu9w3c9h",
    "dseq": 6759987,
    "gseq": 1,
    "oseq": 1,
    "provider": "akash1nxq8gmsw2vlz3m68qvyvcf3kh6q269ajvqw6y0"
  }
}
```


## SDL deploy: nginx (without a tag)

K8s cluster set imagePullPolicy to Always as expected.

```
root@node1:~# kubectl -n $ns get deploy -o yaml | grep -iE 'image|imagepull'
          image: nginx:latest
          imagePullPolicy: Always
```

## images

latest image tag got updated

```
# crictl images |grep nginx | grep -E '1.20.0|1.21.4|1.23|latest'
docker.io/library/nginx                                1.20.0                   7ab27dbbfbdf4       53.7MB
docker.io/library/nginx                                1.21.4                   f6987c8d6ed59       56.7MB
docker.io/library/nginx                                1.23.0                   41b0e86104ba6       56.7MB
docker.io/library/nginx                                latest                   41b0e86104ba6       56.7MB
```


## SDL deploy: nginx:1.23.0

imagePullPolicy is IfNotPresent as expected for tags that aren't `:latest` or untagged.

```
root@node1:~# kubectl -n $ns get deploy -o yaml | grep -iE 'image|imagepull'
          image: nginx:1.23.0
          imagePullPolicy: IfNotPresent
```


Have also tested `akash tx deployment update` for `nginx:1.23.0` -> `nginx` (untagged), `imagePullPolicy` switched from `IfNotPresent` to `Always` as expected.
