### PR TITLE
fix(provider): change netpol to allow the internal container port

### DIFF
--- a/provider/cluster/kube/builder/netpol.go
+++ b/provider/cluster/kube/builder/netpol.go
@@ -146,8 +146,7 @@ func (b *netPol) Create() ([]*netv1.NetworkPolicy, error) { // nolint:golint,unp
 		portsWithIP := make([]netv1.NetworkPolicyPort, 0)
 
 		for _, expose := range service.Expose {
-			portToOpen := util.ExposeExternalPort(expose)
-			portAsIntStr := intstr.FromInt(int(portToOpen))
+			portAsIntStr := intstr.FromInt(int(expose.Port))
 
 			var exposeProto corev1.Protocol
 			switch expose.Proto {


### PR DESCRIPTION
It looks like Scott found a bug here that's been there for a while

If the container port & external port is the same, everything works. If they are different, it does not work. The netpol must allow the container port to be accessed. The external port specified is completely irrelevant.