### PR TITLE
Add network policy for IPs

### DIFF
--- a/provider/cluster/kube/builder/netpol.go
+++ b/provider/cluster/kube/builder/netpol.go
@@ -2,8 +2,6 @@ package builder
 
 import (
 	"fmt"
-	"github.com/ovrclk/akash/provider/cluster/operatorclients"
-
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +20,6 @@ type NetPol interface {
 
 type netPol struct {
 	builder
-	ipop operatorclients.IPOperatorClient
 }
 
 var _ NetPol = (*netPol)(nil)

--- a/provider/cluster/kube/builder/netpol.go
+++ b/provider/cluster/kube/builder/netpol.go
@@ -235,7 +235,6 @@ func (b *netPol) Create() ([]*netv1.NetworkPolicy, error) { // nolint:golint,unp
 		}
 	}
 
-
 	return result, nil
 }
 

--- a/provider/cluster/kube/builder/netpol.go
+++ b/provider/cluster/kube/builder/netpol.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/ovrclk/akash/provider/cluster/operatorclients"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -21,6 +22,7 @@ type NetPol interface {
 
 type netPol struct {
 	builder
+	ipop operatorclients.IPOperatorClient
 }
 
 var _ NetPol = (*netPol)(nil)
@@ -144,11 +146,9 @@ func (b *netPol) Create() ([]*netv1.NetworkPolicy, error) { // nolint:golint,unp
 	for _, service := range b.group.Services {
 		// find all the ports that are exposed directly
 		ports := make([]netv1.NetworkPolicyPort, 0)
-		for _, expose := range service.Expose {
-			if !expose.Global || util.ShouldBeIngress(expose) {
-				continue
-			}
+		portsWithIP := make([]netv1.NetworkPolicyPort, 0)
 
+		for _, expose := range service.Expose {
 			portToOpen := util.ExposeExternalPort(expose)
 			portAsIntStr := intstr.FromInt(int(portToOpen))
 
@@ -158,48 +158,83 @@ func (b *netPol) Create() ([]*netv1.NetworkPolicy, error) { // nolint:golint,unp
 				exposeProto = corev1.ProtocolTCP
 			case manitypes.UDP:
 				exposeProto = corev1.ProtocolUDP
-
 			}
+
 			entry := netv1.NetworkPolicyPort{
 				Port:     &portAsIntStr,
 				Protocol: &exposeProto,
 			}
+
+			if len(expose.IP) != 0 {
+				portsWithIP = append(portsWithIP, entry)
+			}
+
+			if !expose.Global || util.ShouldBeIngress(expose) {
+				continue
+			}
+
 			ports = append(ports, entry)
 		}
 
-		// If no ports are found, skip this service
-		if len(ports) == 0 {
-			continue
-		}
-
-		// Make a network policy just to open these ports to incoming traffic
 		serviceName := service.Name
-		policyName := fmt.Sprintf("akash-%s-np", serviceName)
-		policy := netv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels:    b.labels(),
-				Name:      policyName,
-				Namespace: LidNS(b.lid),
-			},
-			Spec: netv1.NetworkPolicySpec{
-
-				Ingress: []netv1.NetworkPolicyIngressRule{
-					{ // Allow Network Connections to same Namespace
-						Ports: ports,
+		// If no ports are found, skip this service
+		if len(ports) != 0 {
+			// Make a network policy just to open these ports to incoming traffic
+			policyName := fmt.Sprintf("akash-%s-np", serviceName)
+			policy := netv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:    b.labels(),
+					Name:      policyName,
+					Namespace: LidNS(b.lid),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{
+							Ports: ports,
+						},
+					},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							AkashManifestServiceLabelName: serviceName,
+						},
+					},
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeIngress,
 					},
 				},
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						AkashManifestServiceLabelName: serviceName,
-					},
-				},
-				PolicyTypes: []netv1.PolicyType{
-					netv1.PolicyTypeIngress,
-				},
-			},
+			}
+			result = append(result, &policy)
 		}
-		result = append(result, &policy)
+
+		if len(portsWithIP) != 0 {
+			// Make a network policy just to open these ports to incoming traffic from outside the cluster
+			policyName := fmt.Sprintf("akash-%s-ip", serviceName)
+			policy := netv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:    b.labels(),
+					Name:      policyName,
+					Namespace: LidNS(b.lid),
+				},
+				Spec: netv1.NetworkPolicySpec{
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{
+							Ports: portsWithIP,
+						},
+					},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							AkashManifestServiceLabelName: serviceName,
+						},
+					},
+					PolicyTypes: []netv1.PolicyType{
+						netv1.PolicyTypeIngress,
+					},
+				},
+			}
+			result = append(result, &policy)
+		}
 	}
+
 
 	return result, nil
 }


### PR DESCRIPTION
This change should allow any incoming traffic to reach a service exposed via an IP lease. It's mean to be publicly exposed so this should be fine. I think this fixes the multi-node cluster problem I've been encountering on edgenet.

I was experimenting with specifically allowing the pod subnets, but there is lots of complexity in that. Also I'm not entirely sure that it should work that way. It may be a quirk of the way Calico is implemented.

If we're good with this change I'll make a PR for the provider-services as well.

