### PR TITLE
fix(escrow): save closed payments before account hooks

### DIFF
--- a/x/escrow/keeper/keeper.go
+++ b/x/escrow/keeper/keeper.go
@@ -1129,19 +1129,19 @@ func (k *keeper) savePayment(ctx sdk.Context, obj payment) error {
 }
 
 func (k *keeper) save(ctx sdk.Context, acc *account, payments []payment) error {
-	if acc.dirty {
-		err := k.saveAccount(ctx, acc)
-		if err != nil {
-			return err
-		}
-	}
-
 	for _, pmnt := range payments {
 		if pmnt.dirty {
 			err := k.savePayment(ctx, pmnt)
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	if acc.dirty {
+		err := k.saveAccount(ctx, acc)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/x/escrow/keeper/keeper_test.go
+++ b/x/escrow/keeper/keeper_test.go
@@ -273,6 +273,71 @@ func Test_PaymentCreate(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func Test_AccountClose_ClosesPaymentBeforeAccountHook(t *testing.T) {
+	ssuite := state.SetupTestSuite(t)
+	ctx := ssuite.Context()
+
+	bkeeper := ssuite.BankKeeper()
+	ekeeper := ssuite.EscrowKeeper()
+
+	lid := testutil.LeaseID(t)
+	did := lid.DeploymentID()
+
+	aid := did.ToEscrowAccountID()
+	pid := lid.ToEscrowPaymentID()
+
+	aowner := testutil.AccAddress(t)
+	powner := testutil.AccAddress(t)
+
+	amt := testutil.ACTCoin(t, 1000)
+	rate := sdk.NewCoin("uact", sdkmath.NewInt(30))
+
+	ssuite.MockBMEForDeposit(aowner, amt)
+	require.NoError(t, ekeeper.AccountCreate(ctx, aid, aowner, []etypes.Depositor{{
+		Owner:   aowner.String(),
+		Height:  ctx.BlockHeight(),
+		Balance: sdk.NewDecCoinFromCoin(amt),
+	}}))
+	require.NoError(t, ekeeper.PaymentCreate(ctx, pid, powner, sdk.NewDecCoinFromCoin(rate)))
+
+	var nestedErr error
+	ekeeper.AddOnAccountClosedHook(func(ctx sdk.Context, _ etypes.Account) error {
+		payment, err := ekeeper.GetPayment(ctx, pid)
+		if err != nil {
+			nestedErr = err
+			return nil
+		}
+
+		if payment.State.State != etypes.StateClosed {
+			nestedErr = ekeeper.PaymentClose(ctx, pid)
+		}
+
+		return nil
+	})
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 10)
+	bkeeper.
+		On("SendCoinsFromModuleToModule", mock.Anything, module.ModuleName, mock.MatchedBy(func(dest string) bool {
+			return dest == bmemodule.ModuleName || dest == distrtypes.ModuleName
+		}), mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("SendCoinsFromModuleToModule", mock.Anything, bmemodule.ModuleName, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("MintCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("BurnCoins", mock.Anything, bmemodule.ModuleName, mock.Anything).
+		Return(nil).Maybe()
+	bkeeper.
+		On("SendCoinsFromModuleToAccount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	require.NoError(t, ekeeper.AccountClose(ctx, aid))
+	require.NoError(t, nestedErr)
+}
+
 func Test_Overdraft(t *testing.T) {
 	ssuite := state.SetupTestSuite(t)
 	ctx := ssuite.Context()


### PR DESCRIPTION
## Summary

- Add a regression test for the account-close hook path that can call back into PaymentClose.
- Save dirty payments before the account during escrow batch saves.
- Prevent hooks from seeing a closed account while related payments are still open in the store.

## Root cause

AccountClose marked related payments closed in memory, then save persisted the account before payments. Persisting the account fired the account-closed hook. The market hook could then call PaymentClose while the account was already stored as closed and the payment was still stored as open, producing account closed.

## Verification

Failing-before output from the regression test:

```text
=== RUN   Test_AccountClose_ClosesPaymentBeforeAccountHook
    keeper_test.go:338:
        Error:       Received unexpected error:
                     account closed
--- FAIL: Test_AccountClose_ClosesPaymentBeforeAccountHook
```

Passing-after checks:

```text
GOWORK=off go test ./x/escrow/keeper -run Test_AccountClose_ClosesPaymentBeforeAccountHook -count=1 -v
GOWORK=off go test ./x/escrow/keeper ./x/market/keeper ./x/market/handler -count=1
git diff --check
```
