### PR TITLE
fix(market): reject bids when count reaches OrderMaxBids

### DIFF
--- a/x/market/handler/handler_test.go
+++ b/x/market/handler/handler_test.go
@@ -1142,6 +1142,66 @@ func TestCreateBidAlreadyExists(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCreateBidExceedsMaxBids verifies that the bid count limit is enforced when
+// the existing count reaches OrderMaxBids, not only when it exceeds it. With
+// OrderMaxBids set to 1, a single bid is allowed and the next bid must be
+// rejected (otherwise OrderMaxBids+1 bids could be created).
+func TestCreateBidExceedsMaxBids(t *testing.T) {
+	suite := setupTestSuite(t)
+
+	suite.PrepareMocks(func(ts *state.TestSuite) {
+		bkeeper := ts.BankKeeper()
+
+		// BME deposit flow mocks
+		bkeeper.
+			On("SendCoinsFromAccountToModule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+		bkeeper.
+			On("MintCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+			Return(nil)
+		bkeeper.
+			On("BurnCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+			Return(nil)
+		bkeeper.
+			On("SendCoinsFromModuleToAccount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+		bkeeper.
+			On("SendCoinsFromModuleToModule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+	})
+
+	params, err := suite.MarketKeeper().GetParams(suite.Context())
+	require.NoError(t, err)
+	params.OrderMaxBids = 1
+	require.NoError(t, suite.MarketKeeper().SetParams(suite.Context(), params))
+
+	order, gspec := suite.createOrder(testutil.Resources(t, testutil.WithDenom("uact")))
+
+	newBid := func() *mvbeta.MsgCreateBid {
+		providerAddr, err := sdk.AccAddressFromBech32(suite.createProvider(gspec.Requirements.Attributes).Owner)
+		require.NoError(t, err)
+
+		return &mvbeta.MsgCreateBid{
+			ID:    mv1.MakeBidID(order.ID, providerAddr),
+			Price: sdk.NewDecCoin(sdkutil.DenomUact, sdkmath.NewInt(1)),
+			Deposit: deposit.Deposit{
+				Amount:  mvbeta.DefaultBidMinDepositACT,
+				Sources: deposit.Sources{deposit.SourceBalance},
+			},
+		}
+	}
+
+	// First bid brings the count up to OrderMaxBids.
+	res, err := suite.handler(suite.Context(), newBid())
+	require.NotNil(t, res)
+	require.NoError(t, err)
+
+	// Second bid would exceed OrderMaxBids and must be rejected.
+	res, err = suite.handler(suite.Context(), newBid())
+	require.Nil(t, res)
+	require.ErrorIs(t, err, mv1.ErrInvalidBid)
+}
+
 func TestCloseOrderNonExisting(t *testing.T) {
 	t.Skip("TODO CLOSE LEASE")
 	// suite := setupTestSuite(t)

--- a/x/market/handler/server.go
+++ b/x/market/handler/server.go
@@ -42,7 +42,7 @@ func (ms msgServer) CreateBid(goCtx context.Context, msg *mvbeta.MsgCreateBid) (
 		return nil, fmt.Errorf("%w: minimum:%v received:%v", mv1.ErrInvalidDeposit, sdk.NewCoin(msg.Deposit.Amount.Denom, minDeposit), msg.Deposit)
 	}
 
-	if ms.keepers.Market.BidCountForOrder(ctx, msg.ID.OrderID()) > params.OrderMaxBids {
+	if ms.keepers.Market.BidCountForOrder(ctx, msg.ID.OrderID()) >= params.OrderMaxBids {
 		return nil, fmt.Errorf("%w: too many existing bids (%v)", mv1.ErrInvalidBid, params.OrderMaxBids)
 	}
 


### PR DESCRIPTION
## Summary

The bid count check in `CreateBid` used `>` instead of `>=`:

```go
if ms.keepers.Market.BidCountForOrder(ctx, msg.ID.OrderID()) > params.OrderMaxBids {
    return nil, fmt.Errorf("%w: too many existing bids (%v)", mv1.ErrInvalidBid, params.OrderMaxBids)
}
```

This allowed **one more bid than `OrderMaxBids`** to be created. When the existing bid count already equals the limit, the next bid passes the check (`count > limit` is false at `count == limit`), so `OrderMaxBids + 1` bids end up on the order — violating the parameter.

## Change

Use `>=` so a new bid is rejected once the count reaches `OrderMaxBids`.

```go
if ms.keepers.Market.BidCountForOrder(ctx, msg.ID.OrderID()) >= params.OrderMaxBids {
```

## Tests

Added `TestCreateBidExceedsMaxBids`: sets `OrderMaxBids = 1`, creates one bid (allowed), then a second bid from another provider must be rejected with `ErrInvalidBid`. Verified the test fails without the fix (a second bid is created) and passes with it. `go test ./x/market/...`, `gofmt`, `go vet` and `golangci-lint` (repo config) are clean.

## Note

The reporter also observed that `BidCountForOrder` counts bids in all states (Open/Active/Closed). Whether closed bids should count toward the limit is a separate, behaviour-affecting question and is intentionally left out of this change; happy to follow up if maintainers want it addressed.

refs: akash-network/support#413