### PR TITLE
fix(escrow): settle open payments on same-block withdraw

### DIFF
--- a/x/escrow/keeper/keeper.go
+++ b/x/escrow/keeper/keeper.go
@@ -549,12 +549,13 @@ func (k *keeper) accountSettle(ctx sdk.Context, acc *account) ([]payment, bool, 
 		acc.State.SettledAt = ctx.BlockHeight()
 	}
 
+	// Always settle open payments alongside overdrawn ones. When heightDelta is
+	// zero (e.g. a withdrawal in the same block the account was last settled) the
+	// open payments settle to a zero transfer, but they must still be included so
+	// callers such as PaymentWithdraw can find the payment they are operating on.
 	pStates := []etypes.State{
 		etypes.StateOverdrawn,
-	}
-
-	if !heightDelta.IsZero() {
-		pStates = append(pStates, etypes.StateOpen)
+		etypes.StateOpen,
 	}
 
 	acc.dirty = true

--- a/x/escrow/keeper/keeper_test.go
+++ b/x/escrow/keeper/keeper_test.go
@@ -446,3 +446,63 @@ func Test_PaymentCreate_later(t *testing.T) {
 		require.Equal(t, ctx.BlockHeight()-1, acct.State.SettledAt)
 	}
 }
+
+// Test_PaymentWithdraw_SameBlockAsSettlement reproduces a panic where withdrawing
+// from an open payment in the same block the account was last settled (heightDelta
+// == 0) caused accountSettle to query only overdrawn payments, so the open payment
+// was missing from the settled set and PaymentWithdraw panicked with
+// "couldn't find payment".
+func Test_PaymentWithdraw_SameBlockAsSettlement(t *testing.T) {
+	ssuite := state.SetupTestSuite(t)
+	ctx := ssuite.Context()
+
+	bkeeper := ssuite.BankKeeper()
+	ekeeper := ssuite.EscrowKeeper()
+
+	lid := testutil.LeaseID(t)
+	aid := lid.DeploymentID().ToEscrowAccountID()
+	pid := lid.ToEscrowPaymentID()
+
+	aowner := testutil.AccAddress(t)
+	powner := testutil.AccAddress(t)
+
+	amt := testutil.ACTCoin(t, 1000)
+	rate := sdk.NewCoin("uact", sdkmath.NewInt(30))
+
+	ssuite.MockBMEForDeposit(aowner, amt)
+	require.NoError(t, ekeeper.AccountCreate(ctx, aid, aowner, []etypes.Depositor{{
+		Owner:   aowner.String(),
+		Height:  ctx.BlockHeight(),
+		Balance: sdk.NewDecCoinFromCoin(amt),
+	}}))
+
+	require.NoError(t, ekeeper.PaymentCreate(ctx, pid, powner, sdk.NewDecCoinFromCoin(rate)))
+
+	// The account was just settled at the current height by AccountCreate, so a
+	// withdrawal in this same block yields heightDelta == 0.
+	acct, err := ekeeper.GetAccount(ctx, aid)
+	require.NoError(t, err)
+	require.Equal(t, ctx.BlockHeight(), acct.State.SettledAt)
+
+	bkeeper.
+		On("SendCoinsFromModuleToModule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("MintCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("BurnCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("SendCoinsFromModuleToAccount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	require.NotPanics(t, func() {
+		err = ekeeper.PaymentWithdraw(ctx, pid)
+	})
+	require.NoError(t, err)
+
+	payment, err := ekeeper.GetPayment(ctx, pid)
+	require.NoError(t, err)
+	require.Equal(t, etypes.StateOpen, payment.State.State)
+}


### PR DESCRIPTION
## Summary

`PaymentWithdraw` panics with `couldn't find payment` when an open payment is withdrawn in the same block the account was last settled.

In `accountSettle`, open payments were only included in the settled set when `heightDelta` was non-zero:

```go
pStates := []etypes.State{
    etypes.StateOverdrawn,
}
if !heightDelta.IsZero() {
    pStates = append(pStates, etypes.StateOpen)
}
```

`heightDelta` is `ctx.BlockHeight() - acc.State.SettledAt`, so it is zero when a withdrawal happens in the same block the account was just settled (e.g. right after `AccountCreate`/`PaymentCreate`). In that case `accountSettle` returns only overdrawn payments, the open payment being withdrawn is absent from the result, and `PaymentWithdraw` hits:

```go
if pmnt == nil {
    panic(fmt.Sprintf("couldn't find payment %s", id.String()))
}
```

## Change

Always include open payments when settling:

```go
pStates := []etypes.State{
    etypes.StateOverdrawn,
    etypes.StateOpen,
}
```

When `heightDelta == 0`, each open payment settles to `rate * 0 = 0`, so account balances are unchanged - this is a no-op for the economics and byte-identical to the previous behaviour for the `heightDelta > 0` path (where open payments were already included). It only ensures the payment is present so callers like `PaymentWithdraw` can operate on it.

## Tests

Added `Test_PaymentWithdraw_SameBlockAsSettlement`, which creates an account and payment and withdraws in the same block (heightDelta == 0). It panics without the fix (verified) and passes with it. The full `x/escrow/...` suite - including the settlement tests - passes, confirming no change to settlement behaviour. `gofmt`, `go vet` and `golangci-lint` (repo config) report no new issues.

refs: akash-network/support#414