### PR TITLE
fix(audit): scope provider attribute queries to provider keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,5 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (audit) [akash-network/support#619](https://github.com/akash-network/support/issues/619) Scope provider attribute queries to audit provider keys
 * Fix bug in ditribution and querying rewards

--- a/x/audit/keeper/grpc_query.go
+++ b/x/audit/keeper/grpc_query.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 
@@ -30,10 +31,10 @@ func (q Querier) AllProvidersAttributes(
 	var providers types.AuditedProviders
 	ctx := sdk.UnwrapSDKContext(c)
 
-	store := ctx.KVStore(q.skey)
+	store := prefix.NewStore(ctx.KVStore(q.skey), types.PrefixProviderID())
 
 	pageRes, err := sdkquery.Paginate(store, req.Pagination, func(key []byte, value []byte) error {
-		id := ParseIDFromKey(key)
+		id := ParseIDFromKey(append(append([]byte(nil), types.PrefixProviderID()...), key...))
 
 		var sVal types.AuditedAttributesStore
 		if err := q.cdc.Unmarshal(value, &sVal); err != nil {
@@ -132,10 +133,10 @@ func (q Querier) AuditorAttributes(
 
 	var providers types.AuditedProviders
 	ctx := sdk.UnwrapSDKContext(c)
-	store := ctx.KVStore(q.skey)
+	store := prefix.NewStore(ctx.KVStore(q.skey), types.PrefixProviderID())
 
 	pageRes, err := sdkquery.FilteredPaginate(store, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
-		id := ParseIDFromKey(key)
+		id := ParseIDFromKey(append(append([]byte(nil), types.PrefixProviderID()...), key...))
 		if !id.Auditor.Equals(auditor) {
 			return false, nil
 		}

--- a/x/audit/keeper/grpc_query_test.go
+++ b/x/audit/keeper/grpc_query_test.go
@@ -112,6 +112,8 @@ func TestGRPCQueryProvider(t *testing.T) {
 func TestGRPCQueryProviders(t *testing.T) {
 	suite := setupTest(t)
 
+	suite.ctx.KVStore(suite.keeper.StoreKey()).Set([]byte{0xff}, []byte{0x01})
+
 	// creating providers
 	id1, provider := testutil.AuditedProvider(t)
 	err := suite.keeper.CreateOrUpdateProviderAttributes(suite.ctx, id1, provider.Attributes)
@@ -182,6 +184,8 @@ func TestGRPCQueryProviders(t *testing.T) {
 
 func TestGRPCQueryAuditorAttributes(t *testing.T) {
 	suite := setupTest(t)
+
+	suite.ctx.KVStore(suite.keeper.StoreKey()).Set([]byte{0xff}, []byte{0x01})
 
 	// Two providers under the same auditor.
 	auditor := testutil.AccAddress(t)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: https://github.com/akash-network/support/issues/619

Scopes the `AllProvidersAttributes` and `AuditorAttributes` query pagination to the audit provider key prefix.

Previously both query handlers paginated over the full audit KV store and called `ParseIDFromKey` for every key. That works while the store only contains provider keys, but it is fragile: any future non-provider key under the same store key could be parsed as a provider ID and cause incorrect results or a panic.

This change wraps the audit store with `prefix.NewStore(..., types.PrefixProviderID())` before paginating, so only provider attribute records are scanned. The tests add a non-provider key to the audit store and verify both query paths ignore it.



---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/akash-network/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [x] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/akash-network/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
