### PR TITLE
fix(provider): keep the command in manifest (#ENG-647)

### DIFF
--- a/pkg/apis/akash.network/crd.yaml
+++ b/pkg/apis/akash.network/crd.yaml
@@ -50,6 +50,10 @@ spec:
                             type: string
                           image:
                             type: string
+                          command:
+                            type: array
+                            items:
+                              type: string
                           args:
                             type: array
                             items:

--- a/pkg/apis/akash.network/v1/types.go
+++ b/pkg/apis/akash.network/v1/types.go
@@ -184,14 +184,15 @@ func manifestGroupFromAkash(m *manifest.Group) (ManifestGroup, error) {
 	return ma, nil
 }
 
-// ManifestService stores name, image, args, env, unit, count and expose list of service
+// ManifestService stores name, image, command, args, env, unit, count and expose list of service
 type ManifestService struct {
 	// Service name
 	Name string `json:"name,omitempty"`
 	// Docker image
 	Image string   `json:"image,omitempty"`
-	Args  []string `json:"args,omitempty"`
-	Env   []string `json:"env,omitempty"`
+	Command []string `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
 	// Resource requirements
 	// in current version of CRD it is named as unit
 	Resources ResourceUnits `json:"unit"`
@@ -210,6 +211,7 @@ func (ms ManifestService) toAkash() (manifest.Service, error) {
 	ams := &manifest.Service{
 		Name:      ms.Name,
 		Image:     ms.Image,
+		Command:   ms.Command,
 		Args:      ms.Args,
 		Env:       ms.Env,
 		Resources: res,
@@ -237,6 +239,7 @@ func manifestServiceFromAkash(ams manifest.Service) (ManifestService, error) {
 	ms := ManifestService{
 		Name:      ams.Name,
 		Image:     ams.Image,
+		Command:   ams.Command,
 		Args:      ams.Args,
 		Env:       ams.Env,
 		Resources: resources,

--- a/pkg/apis/akash.network/v2beta1/types.go
+++ b/pkg/apis/akash.network/v2beta1/types.go
@@ -193,14 +193,15 @@ type ManifestServiceParams struct {
 	Storage []ManifestStorageParams `json:"storage,omitempty"`
 }
 
-// ManifestService stores name, image, args, env, unit, count and expose list of service
+// ManifestService stores name, image, command, args, env, unit, count and expose list of service
 type ManifestService struct {
 	// Service name
 	Name string `json:"name,omitempty"`
 	// Docker image
 	Image string   `json:"image,omitempty"`
-	Args  []string `json:"args,omitempty"`
-	Env   []string `json:"env,omitempty"`
+	Command []string `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
 	// Resource requirements
 	// in current version of CRD it is named as unit
 	Resources ResourceUnits `json:"unit"`
@@ -221,6 +222,7 @@ func (ms ManifestService) toAkash() (manifest.Service, error) {
 	ams := &manifest.Service{
 		Name:      ms.Name,
 		Image:     ms.Image,
+		Command:   ms.Command,
 		Args:      ms.Args,
 		Env:       ms.Env,
 		Resources: res,
@@ -262,6 +264,7 @@ func manifestServiceFromAkash(ams manifest.Service) (ManifestService, error) {
 	ms := ManifestService{
 		Name:      ams.Name,
 		Image:     ams.Image,
+		Command:   ams.Command,
 		Args:      ams.Args,
 		Env:       ams.Env,
 		Resources: resources,


### PR DESCRIPTION
PR for `0.16.8`

have tested this on my provider using image: `docker.io/andrey01/akash:0.16.8-eng-647` (digest: `fab698b418849`).

- SDL with `command` and `args`;
- `command` is now present in the manifest file;
- `akash-provider` restart did not cause the deployment change (as previously it was removing the `command`);
- hence, no additional replicaset with `CrashLoopBackOff` pod;


The `lease-shell` issue (#ENG-538) is still present though and it is easy to trigger by restarting the `akash-provider`.
