### PR TITLE
ci(release): defer tag detection to makefile when doing dry-run on branch

### DIFF
--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -30,10 +30,8 @@ jobs:
         id: branch_name
         run: |
           echo ::set-output name=MAINNET::$(./script/mainnet-from-tag.sh ${GITHUB_REF#refs/tags/})
-          echo ::set-output name=RELEASE_TAG::${GITHUB_REF#refs/tags/}
       - run: echo "Building for MAINNET=${{ steps.branch_name.outputs.MAINNET }}"
       - name: release dry-run
         run: make release
         env:
-          RELEASE_TAG: ${{ steps.branch_name.outputs.RELEASE_TAG }}
           MAINNET: ${{ steps.branch_name.outputs.MAINNET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
           make release
         env:
           GORELEASER_RELEASE: true
+          GORELEASER_MOUNT_CONFIG: true
           MAINNET: ${{ steps.branch_name.outputs.MAINNET }}
           RELEASE_TAG: ${{ steps.branch_name.outputs.RELEASE_TAG }}
           # using PAT as homebrew is located in different repo

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -1,7 +1,10 @@
+GON_CONFIGFILE           ?= gon.json
+
 GORELEASER_SKIP_VALIDATE ?= false
 GORELEASER_DEBUG         ?= false
 GORELEASER_IMAGE         := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
-GON_CONFIGFILE           ?= gon.json
+GORELEASER_RELEASE       ?= false
+GORELEASER_MOUNT_CONFIG  ?= false
 
 ifeq ($(GORELEASER_RELEASE),true)
 	GORELEASER_SKIP_VALIDATE := false
@@ -10,6 +13,10 @@ else
 	GORELEASER_SKIP_PUBLISH  := --skip-publish=true
 	GORELEASER_SKIP_VALIDATE ?= false
 	GITHUB_TOKEN=
+endif
+
+ifeq ($(GORELEASER_MOUNT_CONFIG),true)
+	GORELEASER_IMAGE := -v $(HOME)/.docker/config.json:/root/.docker/config.json $(GORELEASER_IMAGE)
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -86,7 +93,6 @@ release: modvendor gen-changelog
 		-e GITHUB_TOKEN="$(GITHUB_TOKEN)" \
 		-e GORELEASER_CURRENT_TAG="$(RELEASE_TAG)" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(HOME)/.docker/config.json:/root/.docker/config.json \
 		-v `pwd`:/go/src/$(GO_MOD_NAME) \
 		-w /go/src/$(GO_MOD_NAME) \
 		$(GORELEASER_IMAGE) \


### PR DESCRIPTION
Signed-off-by: Artur Troian <troian.ap@gmail.com>