### PR TITLE
chore(deps): bump akash cosmos sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ replace (
 	// use akash fork of cometbft
 	github.com/cometbft/cometbft => github.com/akash-network/cometbft v0.38.21-akash.1
 	// use akash fork of cosmos sdk
-	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.7-akash.1
+	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.7-akash.2
 
 	github.com/cosmos/gogoproto => github.com/akash-network/gogoproto v1.7.0-akash.2
 


### PR DESCRIPTION
## Summary

Bumps the Akash Cosmos SDK fork pointer to `v0.53.7-akash.2`.

This picks up the bank denom metadata balance query fix from the Akash Cosmos
SDK fork.

Refs akash-network/support#556

## Changes

- `github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk`
  now points at `v0.53.7-akash.2`

No `go.sum` or other module graph changes are included.
